### PR TITLE
Annotate get_import_details with a TypedDict

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,4 +55,8 @@ setup(
         'Programming Language :: Python :: Implementation :: CPython',
         'Topic :: Utilities',
     ],
+    python_requires=">=3.7",
+    install_requires=[
+        "typing-extensions>=3.10.0.0",
+    ],
 )

--- a/src/grimp/adaptors/graph.py
+++ b/src/grimp/adaptors/graph.py
@@ -1,5 +1,5 @@
 from copy import copy
-from typing import Any, Dict, List, Optional, Set, Tuple, Union, cast
+from typing import Dict, List, Optional, Set, Tuple, cast
 
 from grimp.algorithms.shortest_path import bidirectional_shortest_path
 from grimp.application.ports import graph
@@ -21,7 +21,7 @@ class ImportGraph(graph.AbstractImportGraph):
         self._edge_count = 0
 
         # Instantiate a dict that stores the details for all direct imports.
-        self._import_details: Dict[str, List[Dict[str, Any]]] = {}
+        self._import_details: Dict[str, List[graph.DetailedImport]] = {}
         self._squashed_modules: Set[str] = set()
 
     # Dunder methods
@@ -134,8 +134,8 @@ class ImportGraph(graph.AbstractImportGraph):
                 {
                     "importer": importer,
                     "imported": imported,
-                    "line_number": line_number,
-                    "line_contents": line_contents,
+                    "line_number": cast(int, line_number),
+                    "line_contents": cast(str, line_contents),
                 }
             )
 
@@ -235,7 +235,7 @@ class ImportGraph(graph.AbstractImportGraph):
 
     def get_import_details(
         self, *, importer: str, imported: str
-    ) -> List[Dict[str, Union[str, int]]]:
+    ) -> List[graph.DetailedImport]:
         import_details_for_importer = self._import_details.get(importer, [])
         # Only include the details for the imported module.
         # Note: we copy each details dictionary at this point, as our deepcopying

--- a/src/grimp/application/ports/graph.py
+++ b/src/grimp/application/ports/graph.py
@@ -1,5 +1,14 @@
 import abc
-from typing import Dict, Iterator, List, Optional, Set, Tuple, Union
+from typing import Iterator, List, Optional, Set, Tuple
+
+from typing_extensions import TypedDict
+
+
+class DetailedImport(TypedDict):
+    importer: str
+    imported: str
+    line_number: int
+    line_contents: str
 
 
 class AbstractImportGraph(abc.ABC):
@@ -144,7 +153,7 @@ class AbstractImportGraph(abc.ABC):
     @abc.abstractmethod
     def get_import_details(
         self, *, importer: str, imported: str
-    ) -> List[Dict[str, Union[str, int]]]:
+    ) -> List[DetailedImport]:
         """
         Return available metadata relating to the direct imports between two modules, in the form:
         [


### PR DESCRIPTION
This is a big improvement for all code that utilises the get_import_details() method on a graph object. Type-checkers can now verify which keys are being accessed, rather than just allowing any access on any key. They also natively understand the type of each supported key, without us having to cast values manually.

As this project needs to support Python 3.7 for the time being, this introduces a dependency on `typing_extensions` to utilise TypedDict.

Fixes #94 