### PR TITLE
Use tokenize.open for opening files

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -84,3 +84,7 @@ Changelog
 1.2 (2019-11-27)
 ----------------
 * Significantly increase the speed of building the graph.
+
+latest
+------
+* Better handling of source code containing non-ascii compatible characters.

--- a/src/grimp/adaptors/filesystem.py
+++ b/src/grimp/adaptors/filesystem.py
@@ -1,5 +1,6 @@
-from typing import Tuple
 import os
+import tokenize
+from typing import Tuple
 
 from grimp.application.ports.filesystem import AbstractFileSystem
 
@@ -22,7 +23,9 @@ class FileSystem(AbstractFileSystem):
         return os.path.split(file_name)
 
     def read(self, file_name: str) -> str:
-        with open(file_name) as file:
+        # Use tokenize.open to give us a better chance of successfully decoding
+        # source code in a non-ascii compatible encoding.
+        with tokenize.open(file_name) as file:
             return file.read()
 
     def exists(self, file_name: str) -> bool:

--- a/tests/assets/encodingpackage/imported.py
+++ b/tests/assets/encodingpackage/imported.py
@@ -1,0 +1,5 @@
+print("变")
+
+π = 3.14159
+jalapeño = "a hot pepper"
+ラーメン = "delicious"

--- a/tests/assets/encodingpackage/importer.py
+++ b/tests/assets/encodingpackage/importer.py
@@ -1,0 +1,6 @@
+from .imported import π
+
+print('变')
+pi = π
+jalapeño = "a hot pepper"
+ラーメン = "delicious"

--- a/tests/functional/test_encoding_handling.py
+++ b/tests/functional/test_encoding_handling.py
@@ -1,0 +1,21 @@
+import grimp
+
+
+def test_build_graph_of_non_ascii_source():
+    """
+    Tests we can cope with non ascii Python source files.
+    """
+    graph = grimp.build_graph("encodingpackage")
+
+    result = graph.get_import_details(
+        importer="encodingpackage.importer", imported="encodingpackage.imported"
+    )
+
+    assert [
+        {
+            "importer": "encodingpackage.importer",
+            "imported": "encodingpackage.imported",
+            "line_number": 1,
+            "line_contents": "from .imported import π",
+        },
+    ] == result

--- a/tox.ini
+++ b/tox.ini
@@ -48,7 +48,7 @@ commands =
     sphinx-build -b linkcheck docs dist/docs
 
 [testenv:report]
-deps = coverage==4.5.1
+deps = coverage==5.0.3
 skip_install = true
 commands =
     coverage report
@@ -57,4 +57,4 @@ commands =
 [testenv:clean]
 commands = coverage erase
 skip_install = true
-deps = coverage
+deps = coverage==5.0.3


### PR DESCRIPTION
Motivated by https://github.com/seddonym/grimp/issues/75.

Unfortunately this is currently causing problems with the coverage report, which is why the tests are failing.