### PR TITLE
Drop dependency on NetworkX

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -4,3 +4,4 @@ Authors
 
 * David Seddon - https://seddonym.me
 * Kevin Amado - https://github.com/kamadorueda
+* NetworkX developers - The shortest path algorithm was adapted from the NetworkX library https://networkx.org/.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,14 @@
 Changelog
 =========
 
+latest
+------
+
+* Significantly speed up graph copying.
+* Remove find_all_simple_chains method.
+* No longer use a networkx graph internally.
+* Fix bug where import details remained stored in the graph after removing modules or imports.
+
 1.3 (2022-8-15)
 ---------------
 * Officially support Python 3.9 and 3.10.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,6 +8,7 @@ Contents
    readme
    installation
    usage
+   networkx
    contributing
    authors
    changelog

--- a/docs/networkx.rst
+++ b/docs/networkx.rst
@@ -1,0 +1,28 @@
+========
+NetworkX
+========
+
+If you want to analyze the graph in a way that isn't provided by Grimp, you may want to consider converting the graph to a `NetworkX`_ graph.
+
+NetworkX is a third-party Python library with a large number of algorithms for working with graphs.
+
+Converting the Grimp graph to a NetworkX graph
+----------------------------------------------
+
+First, you should install NetworkX (e.g. ``pip install networkx``).
+
+You can then build up a NetworkX graph as shown::
+
+    import grimp
+    import networkx
+
+    grimp_graph = grimp.build_graph("mypackage")
+
+    # Build a NetworkX graph from the Grimp graph.
+    networkx_graph = networkx.DiGraph()
+    for module in grimp_graph.modules:
+        networkx_graph.add_node(module)
+        for imported in grimp_graph.find_modules_directly_imported_by(module):
+            networkx_graph.add_edge(module, imported)
+
+.. _NetworkX: https://networkx.org/

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -214,17 +214,6 @@ Methods for analysing import chains
              contained within other chains in the result set will be excluded.
     :rtype: A set of tuples of strings. Each tuple is ordered from importer to imported modules.
 
-.. py:function:: ImportGraph.find_all_simple_chains(importer, imported)
-
-    :param str importer: A module or subpackage within the graph.
-    :param str imported: Another module or subpackage within the graph.
-    :return: All simple chains between the importer and the imported modules (a simple chain is one with no
-        repeated modules).
-
-        If either module is not present in the graph, grimp.exceptions.ModuleNotPresent
-        will be raised.
-    :rtype: A generator of tuples of strings. Each tuple is ordered from importer to imported modules.
-
 .. py:function:: ImportGraph.chain_exists(importer, imported, as_packages=False)
 
     :param str importer: The module at the start of the potential chain of imports (as in ``find_shortest_chain``).

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,4 @@ setup(
         'Programming Language :: Python :: Implementation :: CPython',
         'Topic :: Utilities',
     ],
-    install_requires=[
-        'networkx>=2.1,<3',
-    ],
 )

--- a/src/grimp/algorithms/shortest_path.py
+++ b/src/grimp/algorithms/shortest_path.py
@@ -1,0 +1,143 @@
+"""
+The algorithms in this module have been adapted from networkx 2.8.5.
+
+See networkx.algorithms.shortest_paths.unweighted.bidirectional_shortest_path.
+
+Original license follows:
+
+--------------------------------------------------------------------------
+
+NetworkX is distributed with the 3-clause BSD license.
+
+::
+
+   Copyright (C) 2004-2022, NetworkX Developers
+   Aric Hagberg <hagberg@lanl.gov>
+   Dan Schult <dschult@colgate.edu>
+   Pieter Swart <swart@lanl.gov>
+   All rights reserved.
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are
+   met:
+
+     * Redistributions of source code must retain the above copyright
+       notice, this list of conditions and the following disclaimer.
+
+     * Redistributions in binary form must reproduce the above
+       copyright notice, this list of conditions and the following
+       disclaimer in the documentation and/or other materials provided
+       with the distribution.
+
+     * Neither the name of the NetworkX Developers nor the names of its
+       contributors may be used to endorse or promote products derived
+       from this software without specific prior written permission.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+   A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+   OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+   DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+   THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+"""
+from typing import Dict, Optional, Set, Tuple
+
+
+def bidirectional_shortest_path(
+    *,
+    importer: str,
+    imported: str,
+    importers_by_imported: Dict[str, Set[str]],
+    importeds_by_importer: Dict[str, Set[str]],
+) -> Optional[Tuple[str, ...]]:
+    """
+    Returns a tuple of modules in the shortest path between importer and imported.
+
+    If no path can be found, return None.
+
+    Args:
+        importer: the module doing the importing; the starting point.
+        imported: the module being imported: the end point.
+        importers_by_imported: Map of modules directly imported by each key.
+        importeds_by_importer: Map of all the modules that directly import each key.
+    """
+
+    results = _search_for_path(
+        importers_by_imported=importers_by_imported,
+        importeds_by_importer=importeds_by_importer,
+        importer=importer,
+        imported=imported,
+    )
+    if results is None:
+        return None
+
+    pred, succ, w = results
+
+    # Transform results into tuple.
+    path = []
+    # From importer to w:
+    while w is not None:
+        path.append(w)
+        w = pred[w]  # type: ignore
+    path.reverse()
+    # From w to imported:
+    w = succ[path[-1]]
+    while w is not None:
+        path.append(w)
+        w = succ[w]
+
+    return tuple(path)
+
+
+def _search_for_path(
+    *, importers_by_imported, importeds_by_importer, importer: str, imported: str
+) -> Optional[Tuple[Dict[str, Optional[str]], Dict[str, Optional[str]], str]]:
+    """Bidirectional shortest path helper.
+
+    Performs a breadth first search from both source and target, meeting in the middle.
+
+    Returns:
+         (pred, succ, w) where
+            - pred is a dictionary of predecessors from w to the source, and
+            - succ is a dictionary of successors from w to the target.
+    """
+    if imported == importer:
+        return ({imported: None}, {importer: None}, importer)
+
+    pred: Dict[str, Optional[str]] = {importer: None}
+    succ: Dict[str, Optional[str]] = {imported: None}
+
+    # Initialize fringes, start with forward.
+    forward_fringe = [importer]
+    reverse_fringe = [imported]
+
+    while forward_fringe and reverse_fringe:
+        if len(forward_fringe) <= len(reverse_fringe):
+            this_level = forward_fringe
+            forward_fringe = []
+            for v in this_level:
+                for w in importeds_by_importer[v]:
+                    if w not in pred:
+                        forward_fringe.append(w)
+                        pred[w] = v
+                    if w in succ:
+                        # Found path.
+                        return pred, succ, w
+        else:
+            this_level = reverse_fringe
+            reverse_fringe = []
+            for v in this_level:
+                for w in importers_by_imported[v]:
+                    if w not in succ:
+                        succ[w] = v
+                        reverse_fringe.append(w)
+                    if w in pred:
+                        # Found path.
+                        return pred, succ, w
+
+    return None

--- a/src/grimp/application/ports/graph.py
+++ b/src/grimp/application/ports/graph.py
@@ -243,19 +243,16 @@ class AbstractImportGraph(abc.ABC):
         """
         Generate all simple chains between the importer and the imported modules.
 
-        A simple chain is one with no repeated modules.
-
-        Returns:
-            A generator that produces tuples of strings. Each tuple is ordered from importer
-            to imported modules.
-
-        If either module is not present in the graph, grimp.exceptions.ModuleNotPresent
-        will be raised.
+        Note: this method is no longer documented and will be removed.
         """
-        raise NotImplementedError
+        raise AttributeError(
+            "This method has been removed. Consider using find_shortest_chains instead?"
+        )
 
     @abc.abstractmethod
-    def chain_exists(self, importer: str, imported: str, as_packages: bool = False) -> bool:
+    def chain_exists(
+        self, importer: str, imported: str, as_packages: bool = False
+    ) -> bool:
         """
         Return whether any chain of imports exists between the two modules, in the direction
         of importer to imported. In other words, does the importer depend on the imported?


### PR DESCRIPTION
Removes the internal NetworkX graph from the Import Graph.

The main reason for this change is to allow a leaner graph that can be deepcopied more efficiently, which is also implemented in this PR. This results in a significant speedup for my downstream library [Import Linter](https://import-linter.readthedocs.io/en/stable/), which does a lot of copying of the graph.

## Dropping support for find simple chains 

As part of this PR I also took the decision to remove the `find_all_simple_chains` method on the graph. https://grimp.readthedocs.io/en/v1.3/usage.html#ImportGraph.find_all_simple_chains.

This is because it uses different data structures underneath than are necessary for the rest of the graph, and I wasn't convinced it was actually a useful method. In most cases it will be better to use `find_shortest_chain` or `find_shortest_chains`. Dropping support will allow the graph to be quicker to copy and will particularly help in making Import Linter faster, which is a priority.

However, to mitigate the potential downsides I have added a page of documentation on how to convert the graph to a NetworkX graph, hopefully freeing up users who continue to need NetworkX.

Because of the backward compatibility issues this will be part of a major release.