### PR TITLE
Import importlib.util

### DIFF
--- a/src/grimp/adaptors/packagefinder.py
+++ b/src/grimp/adaptors/packagefinder.py
@@ -1,4 +1,4 @@
-import importlib
+import importlib.util
 import sys
 import logging
 


### PR DESCRIPTION
This was failing in certain circumstances with
"AttributeError: module 'importlib' has no attribute 'util'".