### PR TITLE
DO NOT MERGE Add macos and windows to CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   tests:
-    name: tox on ${{ matrix.python-version }}
+    name: tox on ${{ matrix.os }}, python ${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
 
     strategy:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,11 +11,12 @@ on:
 jobs:
   tests:
     name: tox on ${{ matrix.python-version }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
 
     strategy:
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Add windows and macos targets to github actions.

This demonstrate why https://github.com/seddonym/grimp/pull/99 is needed: I expect windows tests to fail