### PR TITLE
Add namespace packages support (fixes #80)

### DIFF
--- a/src/grimp/adaptors/importscanner.py
+++ b/src/grimp/adaptors/importscanner.py
@@ -91,9 +91,14 @@ class ImportScanner(AbstractImportScanner):
         package_directory, package_name = self._lookup_module_package_directory(module)
         package_components = package_name.split(".")
         module_components = module.name.split(".")
-        assert module_components[0:len(package_components)] == package_components, "Module should be part of package"
+        assert (
+            module_components[0:len(package_components)] == package_components
+        ), "Module should be part of package"
 
-        filename_root = self.file_system.join(package_directory, *module_components[len(package_components):])
+        filename_root = self.file_system.join(
+            package_directory,
+            *module_components[len(package_components):]
+        )
         candidate_filenames = (
             f"{filename_root}.py",
             self.file_system.join(filename_root, "__init__.py"),
@@ -101,7 +106,7 @@ class ImportScanner(AbstractImportScanner):
         for candidate_filename in candidate_filenames:
             if self.file_system.exists(candidate_filename):
                 return candidate_filename
-        raise FileNotFoundError(f"Could not find module {module} ({package_components} {module_components}).")
+        raise FileNotFoundError(f"Could not find module {module}.")
 
     def _lookup_module_package_directory(self, module: Module) -> Tuple[str, str]:
         for package_directory, (package_name, modules) in self.modules_by_package_directory.items():

--- a/src/grimp/adaptors/modulefinder.py
+++ b/src/grimp/adaptors/modulefinder.py
@@ -19,7 +19,7 @@ class ModuleFinder(modulefinder.AbstractModuleFinder):
 
         for module_filename in self._get_python_files_inside_package(package_directory):
             module_name = self._module_name_from_filename(
-                module_filename, package_directory
+                module_filename, package_directory, package_name
             )
             modules.append(Module(module_name))
 
@@ -65,7 +65,7 @@ class ModuleFinder(modulefinder.AbstractModuleFinder):
         return not filename.startswith(".") and filename.endswith(".py")
 
     def _module_name_from_filename(
-        self, filename_and_path: str, package_directory: str
+        self, filename_and_path: str, package_directory: str, package_name: str
     ) -> str:
         """
         Args:
@@ -74,7 +74,6 @@ class ModuleFinder(modulefinder.AbstractModuleFinder):
          Returns:
             Absolute module name for importing (string).
         """
-        container_directory, package_name = self.file_system.split(package_directory)
         internal_filename_and_path = filename_and_path[len(package_directory) :]
         internal_filename_and_path_without_extension = internal_filename_and_path[1:-3]
         components = [

--- a/src/grimp/application/ports/importscanner.py
+++ b/src/grimp/application/ports/importscanner.py
@@ -1,5 +1,5 @@
 import abc
-from typing import Dict, Set
+from typing import Dict, Set, Tuple
 
 from grimp.application.ports.filesystem import AbstractFileSystem
 from grimp.domain.valueobjects import DirectImport, Module
@@ -12,7 +12,7 @@ class AbstractImportScanner(abc.ABC):
 
     def __init__(
         self,
-        modules_by_package_directory: Dict[str, Set[Module]],
+        modules_by_package_directory: Dict[str, Tuple[str, Set[Module]]],
         file_system: AbstractFileSystem,
         include_external_packages: bool = False,
     ) -> None:
@@ -45,7 +45,7 @@ class AbstractImportScanner(abc.ABC):
 
         # Flatten all the modules into a set.
         self.modules: Set[Module] = set()
-        for package_modules in self.modules_by_package_directory.values():
+        for _, package_modules in self.modules_by_package_directory.values():
             self.modules |= package_modules
 
     @abc.abstractmethod

--- a/src/grimp/application/ports/importscanner.py
+++ b/src/grimp/application/ports/importscanner.py
@@ -22,17 +22,17 @@ class AbstractImportScanner(abc.ABC):
                                             keyed by the full file path of the directory of the
                                             root package for each set of modules. For example:
                                             {
-                                                "/path/to/packageone": {
+                                                "/path/to/packageone": ("packageone", {
                                                     Module("packageone"),
                                                     Module("packageone.foo"),
                                                     Module("packageone.bar"),
                                                     Module("packageone.bar.alpha"),
-                                                },
-                                                "/path/to/packagetwo": {
+                                                }),
+                                                "/path/to/packagetwo": ("packagetwo", {
                                                     Module("packagetwo"),
                                                     Module("packagetwo.baz"),
                                                     ...
-                                                },
+                                                }),
                                             }
             - file_system:                  The file system interface to use.
             - include_external_packages:    Whether to include imports of external modules (i.e.

--- a/src/grimp/application/usecases.py
+++ b/src/grimp/application/usecases.py
@@ -57,7 +57,7 @@ def build_graph(
             file_system=file_system,
         )
         modules.extend(package_modules)
-        modules_by_package_directory[package_directory] = set(package_modules)
+        modules_by_package_directory[package_directory] = (package_name, set(package_modules))
 
     root_modules = {module.root for module in modules}
 


### PR DESCRIPTION
Adds support for packages that are organized in a namespace.
Does NOT allow adding a namespace to the graph (questionable
semantics, definitely a nice to have like a glob).

```
build_graph("acme.foo", "acme.bar") # yes
build_graph("acme") # no
```

Before this would fail because `find_modules` would discover `acme.foo` as `foo`.
Fixing that led to another failure, because `_determine_module_filename`
assumed that a package wouldn't contain a `.`.

- [x] Unit tests
- [x] Update docs on AbstractImportScanner
- [ ] Add Authors
- [ ] Add Changelog

Let me know if there are additional changes needed.