### PR TITLE
Fix tests for windows platforms

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   tests:
-    name: tox on ${{ matrix.os }}, python ${{ matrix.python-version }}
+    name: tox on python ${{ matrix.python-version }}, ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
 
     strategy:

--- a/src/grimp/adaptors/filesystem.py
+++ b/src/grimp/adaptors/filesystem.py
@@ -10,6 +10,10 @@ class FileSystem(AbstractFileSystem):
     Abstraction around file system calls.
     """
 
+    @property
+    def sep(self) -> str:
+        return os.sep
+
     def dirname(self, filename: str) -> str:
         return os.path.dirname(filename)
 

--- a/src/grimp/adaptors/modulefinder.py
+++ b/src/grimp/adaptors/modulefinder.py
@@ -1,5 +1,4 @@
 import logging
-import os
 from typing import Iterable, List
 
 from grimp.application.ports import modulefinder
@@ -84,7 +83,7 @@ class ModuleFinder(modulefinder.AbstractModuleFinder):
         internal_filename_and_path_without_extension = internal_filename_and_path[1:-3]
         components = [
             package_name
-        ] + internal_filename_and_path_without_extension.split(os.sep)
+        ] + internal_filename_and_path_without_extension.split(self.file_system.sep)
         if components[-1] == "__init__":
             components.pop()
         return ".".join(components)

--- a/src/grimp/application/ports/filesystem.py
+++ b/src/grimp/application/ports/filesystem.py
@@ -7,6 +7,15 @@ class AbstractFileSystem(abc.ABC):
     Abstraction around file system calls.
     """
 
+    @property
+    @abc.abstractmethod
+    def sep(self) -> str:
+        """
+        Return the file separator for the FileSystem.
+
+        E.G. '/' for UNIX systems and '\\' for Windows systems
+        """
+
     @abc.abstractmethod
     def dirname(self, filename: str) -> str:
         """

--- a/tests/adaptors/filesystem.py
+++ b/tests/adaptors/filesystem.py
@@ -38,6 +38,10 @@ class FakeFileSystem(AbstractFileSystem):
         self.contents = self._parse_contents(contents)
         self.content_map = content_map if content_map else {}
 
+    @property
+    def sep(self) -> str:
+        return "/"
+
     def dirname(self, filename: str) -> str:
         """
         Return the full path to the directory name of the supplied filename.

--- a/tests/unit/adaptors/test_packagefinder.py
+++ b/tests/unit/adaptors/test_packagefinder.py
@@ -5,6 +5,7 @@ import pytest  # type: ignore
 
 from grimp import exceptions
 from grimp.adaptors.packagefinder import ImportLibPackageFinder
+from grimp.adaptors.filesystem import FileSystem
 from tests.adaptors.filesystem import FakeFileSystem
 
 assets = (Path(__file__).parent.parent.parent / "assets").resolve()
@@ -26,7 +27,7 @@ assets = (Path(__file__).parent.parent.parent / "assets").resolve()
 )
 def test_determine_package_directory(package, expected):
     assert ImportLibPackageFinder().determine_package_directory(
-        package, FakeFileSystem()
+        package, FileSystem()
     ) == str(expected)
 
 


### PR DESCRIPTION
The tests are failing on windows because they were written for linux with a slash file path separator while windows uses backslash.

This PR aims at making the tests run on all platforms, unix-based and windows alike.

Modification:

1. `modulefinder` has a call to `os.sep`. This is platform dependent. I believe it make sense to add the separator in the AbstractFileSystem construct, so the FakeFileSystem used for tests can return a slash ("/") separator even when running on windows (as all tests and the FakeFileSystem  were written with UNIX path in mind)
2. In `test_packagefinder.py`, `test_determine_package_directory` uses the "assets" folder, which contains real files, but FakeFileSystem is given to the function under test. I believe the function should use the real grimp FileSystem here, as the assets folder is real, not fake.

The following PR make the tests pass on windows with minimal changes, I rely on github CI to check linux platforms.