### PR TITLE
Logging

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog
 =========
 
+latest
+------
+
+* Log cache activity.
+
 2.4 (2023-5-5)
 --------------
 

--- a/src/grimp/adaptors/caching.py
+++ b/src/grimp/adaptors/caching.py
@@ -166,10 +166,14 @@ class Cache(AbstractCache):
         try:
             serialized = self.file_system.read(meta_cache_filename)
         except FileNotFoundError:
+            logger.info(f"No cache file: {meta_cache_filename}.")
             return {}
         try:
-            return json.loads(serialized)
+            deserialized = json.loads(serialized)
+            logger.info(f"Used cache meta file {meta_cache_filename}.")
+            return deserialized
         except json.JSONDecodeError:
+            logger.warning(f"Could not use corrupt cache file {meta_cache_filename}.")
             return {}
 
     def _build_data_map(self) -> None:
@@ -186,12 +190,15 @@ class Cache(AbstractCache):
         try:
             serialized = self.file_system.read(data_cache_filename)
         except FileNotFoundError:
+            logger.info(f"No cache file: {data_cache_filename}.")
             return {}
 
         # Deserialize to primitives.
         try:
             deserialized_json = json.loads(serialized)
+            logger.info(f"Used cache data file {data_cache_filename}.")
         except json.JSONDecodeError:
+            logger.warning(f"Could not use corrupt cache file {data_cache_filename}.")
             return {}
 
         primitives_map: PrimitiveFormat = self._to_primitives_data_map(

--- a/tests/unit/adaptors/test_caching.py
+++ b/tests/unit/adaptors/test_caching.py
@@ -8,7 +8,7 @@ from grimp.application.ports.caching import CacheMiss
 from grimp.application.ports.modulefinder import FoundPackage, ModuleFile
 from grimp.domain.valueobjects import DirectImport, Module
 from tests.adaptors.filesystem import FakeFileSystem
-
+import logging
 
 class SimplisticFileNamer(CacheFileNamer):
     """
@@ -446,8 +446,9 @@ class TestCache:
         ),
     )
     def test_write_to_cache(
-        self, include_external_packages, expected_data_file_name, cache_dir
+        self, include_external_packages, expected_data_file_name, cache_dir, caplog
     ):
+        caplog.set_level(logging.INFO, logger=Cache.__module__)
         file_system = FakeFileSystem()
         blue_one = Module(name="blue.one")
         blue_two = Module(name="blue.two")
@@ -521,6 +522,11 @@ class TestCache:
         expected_cache_dir = (
             cache_dir.rstrip(file_system.sep) if cache_dir else ".grimp_cache"
         )
+        assert set(caplog.messages) == {
+            f"Wrote data cache file {expected_cache_dir}/{expected_data_file_name}.",
+            f"Wrote meta cache file {expected_cache_dir}/blue.meta.json.",
+            f"Wrote meta cache file {expected_cache_dir}/green.meta.json.",
+        }
         expected = {
             f"{expected_cache_dir}/blue.meta.json": {
                 blue_one.name: mtimes[blue_one],


### PR DESCRIPTION
Adds some cache-related logging. I'll do a PR in Import Linter to expose this, which will serve as a proof of concept when we come to move some of the contract-related checking into Grimp, as that needs to surface output when in verbose mode.