### PR TITLE
Namespace package error

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -3,3 +3,4 @@ Authors
 =======
 
 * David Seddon - https://seddonym.me
+* Kevin Amado - https://github.com/kamadorueda

--- a/src/grimp/adaptors/packagefinder.py
+++ b/src/grimp/adaptors/packagefinder.py
@@ -1,10 +1,10 @@
 import importlib.util
-import sys
 import logging
+import sys
 
-from grimp.application.ports.packagefinder import AbstractPackageFinder
+from grimp import exceptions
 from grimp.application.ports.filesystem import AbstractFileSystem
-
+from grimp.application.ports.packagefinder import AbstractPackageFinder
 
 logger = logging.getLogger(__name__)
 
@@ -21,5 +21,12 @@ class ImportLibPackageFinder(AbstractPackageFinder):
             raise ValueError(
                 "Could not find package '{}' in your Python path.".format(package_name)
             )
-        assert package_filename.origin  # For type checker.
-        return file_system.dirname(package_filename.origin)
+
+        if package_filename.has_location and package_filename.origin:
+            return file_system.dirname(package_filename.origin)
+
+        raise exceptions.NamespacePackageEncountered(
+            f"Package {package_name} appears to be a 'namespace package' (see PEP 420), "
+            "which is not currently supported. If this is not deliberate, adding an __init__.py "
+            "file should fix the problem."
+        )

--- a/src/grimp/exceptions.py
+++ b/src/grimp/exceptions.py
@@ -13,6 +13,15 @@ class ModuleNotPresent(GrimpException):
     """
 
 
+class NamespacePackageEncountered(GrimpException):
+    """
+    Indicates that there was no __init__.py at the top level.
+
+    This indicates a namespace package (see PEP 420), which is not currently supported. More
+    typically this is just an oversight which can be fixed by adding the __init__.py file.
+    """
+
+
 class SourceSyntaxError(GrimpException):
     """
     Indicates a syntax error in code that was being statically analysed.

--- a/tests/assets/missingrootinitpackage/one/alpha.py
+++ b/tests/assets/missingrootinitpackage/one/alpha.py
@@ -1,0 +1,4 @@
+import sys  # Standard library import.
+import pytest  # Third party library import.
+
+BAR = "bar"

--- a/tests/assets/missingrootinitpackage/utils.py
+++ b/tests/assets/missingrootinitpackage/utils.py
@@ -1,0 +1,7 @@
+from . import one
+
+
+def foo():
+    from .two import alpha
+
+    return 1

--- a/tests/functional/test_error_handling.py
+++ b/tests/functional/test_error_handling.py
@@ -17,3 +17,16 @@ def test_syntax_error_includes_module():
         filename=filename, lineno=5, text="fromb . import two\n"
     )
     assert expected_exception == excinfo.value
+
+
+@pytest.mark.xfail
+def test_missing_root_init_file():
+    with pytest.raises(
+        exceptions.NamespacePackageEncountered,
+        match=(
+            r"Package missingrootinitpackage appears to be a 'namespace package' (see PEP 420),"
+            r"which is not currently supported. If this is not deliberate, adding an __init__.py"
+            r"file should fix the problem."
+        ),
+    ):
+        build_graph("missingrootinitpackage")

--- a/tests/functional/test_error_handling.py
+++ b/tests/functional/test_error_handling.py
@@ -19,13 +19,12 @@ def test_syntax_error_includes_module():
     assert expected_exception == excinfo.value
 
 
-@pytest.mark.xfail
 def test_missing_root_init_file():
     with pytest.raises(
         exceptions.NamespacePackageEncountered,
         match=(
-            r"Package missingrootinitpackage appears to be a 'namespace package' (see PEP 420),"
-            r"which is not currently supported. If this is not deliberate, adding an __init__.py"
+            r"Package missingrootinitpackage appears to be a 'namespace package' \(see PEP 420\), "
+            r"which is not currently supported. If this is not deliberate, adding an __init__\.py "
             r"file should fix the problem."
         ),
     ):


### PR DESCRIPTION
Raise a more helpful error message when there is a missing __init__.py file.