### PR TITLE
Layers

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ latest
 
 * Log cache activity.
 * Drop support for Python 3.7.
+* Add find_illegal_dependencies_for_layers method.
 
 2.4 (2023-5-5)
 --------------

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -267,22 +267,22 @@ Higher level analysis
                 "medium",
                 "low",
             ),
-            containers=(
+            containers={
                 "mypackage.foo",
                 "mypackage.bar",
-            ),
+            },
         )
 
-    :param tuple[str, ...] layers: The name of each layer module. If ``containers`` are also specified,
+    :param Sequence[str] layers: The name of each layer module. If ``containers`` are also specified,
         then these names must be relative to the container. The order is from higher to lower level layers.
         *Any layers that don't exist in the graph will be ignored.*
-    :param tuple[str, ...] containers: The parent modules of the layers, as absolute names that you could
+    :param set[str] containers: The parent modules of the layers, as absolute names that you could
         import, such as ``mypackage.foo``. (Optional.)
     :return: The illegal dependencies in the form of a set of :class:`.PackageDependency` objects. Each package
              dependency is for a different permutation of two layers for which there is a violation, and contains
              information about the illegal chains of imports from the lower layer (the 'upstream') to the higher layer
              (the 'downstream').
-    :rtype: ``frozenset[PackageDependency]``.
+    :rtype: ``set[PackageDependency]``.
     :raises grimp.exceptions.NoSuchContainer: if a container is not a module in the graph.
 
     .. class:: PackageDependency

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -249,6 +249,10 @@ Higher level analysis
     with its search. As a result, any illegal Routes that have sections in common with other illegal Routes may not
     be returned.
 
+    Additionally, unfortunately the Routes included in the PackageDependencies are not, currently, completely
+    deterministic. If there are multiple illegal Routes of the same length, it is not predictable which one will be
+    found first. This means that the PackageDependencies returned can vary for the same graph.
+
     Example::
 
         dependencies = graph.find_illegal_dependencies_for_layers(

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,3 +2,6 @@
 extend-ignore = E731, E203
 max-line-length = 100
 exclude = */migrations/*, tests/assets/*
+
+[tool:pytest]
+xfail_strict=true

--- a/src/grimp/__init__.py
+++ b/src/grimp/__init__.py
@@ -1,7 +1,16 @@
 __version__ = "2.4"
 
 from .application.ports.graph import DetailedImport, ImportGraph
+from .domain.analysis import PackageDependency, Route
 from .domain.valueobjects import DirectImport, Module
 from .main import build_graph
 
-__all__ = ["Module", "DetailedImport", "DirectImport", "ImportGraph", "build_graph"]
+__all__ = [
+    "Module",
+    "DetailedImport",
+    "DirectImport",
+    "ImportGraph",
+    "PackageDependency",
+    "Route",
+    "build_graph",
+]

--- a/src/grimp/adaptors/_layers.py
+++ b/src/grimp/adaptors/_layers.py
@@ -1,0 +1,343 @@
+from __future__ import annotations
+
+import copy
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Iterator
+
+from grimp import Route
+from grimp.application.ports.graph import ImportGraph
+from grimp.domain.analysis import PackageDependency
+from grimp.exceptions import NoSuchContainer
+
+
+def find_illegal_dependencies(
+    graph: ImportGraph,
+    layers: tuple[str, ...],
+    containers: set[str],
+) -> frozenset[PackageDependency]:
+    """
+    Find dependencies that don't conform to the supplied layered architecture.
+
+    See ImportGraph.find_illegal_dependencies_for_layers.
+
+    The only difference between this and the method is that the containers passed in
+    is already a (potentially empty) set.
+    """
+    _check_containers_exist(graph, containers)
+
+    package_dependencies = set()
+
+    for (
+        higher_layer_package,
+        lower_layer_package,
+        container,
+    ) in _generate_module_permutations(graph, layers, containers):
+
+        dependency_or_none = _search_for_package_dependency(
+            higher_layer_package=higher_layer_package,
+            lower_layer_package=lower_layer_package,
+            layers=layers,
+            container=container,
+            graph=graph,
+        )
+
+        if dependency_or_none:
+            package_dependencies.add(dependency_or_none)
+
+    return frozenset(package_dependencies)
+
+
+class _Module:
+    """
+    A Python module.
+    """
+
+    def __init__(self, name: str) -> None:
+        """
+        Args:
+            name: The fully qualified name of a Python module, e.g. 'package.foo.bar'.
+        """
+        self.name = name
+
+    def __str__(self) -> str:
+        return self.name
+
+    def __eq__(self, other: Any) -> bool:
+        if isinstance(other, self.__class__):
+            return hash(self) == hash(other)
+        else:
+            return False
+
+    def __hash__(self) -> int:
+        return hash(str(self))
+
+    def is_descendant_of(self, module: "_Module") -> bool:
+        return self.name.startswith(f"{module.name}.")
+
+
+@dataclass(frozen=True)
+class _Link:
+    importer: str
+    imported: str
+
+
+# A chain of modules, each of which imports the next.
+if TYPE_CHECKING:
+    # TODO: remove TYPE_CHECKING conditional once on Python 3.9.
+    _Chain = tuple[str, ...]
+
+
+def _check_containers_exist(graph: ImportGraph, containers: set[str]) -> None:
+    for container in containers:
+        if container not in graph.modules:
+            raise NoSuchContainer(f"Container {container} does not exist.")
+
+
+def _generate_module_permutations(
+    graph: ImportGraph,
+    layers: tuple[str, ...],
+    containers: set[str],
+) -> Iterator[tuple[_Module, _Module, str | None]]:
+    """
+    Return all possible combinations of higher level and lower level modules, in pairs.
+
+    Each pair of modules consists of immediate children of two different layers. The first
+    module is in a layer higher than the layer of the second module. This means the first
+    module is allowed to import the second, but not the other way around.
+
+    Returns:
+        module_in_higher_layer, module_in_lower_layer, container
+    """
+    # If there are no containers, we still want to run the loop once.
+    quasi_containers = containers or [None]
+
+    for container in quasi_containers:
+        for index, higher_layer in enumerate(layers):
+            higher_layer_module = _module_from_layer(higher_layer, container)
+
+            if higher_layer_module.name not in graph.modules:
+                continue
+
+            for lower_layer in layers[index + 1 :]:
+
+                lower_layer_module = _module_from_layer(lower_layer, container)
+
+                if lower_layer_module.name not in graph.modules:
+                    continue
+
+                yield higher_layer_module, lower_layer_module, container
+
+
+def _module_from_layer(layer: str, container: str | None = None) -> _Module:
+    if container:
+        name = ".".join([container, layer])
+    else:
+        name = layer
+    return _Module(name)
+
+
+def _search_for_package_dependency(
+    higher_layer_package: _Module,
+    lower_layer_package: _Module,
+    layers: tuple[str, ...],
+    container: str | None,
+    graph: ImportGraph,
+) -> PackageDependency | None:
+    """
+    Return a PackageDependency containing illegal chains between two layers, if they exist.
+    """
+    temp_graph = copy.deepcopy(graph)
+    _remove_other_layers(
+        temp_graph,
+        layers=layers,
+        container=container,
+        layers_to_preserve=(higher_layer_package, lower_layer_package),
+    )
+    # Assemble direct imports between the layers, then remove them.
+    import_details_between_layers = _pop_direct_imports(
+        higher_layer_package=higher_layer_package,
+        lower_layer_package=lower_layer_package,
+        graph=temp_graph,
+    )
+    routes: set[Route] = set()
+
+    for import_details_list in import_details_between_layers:
+        any_element = tuple(import_details_list)[0]
+        routes.add(
+            Route(
+                heads=frozenset({any_element.importer}),
+                middle=(),
+                tails=frozenset({any_element.imported}),
+            )
+        )
+
+    indirect_routes = _get_indirect_routes(
+        temp_graph,
+        importer_package=lower_layer_package,
+        imported_package=higher_layer_package,
+    )
+
+    routes |= indirect_routes
+
+    if routes:
+        return PackageDependency(
+            upstream=lower_layer_package.name,
+            downstream=higher_layer_package.name,
+            routes=frozenset(routes),
+        )
+    else:
+        return None
+
+
+def _get_indirect_routes(
+    graph: ImportGraph, importer_package: _Module, imported_package: _Module
+) -> set[Route]:
+    """
+    Squashes the two packages.
+    Gets a list of paths between them, called segments.
+    Add the heads and tails to the segments.
+    """
+    temp_graph = copy.deepcopy(graph)
+
+    temp_graph.squash_module(importer_package.name)
+    temp_graph.squash_module(imported_package.name)
+
+    middles = _find_middles(
+        temp_graph,
+        importer=importer_package,
+        imported=imported_package,
+    )
+    return _middles_to_routes(
+        graph, middles, importer=importer_package, imported=imported_package
+    )
+
+
+def _remove_other_layers(
+    graph: ImportGraph,
+    layers: tuple[str, ...],
+    container: str | None,
+    layers_to_preserve: tuple[_Module, ...],
+) -> None:
+    for index, layer in enumerate(layers):  # type: ignore
+        candidate_layer = _module_from_layer(layer, container)
+        if (
+            candidate_layer.name in graph.modules
+            and candidate_layer not in layers_to_preserve
+        ):
+            _remove_layer(graph, layer_package=candidate_layer)
+
+
+def _remove_layer(graph: ImportGraph, layer_package: _Module) -> None:
+    for module in graph.find_descendants(layer_package.name):
+        graph.remove_module(module)
+    graph.remove_module(layer_package.name)
+
+
+def _pop_direct_imports(
+    higher_layer_package, lower_layer_package, graph: ImportGraph
+) -> set[frozenset[_Link]]:
+    import_details_set: set[frozenset[_Link]] = set()
+
+    lower_layer_modules = {lower_layer_package.name} | graph.find_descendants(
+        lower_layer_package.name
+    )
+    for lower_layer_module in lower_layer_modules:
+        imported_modules = graph.find_modules_directly_imported_by(
+            lower_layer_module
+        ).copy()
+        for imported_module in imported_modules:
+            if _Module(imported_module) == higher_layer_package or _Module(
+                imported_module
+            ).is_descendant_of(higher_layer_package):
+                import_details = frozenset(
+                    {
+                        _Link(
+                            importer=lower_layer_module,
+                            imported=imported_module,
+                        ),
+                    }
+                )
+                import_details_set.add(import_details)
+                graph.remove_import(
+                    importer=lower_layer_module, imported=imported_module
+                )
+    return import_details_set
+
+
+def _find_middles(
+    graph: ImportGraph, importer: _Module, imported: _Module
+) -> set[_Chain]:
+    """
+    Return set of headless and tailless chains.
+    """
+    middles: set[_Chain] = set()
+
+    for chain in _pop_shortest_chains(
+        graph, importer=importer.name, imported=imported.name
+    ):
+        if len(chain) == 2:
+            raise ValueError("Direct chain found - these should have been removed.")
+        middles.add(chain[1:-1])
+
+    return middles
+
+
+def _middles_to_routes(
+    graph: ImportGraph, middles: set[_Chain], importer: _Module, imported: _Module
+) -> set[Route]:
+    """
+    Build a set of routes from the chains between one package and another.
+
+    The middles are the chains that exist from the importer package to
+    the importer package. This function works out the head and tail packages of
+    those chains by consulting the graph.
+    """
+    routes: set[Route] = set()
+
+    for middle in middles:
+        heads: set[str] = set()
+        imported_module = middle[0]
+        candidate_modules = sorted(
+            graph.find_modules_that_directly_import(imported_module)
+        )
+        for module in [
+            m
+            for m in candidate_modules
+            if _Module(m) == importer or _Module(m).is_descendant_of(importer)
+        ]:
+            heads.add(module)
+
+        tails: set[str] = set()
+        importer_module = middle[-1]
+        candidate_modules = sorted(
+            graph.find_modules_directly_imported_by(importer_module)
+        )
+        for module in [
+            m
+            for m in candidate_modules
+            if _Module(m) == imported or _Module(m).is_descendant_of(imported)
+        ]:
+            tails.add(module)
+
+        routes.add(
+            Route(
+                heads=frozenset(heads),
+                middle=middle,
+                tails=frozenset(tails),
+            )
+        )
+
+    return routes
+
+
+def _pop_shortest_chains(
+    graph: ImportGraph, importer: str, imported: str
+) -> Iterator[tuple[str, ...]]:
+    chain: tuple[str, ...] | bool | None = True
+    while chain:
+        chain = graph.find_shortest_chain(importer, imported)
+        if chain:
+            # Remove chain of imports from graph.
+            for index in range(len(chain) - 1):
+                graph.remove_import(importer=chain[index], imported=chain[index + 1])
+            yield chain

--- a/src/grimp/adaptors/_layers.py
+++ b/src/grimp/adaptors/_layers.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import copy
 import logging
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Iterator
+from typing import TYPE_CHECKING, Any, Iterator, Sequence
 
 from grimp import Route
 from grimp.application.config import settings
@@ -16,9 +16,9 @@ logger = logging.getLogger("grimp")
 
 def find_illegal_dependencies(
     graph: ImportGraph,
-    layers: tuple[str, ...],
+    layers: Sequence[str],
     containers: set[str],
-) -> frozenset[PackageDependency]:
+) -> set[PackageDependency]:
     """
     Find dependencies that don't conform to the supplied layered architecture.
 
@@ -54,7 +54,7 @@ def find_illegal_dependencies(
 
         _log_illegal_route_count(dependency_or_none, duration_in_s=timer.duration_in_s)
 
-    return frozenset(package_dependencies)
+    return package_dependencies
 
 
 class _Module:
@@ -105,7 +105,7 @@ def _check_containers_exist(graph: ImportGraph, containers: set[str]) -> None:
 
 def _generate_module_permutations(
     graph: ImportGraph,
-    layers: tuple[str, ...],
+    layers: Sequence[str],
     containers: set[str],
 ) -> Iterator[tuple[_Module, _Module, str | None]]:
     """
@@ -149,7 +149,7 @@ def _module_from_layer(layer: str, container: str | None = None) -> _Module:
 def _search_for_package_dependency(
     higher_layer_package: _Module,
     lower_layer_package: _Module,
-    layers: tuple[str, ...],
+    layers: Sequence[str],
     container: str | None,
     graph: ImportGraph,
 ) -> PackageDependency | None:
@@ -224,7 +224,7 @@ def _get_indirect_routes(
 
 def _remove_other_layers(
     graph: ImportGraph,
-    layers: tuple[str, ...],
+    layers: Sequence[str],
     container: str | None,
     layers_to_preserve: tuple[_Module, ...],
 ) -> None:

--- a/src/grimp/adaptors/graph.py
+++ b/src/grimp/adaptors/graph.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from copy import copy
-from typing import Dict, List, Optional, Set, Tuple, cast
+from typing import Dict, List, Optional, Sequence, Set, Tuple, cast
 
 from grimp.algorithms.shortest_path import bidirectional_shortest_path
 from grimp.application.ports import graph
@@ -381,9 +381,9 @@ class ImportGraph(graph.ImportGraph):
 
     def find_illegal_dependencies_for_layers(
         self,
-        layers: Tuple[str, ...],
+        layers: Sequence[str],
         containers: Optional[Set[str]] = None,
-    ) -> frozenset[PackageDependency]:
+    ) -> set[PackageDependency]:
         return _layers.find_illegal_dependencies(
             graph=self, layers=layers, containers=containers or set()
         )

--- a/src/grimp/adaptors/graph.py
+++ b/src/grimp/adaptors/graph.py
@@ -1,8 +1,11 @@
+from __future__ import annotations
+
 from copy import copy
 from typing import Dict, List, Optional, Set, Tuple, cast
 
 from grimp.algorithms.shortest_path import bidirectional_shortest_path
 from grimp.application.ports import graph
+from grimp.domain.analysis import PackageDependency
 from grimp.domain.valueobjects import Module
 from grimp.exceptions import ModuleNotPresent
 
@@ -371,6 +374,15 @@ class ImportGraph(graph.ImportGraph):
                     return True
 
         return False
+
+    # High level analysis
+
+    def find_illegal_dependencies_for_layers(
+        self,
+        layers: Tuple[str, ...],
+        containers: Optional[Set[str]] = None,
+    ) -> frozenset[PackageDependency]:
+        return frozenset()
 
     # Private methods
 

--- a/src/grimp/adaptors/graph.py
+++ b/src/grimp/adaptors/graph.py
@@ -9,6 +9,8 @@ from grimp.domain.analysis import PackageDependency
 from grimp.domain.valueobjects import Module
 from grimp.exceptions import ModuleNotPresent
 
+from . import _layers
+
 
 class ImportGraph(graph.ImportGraph):
     """
@@ -382,7 +384,9 @@ class ImportGraph(graph.ImportGraph):
         layers: Tuple[str, ...],
         containers: Optional[Set[str]] = None,
     ) -> frozenset[PackageDependency]:
-        return frozenset()
+        return _layers.find_illegal_dependencies(
+            graph=self, layers=layers, containers=containers or set()
+        )
 
     # Private methods
 

--- a/src/grimp/adaptors/timing.py
+++ b/src/grimp/adaptors/timing.py
@@ -1,0 +1,8 @@
+import time
+
+from grimp.application.ports.timing import Timer
+
+
+class SystemClockTimer(Timer):
+    def get_current_time(self) -> float:
+        return time.time()

--- a/src/grimp/application/ports/graph.py
+++ b/src/grimp/application/ports/graph.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import abc
-from typing import Iterator, List, Optional, Set, Tuple
+from typing import Iterator, List, Optional, Sequence, Set, Tuple
 
 from typing_extensions import TypedDict
 
@@ -283,9 +283,9 @@ class ImportGraph(abc.ABC):
 
     def find_illegal_dependencies_for_layers(
         self,
-        layers: Tuple[str, ...],
+        layers: Sequence[str],
         containers: Optional[Set[str]] = None,
-    ) -> frozenset[PackageDependency]:
+    ) -> set[PackageDependency]:
         """
         Find dependencies that don't conform to the supplied layered architecture.
 

--- a/src/grimp/application/ports/graph.py
+++ b/src/grimp/application/ports/graph.py
@@ -1,7 +1,11 @@
+from __future__ import annotations
+
 import abc
 from typing import Iterator, List, Optional, Set, Tuple
 
 from typing_extensions import TypedDict
+
+from grimp.domain.analysis import PackageDependency
 
 
 class DetailedImport(TypedDict):
@@ -271,6 +275,39 @@ class ImportGraph(abc.ABC):
                          or as packages (including any descendants, if there are any). If
                          treating them as subpackages, all descendants of the supplied modules
                          will be checked too.
+        """
+        raise NotImplementedError
+
+    # High level analysis
+    # -------------------
+
+    def find_illegal_dependencies_for_layers(
+        self,
+        layers: Tuple[str, ...],
+        containers: Optional[Set[str]] = None,
+    ) -> frozenset[PackageDependency]:
+        """
+        Find dependencies that don't conform to the supplied layered architecture.
+
+        'Layers' is an architectural pattern in which a list of sibling modules/packages
+        have a dependency direction from high to low. In other words, a higher layer would
+        be allowed to import a lower layer, but not the other way around.
+
+        Arguments:
+
+        - layers:     The name of each layer module. If containers are also specified,
+                      then these names must be relative to the container. The order is from
+                      higher to lower level layers. Any layers that don't exist in the graph
+                      will be ignored.
+        - containers: The parent modules of the layers, as absolute names that you could import,
+                      such as "mypackage.foo". (Optional.)
+
+        Returns the illegal dependencies in the form of a set of PackageDependency objects.
+        Each package dependency is for a different permutation of two layers for which there
+        is a violation, and contains information about the illegal chains of imports from the
+        lower layer (the 'upstream') to the higher layer (the 'downstream').
+
+        Raises NoSuchContainer if the container is not a module in the graph.
         """
         raise NotImplementedError
 

--- a/src/grimp/application/ports/graph.py
+++ b/src/grimp/application/ports/graph.py
@@ -221,7 +221,7 @@ class ImportGraph(abc.ABC):
     @abc.abstractmethod
     def find_shortest_chain(
         self, importer: str, imported: str
-    ) -> Optional[Tuple[str, ...]]:
+    ) -> tuple[str, ...] | None:
         """
         Attempt to find the shortest chain of imports between two modules, in the direction
         of importer to imported.

--- a/src/grimp/application/ports/timing.py
+++ b/src/grimp/application/ports/timing.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import abc
+from types import TracebackType
+
+
+class Timer(abc.ABC):
+    """
+    Context manager to allow easy timing of events.
+
+    This is an abstraction that needs to be implemented using a subclass
+    that implements the get_current_time method.
+
+    Usage:
+
+        with Timer() as timer:
+            do_something()
+        print(timer.duration_in_s)
+    """
+
+    def __init__(self) -> None:
+        # We use a stack so context managers can be nested.
+        self._start_stack: list[float] = []
+
+    def __enter__(self) -> Timer:
+        self._start_stack.append(self.get_current_time())
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
+        end = self.get_current_time()
+        start = self._start_stack.pop()
+        self.duration_in_s = int(end - start)
+
+    @abc.abstractmethod
+    def get_current_time(self) -> float:
+        """
+        Return the time in seconds since the epoch as a floating point number.
+
+        See https://docs.python.org/3/library/time.html#time.time
+        """
+        raise NotImplementedError

--- a/src/grimp/domain/analysis.py
+++ b/src/grimp/domain/analysis.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Route:
+    """
+    A set of 'chains' that share the same middle.
+
+    A chain is a sequence of modules linked by imports, for example:
+    mypackage.foo -> mypackage.bar -> mypackage.baz.
+
+    The route fans in at the head and out at the tail, but the middle of the chain just links
+    individual modules.
+    """
+
+    heads: frozenset[str]  # Importer modules at the start of the chain.
+    middle: tuple[str, ...]
+    tails: frozenset[str]  # Imported modules at the end of the chain.
+
+
+@dataclass(frozen=True)
+class PackageDependency:
+    """
+    Dependencies from one package to another.
+    """
+
+    # The full name of the package from which all the routes start.
+    upstream: str
+    # The full name of the package from which all the routes end.
+    downstream: str
+    routes: frozenset[Route]

--- a/src/grimp/domain/analysis.py
+++ b/src/grimp/domain/analysis.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Iterable, Sequence
 
 
 @dataclass(frozen=True)
@@ -19,6 +20,47 @@ class Route:
     middle: tuple[str, ...]
     tails: frozenset[str]  # Imported modules at the end of the chain.
 
+    @classmethod
+    def new(
+        cls,
+        heads: Iterable[str],
+        tails: Iterable[str],
+        middle: Sequence[str] | None = None,
+    ) -> Route:
+        """
+        Optional constructor for a Route with more permissive input types.
+
+        Example:
+
+            Route.new(
+                heads={"foo"},
+                middle=["bar", "baz"],
+                tails={"foobar"},
+            )
+
+        """
+        return cls(
+            heads=frozenset(heads),
+            middle=tuple(middle) if middle else (),
+            tails=frozenset(tails),
+        )
+
+    @classmethod
+    def single_chained(cls, *modules: str) -> Route:
+        """
+        Optional constructor for a Route with a single chain.
+
+        Example:
+
+            Route.single_chained("foo", "bar", "baz")
+
+        """
+        return Route.new(
+            heads={modules[0]},
+            middle=tuple(modules[1:-1]),
+            tails={modules[-1]},
+        )
+
 
 @dataclass(frozen=True)
 class PackageDependency:
@@ -31,3 +73,24 @@ class PackageDependency:
     # The full name of the package from which all the routes end.
     downstream: str
     routes: frozenset[Route]
+
+    @classmethod
+    def new(
+        cls,
+        upstream: str,
+        downstream: str,
+        routes: Iterable[Route],
+    ) -> PackageDependency:
+        """
+        Optional constructor for a PackageDependency with more permissive input types.
+
+        Example:
+
+            PackageDependency.new(
+                upstream="foo",
+                downstream="bar",
+                routes={Route.single_chained("foo", "bar")},
+            )
+
+        """
+        return cls(upstream=upstream, downstream=downstream, routes=frozenset(routes))

--- a/src/grimp/exceptions.py
+++ b/src/grimp/exceptions.py
@@ -13,6 +13,12 @@ class ModuleNotPresent(GrimpException):
     """
 
 
+class NoSuchContainer(GrimpException):
+    """
+    Indicates that a passed container was not found as a module in the graph.
+    """
+
+
 class NamespacePackageEncountered(GrimpException):
     """
     Indicates that there was no __init__.py at the top level.

--- a/src/grimp/main.py
+++ b/src/grimp/main.py
@@ -6,6 +6,7 @@ from .adaptors.graph import ImportGraph
 from .adaptors.importscanner import ImportScanner
 from .adaptors.modulefinder import ModuleFinder
 from .adaptors.packagefinder import ImportLibPackageFinder
+from .adaptors.timing import SystemClockTimer
 from .application.config import settings
 from .application.usecases import build_graph
 
@@ -16,4 +17,5 @@ settings.configure(
     IMPORT_GRAPH_CLASS=ImportGraph,
     PACKAGE_FINDER=ImportLibPackageFinder(),
     CACHE_CLASS=Cache,
+    TIMER=SystemClockTimer(),
 )

--- a/tests/adaptors/timing.py
+++ b/tests/adaptors/timing.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from types import TracebackType
+
+from grimp.application.ports.timing import Timer
+
+
+class FakeTimer(Timer):
+    ARBITRARY_SECONDS_SINCE_EPOCH = 1_000_000
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._current_time = float(self.ARBITRARY_SECONDS_SINCE_EPOCH)
+        self._tick_duration = 1
+        self._increment = 0
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
+        self._tick()
+        super().__exit__(exc_type, exc_val, exc_tb)
+
+    def get_current_time(self) -> float:
+        return self._current_time
+
+    def setup(self, tick_duration: int, increment: int) -> None:
+        self._tick_duration = tick_duration
+        self._increment = increment
+
+    def _tick(self) -> None:
+        self._current_time += self._tick_duration
+        self._tick_duration += self._increment

--- a/tests/unit/adaptors/graph/test_chains.py
+++ b/tests/unit/adaptors/graph/test_chains.py
@@ -138,6 +138,35 @@ class TestFindShortestChain:
 
         assert (a, b, c, d, e) == graph.find_shortest_chain(importer=a, imported=e)
 
+    def test_demonstrate_nondeterminism_of_equal_chains(self):
+        """
+        This test demonstrates that, unfortunately, find_shortest_chain
+        does not have deterministic behaviour when two chains of equal
+        length exist in the graph.
+        """
+        graph = ImportGraph()
+        source, destination = "source", "destination"
+        a, b, c = "a", "b", "c"
+        d, e, f = "d", "e", "f"
+
+        # Add first chain.
+        graph.add_import(importer=source, imported=a)
+        graph.add_import(importer=a, imported=b)
+        graph.add_import(importer=b, imported=c)
+        graph.add_import(importer=c, imported=destination)
+
+        # Add a second chain of equal length.
+        graph.add_import(importer=source, imported=d)
+        graph.add_import(importer=d, imported=e)
+        graph.add_import(importer=e, imported=f)
+        graph.add_import(importer=f, imported=destination)
+
+        result = graph.find_shortest_chain(importer=source, imported=destination)
+
+        one_chain = (source, a, b, c, destination)
+        other_chain = (source, d, e, f, destination)
+        assert (result == one_chain) or (result == other_chain)
+
 
 class TestFindShortestChains:
     def test_top_level_import(self):

--- a/tests/unit/adaptors/graph/test_layers.py
+++ b/tests/unit/adaptors/graph/test_layers.py
@@ -12,14 +12,6 @@ from grimp.exceptions import NoSuchContainer
 from tests.adaptors.timing import FakeTimer
 
 
-def _single_chain_route(*modules: str) -> Route:
-    return Route(
-        heads=frozenset({modules[0]}),
-        middle=tuple(modules[1:-1]),
-        tails=frozenset({modules[-1]}),
-    )
-
-
 class TestSingleOrNoContainer:
     @pytest.mark.parametrize("specify_container", (True, False))
     def test_no_illegal_imports(self, specify_container: bool):
@@ -48,14 +40,10 @@ class TestSingleOrNoContainer:
 
         assert result == frozenset(
             {
-                PackageDependency(
+                PackageDependency.new(
                     upstream="mypackage.medium",
                     downstream="mypackage.high",
-                    routes=frozenset(
-                        {
-                            _single_chain_route(importer, imported),
-                        }
-                    ),
+                    routes={Route.single_chained(importer, imported)},
                 ),
             }
         )
@@ -99,18 +87,16 @@ class TestSingleOrNoContainer:
 
         assert result == frozenset(
             {
-                PackageDependency(
+                PackageDependency.new(
                     upstream="mypackage.medium",
                     downstream="mypackage.high",
-                    routes=frozenset(
-                        {
-                            Route(
-                                heads=frozenset({start}),
-                                middle=tuple(route_middle),
-                                tails=frozenset({end}),
-                            ),
-                        }
-                    ),
+                    routes={
+                        Route.new(
+                            heads={start},
+                            middle=route_middle,
+                            tails={end},
+                        ),
+                    },
                 )
             }
         )
@@ -128,27 +114,23 @@ class TestSingleOrNoContainer:
 
         assert result == frozenset(
             {
-                PackageDependency(
+                PackageDependency.new(
                     upstream="mypackage.low",
                     downstream="mypackage.medium",
-                    routes=frozenset(
-                        {
-                            _single_chain_route(
-                                "mypackage.low.white", "mypackage.medium.orange.beta"
-                            ),
-                        }
-                    ),
+                    routes={
+                        Route.single_chained(
+                            "mypackage.low.white", "mypackage.medium.orange.beta"
+                        ),
+                    },
                 ),
-                PackageDependency(
+                PackageDependency.new(
                     upstream="mypackage.medium",
                     downstream="mypackage.high",
-                    routes=frozenset(
-                        {
-                            _single_chain_route(
-                                "mypackage.medium.orange", "mypackage.high.green"
-                            ),
-                        }
-                    ),
+                    routes={
+                        Route.single_chained(
+                            "mypackage.medium.orange", "mypackage.high.green"
+                        ),
+                    },
                 ),
             }
         )
@@ -173,24 +155,22 @@ class TestSingleOrNoContainer:
 
         assert result == frozenset(
             {
-                PackageDependency(
+                PackageDependency.new(
                     upstream="mypackage.medium",
                     downstream="mypackage.high",
-                    routes=frozenset(
-                        {
-                            _single_chain_route(
-                                "mypackage.medium.orange",
-                                "mypackage.tungsten",
-                                "mypackage.copper",
-                                "mypackage.high.green",
-                            ),
-                            _single_chain_route(
-                                "mypackage.medium.orange",
-                                "mypackage.gold.delta",
-                                "mypackage.high.green",
-                            ),
-                        }
-                    ),
+                    routes={
+                        Route.single_chained(
+                            "mypackage.medium.orange",
+                            "mypackage.tungsten",
+                            "mypackage.copper",
+                            "mypackage.high.green",
+                        ),
+                        Route.single_chained(
+                            "mypackage.medium.orange",
+                            "mypackage.gold.delta",
+                            "mypackage.high.green",
+                        ),
+                    },
                 ),
             }
         )
@@ -215,24 +195,22 @@ class TestSingleOrNoContainer:
 
         assert result == frozenset(
             {
-                PackageDependency(
+                PackageDependency.new(
                     upstream="mypackage.medium",
                     downstream="mypackage.high",
-                    routes=frozenset(
-                        {
-                            _single_chain_route(
-                                "mypackage.medium.orange",
-                                "mypackage.tungsten",
-                                "mypackage.copper",
-                                "mypackage.high.green",
-                            ),
-                            _single_chain_route(
-                                "mypackage.medium.orange.beta",
-                                "mypackage.gold.delta",
-                                "mypackage.high.yellow",
-                            ),
-                        }
-                    ),
+                    routes={
+                        Route.single_chained(
+                            "mypackage.medium.orange",
+                            "mypackage.tungsten",
+                            "mypackage.copper",
+                            "mypackage.high.green",
+                        ),
+                        Route.single_chained(
+                            "mypackage.medium.orange.beta",
+                            "mypackage.gold.delta",
+                            "mypackage.high.yellow",
+                        ),
+                    },
                 ),
             }
         )
@@ -260,33 +238,27 @@ class TestSingleOrNoContainer:
 
         assert result == frozenset(
             {
-                PackageDependency(
+                PackageDependency.new(
                     upstream="mypackage.medium",
                     downstream="mypackage.high",
-                    routes=frozenset(
-                        {
-                            Route(
-                                heads=frozenset(
-                                    {
-                                        "mypackage.medium.orange",
-                                        "mypackage.medium.orange.beta",
-                                        "mypackage.medium.red",
-                                    }
-                                ),
-                                middle=(
-                                    "mypackage.tungsten",
-                                    "mypackage.copper",
-                                ),
-                                tails=frozenset(
-                                    {
-                                        "mypackage.high.green",
-                                        "mypackage.high",
-                                        "mypackage.high.yellow.alpha",
-                                    }
-                                ),
+                    routes={
+                        Route.new(
+                            heads={
+                                "mypackage.medium.orange",
+                                "mypackage.medium.orange.beta",
+                                "mypackage.medium.red",
+                            },
+                            middle=(
+                                "mypackage.tungsten",
+                                "mypackage.copper",
                             ),
-                        }
-                    ),
+                            tails={
+                                "mypackage.high.green",
+                                "mypackage.high",
+                                "mypackage.high.yellow.alpha",
+                            },
+                        ),
+                    },
                 ),
             }
         )
@@ -316,15 +288,13 @@ class TestSingleOrNoContainer:
 
         assert result == frozenset(
             {
-                PackageDependency(
+                PackageDependency.new(
                     upstream="low",
                     downstream="high",
-                    routes=frozenset(
-                        {
-                            _single_chain_route(source, a, b, destination),
-                            _single_chain_route(source, c, d, destination),
-                        }
-                    ),
+                    routes={
+                        Route.single_chained(source, a, b, destination),
+                        Route.single_chained(source, c, d, destination),
+                    },
                 ),
             }
         )
@@ -353,14 +323,12 @@ class TestSingleOrNoContainer:
 
         assert result == frozenset(
             {
-                PackageDependency(
+                PackageDependency.new(
                     upstream="low",
                     downstream="high",
-                    routes=frozenset(
-                        {
-                            _single_chain_route(source, a, b, destination),
-                        }
-                    ),
+                    routes={
+                        Route.single_chained(source, a, b, destination),
+                    },
                 ),
             }
         )
@@ -392,27 +360,23 @@ class TestSingleOrNoContainer:
 
         first_option = frozenset(
             {
-                PackageDependency(
+                PackageDependency.new(
                     upstream="low",
                     downstream="high",
-                    routes=frozenset(
-                        {
-                            _single_chain_route(source, a, b, destination),
-                        }
-                    ),
+                    routes={
+                        Route.single_chained(source, a, b, destination),
+                    },
                 ),
             }
         )
         second_option = frozenset(
             {
-                PackageDependency(
+                PackageDependency.new(
                     upstream="low",
                     downstream="high",
-                    routes=frozenset(
-                        {
-                            _single_chain_route(source, a, c, destination),
-                        }
-                    ),
+                    routes={
+                        Route.single_chained(source, a, c, destination),
+                    },
                 ),
             }
         )
@@ -484,14 +448,10 @@ class TestMultiplePackages:
 
         assert result == frozenset(
             {
-                PackageDependency(
+                PackageDependency.new(
                     upstream="medium",
                     downstream="high",
-                    routes=frozenset(
-                        {
-                            _single_chain_route(importer, imported),
-                        }
-                    ),
+                    routes={Route.single_chained(importer, imported)},
                 ),
             }
         )
@@ -534,18 +494,16 @@ class TestMultiplePackages:
 
         assert result == frozenset(
             {
-                PackageDependency(
+                PackageDependency.new(
                     upstream="medium",
                     downstream="high",
-                    routes=frozenset(
-                        {
-                            Route(
-                                heads=frozenset({start}),
-                                middle=tuple(route_middle),
-                                tails=frozenset({end}),
-                            ),
-                        }
-                    ),
+                    routes={
+                        Route.new(
+                            heads={start},
+                            middle=route_middle,
+                            tails={end},
+                        ),
+                    },
                 )
             }
         )
@@ -612,33 +570,29 @@ class TestMultipleContainers:
 
         assert result == frozenset(
             {
-                PackageDependency(
+                PackageDependency.new(
                     upstream="one.low",
                     downstream="one.high",
-                    routes=frozenset(
-                        {
-                            _single_chain_route("one.low.white", "one.high.green"),
-                            _single_chain_route("one.low.white", "one.high.brown"),
-                            Route(
-                                heads=frozenset({"one.low.white"}),
-                                middle=("two.medium.pink",),
-                                # N.B. two.medium.pink ->  one.high.blue is in the
-                                # legal imports added in _build_legal_graph.
-                                tails=frozenset({"one.high.green", "one.high.blue"}),
-                            ),
-                        }
-                    ),
+                    routes={
+                        Route.single_chained("one.low.white", "one.high.green"),
+                        Route.single_chained("one.low.white", "one.high.brown"),
+                        Route.new(
+                            heads={"one.low.white"},
+                            middle=("two.medium.pink",),
+                            # N.B. two.medium.pink ->  one.high.blue is in the
+                            # legal imports added in _build_legal_graph.
+                            tails={"one.high.green", "one.high.blue"},
+                        ),
+                    },
                 ),
-                PackageDependency(
+                PackageDependency.new(
                     upstream="two.medium",
                     downstream="two.high",
-                    routes=frozenset(
-                        {
-                            _single_chain_route(
-                                "two.medium.pink.delta", "two.high.yellow.gamma"
-                            ),
-                        }
-                    ),
+                    routes={
+                        Route.single_chained(
+                            "two.medium.pink.delta", "two.high.yellow.gamma"
+                        ),
+                    },
                 ),
             }
         )
@@ -794,16 +748,14 @@ class TestMissingLayers:
 
         assert result == frozenset(
             {
-                PackageDependency(
+                PackageDependency.new(
                     upstream="mypackage.medium",
                     downstream="mypackage.high",
-                    routes=frozenset(
-                        {
-                            _single_chain_route(
-                                "mypackage.medium.blue", "mypackage.high.green"
-                            )
-                        }
-                    ),
+                    routes={
+                        Route.single_chained(
+                            "mypackage.medium.blue", "mypackage.high.green"
+                        )
+                    },
                 )
             }
         )
@@ -826,12 +778,10 @@ class TestMissingLayers:
 
         assert result == frozenset(
             {
-                PackageDependency(
+                PackageDependency.new(
                     upstream="two.medium",
                     downstream="two.high",
-                    routes=frozenset(
-                        {_single_chain_route("two.medium.blue", "two.high.green")}
-                    ),
+                    routes={Route.single_chained("two.medium.blue", "two.high.green")},
                 )
             }
         )

--- a/tests/unit/adaptors/graph/test_layers.py
+++ b/tests/unit/adaptors/graph/test_layers.py
@@ -19,7 +19,7 @@ class TestSingleOrNoContainer:
 
         result = self._analyze(graph, specify_container=specify_container)
 
-        assert result == frozenset()
+        assert result == set()
 
     @pytest.mark.parametrize("specify_container", (True, False))
     @pytest.mark.parametrize(
@@ -38,15 +38,13 @@ class TestSingleOrNoContainer:
 
         result = self._analyze(graph, specify_container=specify_container)
 
-        assert result == frozenset(
-            {
-                PackageDependency.new(
-                    upstream="mypackage.medium",
-                    downstream="mypackage.high",
-                    routes={Route.single_chained(importer, imported)},
-                ),
-            }
-        )
+        assert result == {
+            PackageDependency.new(
+                upstream="mypackage.medium",
+                downstream="mypackage.high",
+                routes={Route.single_chained(importer, imported)},
+            ),
+        }
 
     @pytest.mark.parametrize("specify_container", (True, False))
     @pytest.mark.parametrize(
@@ -85,21 +83,19 @@ class TestSingleOrNoContainer:
 
         result = self._analyze(graph, specify_container=specify_container)
 
-        assert result == frozenset(
-            {
-                PackageDependency.new(
-                    upstream="mypackage.medium",
-                    downstream="mypackage.high",
-                    routes={
-                        Route.new(
-                            heads={start},
-                            middle=route_middle,
-                            tails={end},
-                        ),
-                    },
-                )
-            }
-        )
+        assert result == {
+            PackageDependency.new(
+                upstream="mypackage.medium",
+                downstream="mypackage.high",
+                routes={
+                    Route.new(
+                        heads={start},
+                        middle=route_middle,
+                        tails={end},
+                    ),
+                },
+            )
+        }
 
     def test_two_package_dependencies(self):
         graph = self._build_legal_graph()
@@ -112,28 +108,26 @@ class TestSingleOrNoContainer:
 
         result = self._analyze(graph)
 
-        assert result == frozenset(
-            {
-                PackageDependency.new(
-                    upstream="mypackage.low",
-                    downstream="mypackage.medium",
-                    routes={
-                        Route.single_chained(
-                            "mypackage.low.white", "mypackage.medium.orange.beta"
-                        ),
-                    },
-                ),
-                PackageDependency.new(
-                    upstream="mypackage.medium",
-                    downstream="mypackage.high",
-                    routes={
-                        Route.single_chained(
-                            "mypackage.medium.orange", "mypackage.high.green"
-                        ),
-                    },
-                ),
-            }
-        )
+        assert result == {
+            PackageDependency.new(
+                upstream="mypackage.low",
+                downstream="mypackage.medium",
+                routes={
+                    Route.single_chained(
+                        "mypackage.low.white", "mypackage.medium.orange.beta"
+                    ),
+                },
+            ),
+            PackageDependency.new(
+                upstream="mypackage.medium",
+                downstream="mypackage.high",
+                routes={
+                    Route.single_chained(
+                        "mypackage.medium.orange", "mypackage.high.green"
+                    ),
+                },
+            ),
+        }
 
     def test_multiple_illegal_routes_same_ends(self):
         graph = self._build_legal_graph()
@@ -153,27 +147,25 @@ class TestSingleOrNoContainer:
 
         result = self._analyze(graph)
 
-        assert result == frozenset(
-            {
-                PackageDependency.new(
-                    upstream="mypackage.medium",
-                    downstream="mypackage.high",
-                    routes={
-                        Route.single_chained(
-                            "mypackage.medium.orange",
-                            "mypackage.tungsten",
-                            "mypackage.copper",
-                            "mypackage.high.green",
-                        ),
-                        Route.single_chained(
-                            "mypackage.medium.orange",
-                            "mypackage.gold.delta",
-                            "mypackage.high.green",
-                        ),
-                    },
-                ),
-            }
-        )
+        assert result == {
+            PackageDependency.new(
+                upstream="mypackage.medium",
+                downstream="mypackage.high",
+                routes={
+                    Route.single_chained(
+                        "mypackage.medium.orange",
+                        "mypackage.tungsten",
+                        "mypackage.copper",
+                        "mypackage.high.green",
+                    ),
+                    Route.single_chained(
+                        "mypackage.medium.orange",
+                        "mypackage.gold.delta",
+                        "mypackage.high.green",
+                    ),
+                },
+            ),
+        }
 
     def test_multiple_illegal_routes_different_ends_in_same_layer(self):
         graph = self._build_legal_graph()
@@ -193,27 +185,25 @@ class TestSingleOrNoContainer:
 
         result = self._analyze(graph)
 
-        assert result == frozenset(
-            {
-                PackageDependency.new(
-                    upstream="mypackage.medium",
-                    downstream="mypackage.high",
-                    routes={
-                        Route.single_chained(
-                            "mypackage.medium.orange",
-                            "mypackage.tungsten",
-                            "mypackage.copper",
-                            "mypackage.high.green",
-                        ),
-                        Route.single_chained(
-                            "mypackage.medium.orange.beta",
-                            "mypackage.gold.delta",
-                            "mypackage.high.yellow",
-                        ),
-                    },
-                ),
-            }
-        )
+        assert result == {
+            PackageDependency.new(
+                upstream="mypackage.medium",
+                downstream="mypackage.high",
+                routes={
+                    Route.single_chained(
+                        "mypackage.medium.orange",
+                        "mypackage.tungsten",
+                        "mypackage.copper",
+                        "mypackage.high.green",
+                    ),
+                    Route.single_chained(
+                        "mypackage.medium.orange.beta",
+                        "mypackage.gold.delta",
+                        "mypackage.high.yellow",
+                    ),
+                },
+            ),
+        }
 
     def test_illegal_route_with_extra_ends(self):
         graph = self._build_legal_graph()
@@ -236,32 +226,30 @@ class TestSingleOrNoContainer:
 
         result = self._analyze(graph)
 
-        assert result == frozenset(
-            {
-                PackageDependency.new(
-                    upstream="mypackage.medium",
-                    downstream="mypackage.high",
-                    routes={
-                        Route.new(
-                            heads={
-                                "mypackage.medium.orange",
-                                "mypackage.medium.orange.beta",
-                                "mypackage.medium.red",
-                            },
-                            middle=(
-                                "mypackage.tungsten",
-                                "mypackage.copper",
-                            ),
-                            tails={
-                                "mypackage.high.green",
-                                "mypackage.high",
-                                "mypackage.high.yellow.alpha",
-                            },
+        assert result == {
+            PackageDependency.new(
+                upstream="mypackage.medium",
+                downstream="mypackage.high",
+                routes={
+                    Route.new(
+                        heads={
+                            "mypackage.medium.orange",
+                            "mypackage.medium.orange.beta",
+                            "mypackage.medium.red",
+                        },
+                        middle=(
+                            "mypackage.tungsten",
+                            "mypackage.copper",
                         ),
-                    },
-                ),
-            }
-        )
+                        tails={
+                            "mypackage.high.green",
+                            "mypackage.high",
+                            "mypackage.high.yellow.alpha",
+                        },
+                    ),
+                },
+            ),
+        }
 
     def test_finds_two_equal_routes(self):
         graph = ImportGraph()
@@ -286,18 +274,16 @@ class TestSingleOrNoContainer:
             layers=("high", "low"),
         )
 
-        assert result == frozenset(
-            {
-                PackageDependency.new(
-                    upstream="low",
-                    downstream="high",
-                    routes={
-                        Route.single_chained(source, a, b, destination),
-                        Route.single_chained(source, c, d, destination),
-                    },
-                ),
-            }
-        )
+        assert result == {
+            PackageDependency.new(
+                upstream="low",
+                downstream="high",
+                routes={
+                    Route.single_chained(source, a, b, destination),
+                    Route.single_chained(source, c, d, destination),
+                },
+            ),
+        }
 
     def test_longer_forked_routes_dont_appear(self):
         graph = ImportGraph()
@@ -321,17 +307,15 @@ class TestSingleOrNoContainer:
             layers=("high", "low"),
         )
 
-        assert result == frozenset(
-            {
-                PackageDependency.new(
-                    upstream="low",
-                    downstream="high",
-                    routes={
-                        Route.single_chained(source, a, b, destination),
-                    },
-                ),
-            }
-        )
+        assert result == {
+            PackageDependency.new(
+                upstream="low",
+                downstream="high",
+                routes={
+                    Route.single_chained(source, a, b, destination),
+                },
+            ),
+        }
 
     def test_demonstrate_nondeterminism_with_equal_length_forked_routes(self):
         """
@@ -358,28 +342,26 @@ class TestSingleOrNoContainer:
             layers=("high", "low"),
         )
 
-        first_option = frozenset(
-            {
-                PackageDependency.new(
-                    upstream="low",
-                    downstream="high",
-                    routes={
-                        Route.single_chained(source, a, b, destination),
-                    },
-                ),
-            }
-        )
-        second_option = frozenset(
-            {
-                PackageDependency.new(
-                    upstream="low",
-                    downstream="high",
-                    routes={
-                        Route.single_chained(source, a, c, destination),
-                    },
-                ),
-            }
-        )
+        first_option = {
+            PackageDependency.new(
+                upstream="low",
+                downstream="high",
+                routes={
+                    Route.single_chained(source, a, b, destination),
+                },
+            ),
+        }
+
+        second_option = {
+            PackageDependency.new(
+                upstream="low",
+                downstream="high",
+                routes={
+                    Route.single_chained(source, a, c, destination),
+                },
+            ),
+        }
+
         assert (result == first_option) or (result == second_option)
 
     def _build_legal_graph(self):
@@ -419,7 +401,7 @@ class TestSingleOrNoContainer:
 
     def _analyze(
         self, graph: ImportGraph, specify_container: bool = False
-    ) -> frozenset[PackageDependency]:
+    ) -> set[PackageDependency]:
         if specify_container:
             return graph.find_illegal_dependencies_for_layers(
                 layers=("high", "medium", "low"),
@@ -446,15 +428,13 @@ class TestMultiplePackages:
 
         result = self._analyze(graph)
 
-        assert result == frozenset(
-            {
-                PackageDependency.new(
-                    upstream="medium",
-                    downstream="high",
-                    routes={Route.single_chained(importer, imported)},
-                ),
-            }
-        )
+        assert result == {
+            PackageDependency.new(
+                upstream="medium",
+                downstream="high",
+                routes={Route.single_chained(importer, imported)},
+            ),
+        }
 
     @pytest.mark.parametrize(
         "start",
@@ -492,21 +472,19 @@ class TestMultiplePackages:
 
         result = self._analyze(graph)
 
-        assert result == frozenset(
-            {
-                PackageDependency.new(
-                    upstream="medium",
-                    downstream="high",
-                    routes={
-                        Route.new(
-                            heads={start},
-                            middle=route_middle,
-                            tails={end},
-                        ),
-                    },
-                )
-            }
-        )
+        assert result == {
+            PackageDependency.new(
+                upstream="medium",
+                downstream="high",
+                routes={
+                    Route.new(
+                        heads={start},
+                        middle=route_middle,
+                        tails={end},
+                    ),
+                },
+            )
+        }
 
     def _build_legal_graph(self):
         graph = ImportGraph()
@@ -536,7 +514,7 @@ class TestMultiplePackages:
 
         return graph
 
-    def _analyze(self, graph: ImportGraph) -> frozenset[PackageDependency]:
+    def _analyze(self, graph: ImportGraph) -> set[PackageDependency]:
         return graph.find_illegal_dependencies_for_layers(
             layers=("high", "medium", "low"),
         )
@@ -548,7 +526,7 @@ class TestMultipleContainers:
 
         result = self._analyze(graph)
 
-        assert result == frozenset()
+        assert result == set()
 
     def test_multiple_illegal_imports(self):
         graph = self._build_legal_graph()
@@ -568,34 +546,32 @@ class TestMultipleContainers:
 
         result = self._analyze(graph)
 
-        assert result == frozenset(
-            {
-                PackageDependency.new(
-                    upstream="one.low",
-                    downstream="one.high",
-                    routes={
-                        Route.single_chained("one.low.white", "one.high.green"),
-                        Route.single_chained("one.low.white", "one.high.brown"),
-                        Route.new(
-                            heads={"one.low.white"},
-                            middle=("two.medium.pink",),
-                            # N.B. two.medium.pink ->  one.high.blue is in the
-                            # legal imports added in _build_legal_graph.
-                            tails={"one.high.green", "one.high.blue"},
-                        ),
-                    },
-                ),
-                PackageDependency.new(
-                    upstream="two.medium",
-                    downstream="two.high",
-                    routes={
-                        Route.single_chained(
-                            "two.medium.pink.delta", "two.high.yellow.gamma"
-                        ),
-                    },
-                ),
-            }
-        )
+        assert result == {
+            PackageDependency.new(
+                upstream="one.low",
+                downstream="one.high",
+                routes={
+                    Route.single_chained("one.low.white", "one.high.green"),
+                    Route.single_chained("one.low.white", "one.high.brown"),
+                    Route.new(
+                        heads={"one.low.white"},
+                        middle=("two.medium.pink",),
+                        # N.B. two.medium.pink ->  one.high.blue is in the
+                        # legal imports added in _build_legal_graph.
+                        tails={"one.high.green", "one.high.blue"},
+                    ),
+                },
+            ),
+            PackageDependency.new(
+                upstream="two.medium",
+                downstream="two.high",
+                routes={
+                    Route.single_chained(
+                        "two.medium.pink.delta", "two.high.yellow.gamma"
+                    ),
+                },
+            ),
+        }
 
     def _build_legal_graph(self):
         graph = ImportGraph()
@@ -641,7 +617,7 @@ class TestMultipleContainers:
 
         return graph
 
-    def _analyze(self, graph: ImportGraph) -> frozenset[PackageDependency]:
+    def _analyze(self, graph: ImportGraph) -> set[PackageDependency]:
         return graph.find_illegal_dependencies_for_layers(
             layers=("high", "medium", "low"),
             containers={"one", "two"},
@@ -746,19 +722,17 @@ class TestMissingLayers:
                 layers=("mypackage.high", "mypackage.medium", "mypackage.low"),
             )
 
-        assert result == frozenset(
-            {
-                PackageDependency.new(
-                    upstream="mypackage.medium",
-                    downstream="mypackage.high",
-                    routes={
-                        Route.single_chained(
-                            "mypackage.medium.blue", "mypackage.high.green"
-                        )
-                    },
-                )
-            }
-        )
+        assert result == {
+            PackageDependency.new(
+                upstream="mypackage.medium",
+                downstream="mypackage.high",
+                routes={
+                    Route.single_chained(
+                        "mypackage.medium.blue", "mypackage.high.green"
+                    )
+                },
+            )
+        }
 
     def test_missing_layer_is_ignored_with_multiple_containers(self):
         graph = ImportGraph()
@@ -776,15 +750,13 @@ class TestMissingLayers:
             containers=containers,
         )
 
-        assert result == frozenset(
-            {
-                PackageDependency.new(
-                    upstream="two.medium",
-                    downstream="two.high",
-                    routes={Route.single_chained("two.medium.blue", "two.high.green")},
-                )
-            }
-        )
+        assert result == {
+            PackageDependency.new(
+                upstream="two.medium",
+                downstream="two.high",
+                routes={Route.single_chained("two.medium.blue", "two.high.green")},
+            )
+        }
 
 
 def _pairwise(iterable):

--- a/tests/unit/adaptors/graph/test_layers.py
+++ b/tests/unit/adaptors/graph/test_layers.py
@@ -1,0 +1,664 @@
+from __future__ import annotations
+
+import itertools
+
+import pytest  # type: ignore
+
+from grimp import PackageDependency, Route
+from grimp.adaptors.graph import ImportGraph
+from grimp.exceptions import NoSuchContainer
+
+
+def _single_chain_route(*modules: str) -> Route:
+    return Route(
+        heads=frozenset({modules[0]}),
+        middle=tuple(modules[1:-1]),
+        tails=frozenset({modules[-1]}),
+    )
+
+
+class TestSingleOrNoContainer:
+    @pytest.mark.parametrize("specify_container", (True, False))
+    def test_no_illegal_imports(self, specify_container: bool):
+        graph = self._build_legal_graph()
+
+        result = self._analyze(graph, specify_container=specify_container)
+
+        assert result == frozenset()
+
+    @pytest.mark.parametrize("specify_container", (True, False))
+    @pytest.mark.parametrize(
+        "importer",
+        ("mypackage.medium", "mypackage.medium.orange", "mypackage.medium.orange.beta"),
+    )
+    @pytest.mark.parametrize(
+        "imported",
+        ("mypackage.high", "mypackage.high.yellow", "mypackage.high.yellow.alpha"),
+    )
+    def test_direct_illegal_within_one_package(
+        self, specify_container: bool, importer: str, imported: str
+    ):
+        graph = self._build_legal_graph()
+        graph.add_import(importer=importer, imported=imported)
+
+        result = self._analyze(graph, specify_container=specify_container)
+
+        assert result == frozenset(
+            {
+                PackageDependency(
+                    upstream="mypackage.medium",
+                    downstream="mypackage.high",
+                    routes=frozenset(
+                        {
+                            _single_chain_route(importer, imported),
+                        }
+                    ),
+                ),
+            }
+        )
+
+    @pytest.mark.parametrize("specify_container", (True, False))
+    @pytest.mark.parametrize(
+        "start",
+        ("mypackage.medium", "mypackage.medium.orange", "mypackage.medium.orange.beta"),
+    )
+    @pytest.mark.parametrize(
+        "end",
+        ("mypackage.high", "mypackage.high.yellow", "mypackage.high.yellow.alpha"),
+    )
+    @pytest.mark.parametrize(
+        "route_middle",
+        [
+            ["mypackage.nickel"],
+            ["mypackage.bismuth", "mypackage.gold"],
+            [
+                "mypackage.iron",
+                "mypackage.gold.alpha",
+                "mypackage.plutonium.yellow.beta",
+            ],
+            [
+                "mypackage.boron.purple",
+                "mypackage.iron",
+                "mypackage.boron.green",
+                "mypackage.boron.green.gamma",
+            ],
+        ],
+    )
+    def test_indirect_illegal_within_one_package(
+        self, specify_container: bool, start: str, end: str, route_middle: list[str]
+    ):
+        graph = self._build_legal_graph()
+        import_pairs = _pairwise([start] + route_middle + [end])
+        for importer, imported in import_pairs:
+            graph.add_import(importer=importer, imported=imported)
+
+        result = self._analyze(graph, specify_container=specify_container)
+
+        assert result == frozenset(
+            {
+                PackageDependency(
+                    upstream="mypackage.medium",
+                    downstream="mypackage.high",
+                    routes=frozenset(
+                        {
+                            Route(
+                                heads=frozenset({start}),
+                                middle=tuple(route_middle),
+                                tails=frozenset({end}),
+                            ),
+                        }
+                    ),
+                )
+            }
+        )
+
+    def test_two_package_dependencies(self):
+        graph = self._build_legal_graph()
+        graph.add_import(
+            importer="mypackage.low.white", imported="mypackage.medium.orange.beta"
+        )
+        graph.add_import(
+            importer="mypackage.medium.orange", imported="mypackage.high.green"
+        )
+
+        result = self._analyze(graph)
+
+        assert result == frozenset(
+            {
+                PackageDependency(
+                    upstream="mypackage.low",
+                    downstream="mypackage.medium",
+                    routes=frozenset(
+                        {
+                            _single_chain_route(
+                                "mypackage.low.white", "mypackage.medium.orange.beta"
+                            ),
+                        }
+                    ),
+                ),
+                PackageDependency(
+                    upstream="mypackage.medium",
+                    downstream="mypackage.high",
+                    routes=frozenset(
+                        {
+                            _single_chain_route(
+                                "mypackage.medium.orange", "mypackage.high.green"
+                            ),
+                        }
+                    ),
+                ),
+            }
+        )
+
+    def test_multiple_illegal_routes_same_ends(self):
+        graph = self._build_legal_graph()
+        # Route 1.
+        graph.add_import(
+            importer="mypackage.medium.orange", imported="mypackage.tungsten"
+        )
+        graph.add_import(importer="mypackage.tungsten", imported="mypackage.copper")
+        graph.add_import(importer="mypackage.copper", imported="mypackage.high.green")
+        # Route 2.
+        graph.add_import(
+            importer="mypackage.medium.orange", imported="mypackage.gold.delta"
+        )
+        graph.add_import(
+            importer="mypackage.gold.delta", imported="mypackage.high.green"
+        )
+
+        result = self._analyze(graph)
+
+        assert result == frozenset(
+            {
+                PackageDependency(
+                    upstream="mypackage.medium",
+                    downstream="mypackage.high",
+                    routes=frozenset(
+                        {
+                            _single_chain_route(
+                                "mypackage.medium.orange",
+                                "mypackage.tungsten",
+                                "mypackage.copper",
+                                "mypackage.high.green",
+                            ),
+                            _single_chain_route(
+                                "mypackage.medium.orange",
+                                "mypackage.gold.delta",
+                                "mypackage.high.green",
+                            ),
+                        }
+                    ),
+                ),
+            }
+        )
+
+    def test_multiple_illegal_routes_different_ends_in_same_layer(self):
+        graph = self._build_legal_graph()
+        # Route 1.
+        graph.add_import(
+            importer="mypackage.medium.orange", imported="mypackage.tungsten"
+        )
+        graph.add_import(importer="mypackage.tungsten", imported="mypackage.copper")
+        graph.add_import(importer="mypackage.copper", imported="mypackage.high.green")
+        # Route 2.
+        graph.add_import(
+            importer="mypackage.medium.orange.beta", imported="mypackage.gold.delta"
+        )
+        graph.add_import(
+            importer="mypackage.gold.delta", imported="mypackage.high.yellow"
+        )
+
+        result = self._analyze(graph)
+
+        assert result == frozenset(
+            {
+                PackageDependency(
+                    upstream="mypackage.medium",
+                    downstream="mypackage.high",
+                    routes=frozenset(
+                        {
+                            _single_chain_route(
+                                "mypackage.medium.orange",
+                                "mypackage.tungsten",
+                                "mypackage.copper",
+                                "mypackage.high.green",
+                            ),
+                            _single_chain_route(
+                                "mypackage.medium.orange.beta",
+                                "mypackage.gold.delta",
+                                "mypackage.high.yellow",
+                            ),
+                        }
+                    ),
+                ),
+            }
+        )
+
+    def test_illegal_route_with_extra_ends(self):
+        graph = self._build_legal_graph()
+        # Route 1.
+        graph.add_import(
+            importer="mypackage.medium.orange", imported="mypackage.tungsten"
+        )
+        graph.add_import(importer="mypackage.tungsten", imported="mypackage.copper")
+        graph.add_import(importer="mypackage.copper", imported="mypackage.high.green")
+        # Extra firsts.
+        graph.add_import(
+            importer="mypackage.medium.orange.beta", imported="mypackage.tungsten"
+        )
+        graph.add_import(importer="mypackage.medium.red", imported="mypackage.tungsten")
+        # Extra lasts.
+        graph.add_import(importer="mypackage.copper", imported="mypackage.high")
+        graph.add_import(
+            importer="mypackage.copper", imported="mypackage.high.yellow.alpha"
+        )
+
+        result = self._analyze(graph)
+
+        assert result == frozenset(
+            {
+                PackageDependency(
+                    upstream="mypackage.medium",
+                    downstream="mypackage.high",
+                    routes=frozenset(
+                        {
+                            Route(
+                                heads=frozenset(
+                                    {
+                                        "mypackage.medium.orange",
+                                        "mypackage.medium.orange.beta",
+                                        "mypackage.medium.red",
+                                    }
+                                ),
+                                middle=(
+                                    "mypackage.tungsten",
+                                    "mypackage.copper",
+                                ),
+                                tails=frozenset(
+                                    {
+                                        "mypackage.high.green",
+                                        "mypackage.high",
+                                        "mypackage.high.yellow.alpha",
+                                    }
+                                ),
+                            ),
+                        }
+                    ),
+                ),
+            }
+        )
+
+    def _build_legal_graph(self):
+        graph = ImportGraph()
+        for module in (
+            "mypackage",
+            "mypackage.high",
+            "mypackage.high.green",
+            "mypackage.high.blue",
+            "mypackage.high.yellow",
+            "mypackage.high.yellow.alpha",
+            "mypackage.medium",
+            "mypackage.medium.orange",
+            "mypackage.medium.orange.beta",
+            "mypackage.medium.red",
+            "mypackage.low",
+            "mypackage.low.black",
+            "mypackage.low.white",
+            "mypackage.low.white.gamma",
+        ):
+            graph.add_module(module)
+
+        # Add some 'legal' imports.
+        graph.add_import(
+            importer="mypackage.high.green", imported="mypackage.medium.orange"
+        )
+        graph.add_import(
+            importer="mypackage.high.green", imported="mypackage.low.white.gamma"
+        )
+        graph.add_import(
+            importer="mypackage.medium.orange", imported="mypackage.low.white"
+        )
+        graph.add_import(importer="mypackage.high.blue", imported="mypackage.utils")
+        graph.add_import(importer="mypackage.utils", imported="mypackage.medium.red")
+
+        return graph
+
+    def _analyze(
+        self, graph: ImportGraph, specify_container: bool = False
+    ) -> frozenset[PackageDependency]:
+        if specify_container:
+            return graph.find_illegal_dependencies_for_layers(
+                layers=("high", "medium", "low"),
+                containers={"mypackage"},
+            )
+        else:
+            return graph.find_illegal_dependencies_for_layers(
+                layers=("mypackage.high", "mypackage.medium", "mypackage.low"),
+            )
+
+
+class TestMultiplePackages:
+    @pytest.mark.parametrize(
+        "importer",
+        ("medium", "medium.orange", "medium.orange.beta"),
+    )
+    @pytest.mark.parametrize(
+        "imported",
+        ("high", "high.yellow", "high.yellow.alpha"),
+    )
+    def test_direct_illegal_across_two_packages(self, importer: str, imported: str):
+        graph = self._build_legal_graph()
+        graph.add_import(importer=importer, imported=imported)
+
+        result = self._analyze(graph)
+
+        assert result == frozenset(
+            {
+                PackageDependency(
+                    upstream="medium",
+                    downstream="high",
+                    routes=frozenset(
+                        {
+                            _single_chain_route(importer, imported),
+                        }
+                    ),
+                ),
+            }
+        )
+
+    @pytest.mark.parametrize(
+        "start",
+        ("medium", "medium.orange", "medium.orange.beta"),
+    )
+    @pytest.mark.parametrize(
+        "end",
+        ("high", "high.yellow", "high.yellow.alpha"),
+    )
+    @pytest.mark.parametrize(
+        "route_middle",
+        [
+            ["nickel"],
+            ["bismuth", "gold"],
+            [
+                "iron",
+                "gold.alpha",
+                "plutonium.yellow.beta",
+            ],
+            [
+                "boron.purple",
+                "iron",
+                "boron.green",
+                "boron.green.gamma",
+            ],
+        ],
+    )
+    def test_indirect_illegal_across_two_packages(
+        self, start: str, end: str, route_middle: list[str]
+    ):
+        graph = self._build_legal_graph()
+        import_pairs = _pairwise([start] + route_middle + [end])
+        for importer, imported in import_pairs:
+            graph.add_import(importer=importer, imported=imported)
+
+        result = self._analyze(graph)
+
+        assert result == frozenset(
+            {
+                PackageDependency(
+                    upstream="medium",
+                    downstream="high",
+                    routes=frozenset(
+                        {
+                            Route(
+                                heads=frozenset({start}),
+                                middle=tuple(route_middle),
+                                tails=frozenset({end}),
+                            ),
+                        }
+                    ),
+                )
+            }
+        )
+
+    def _build_legal_graph(self):
+        graph = ImportGraph()
+        for module in (
+            "high",
+            "high.green",
+            "high.blue",
+            "high.yellow",
+            "high.yellow.alpha",
+            "medium",
+            "medium.orange",
+            "medium.orange.beta",
+            "medium.red",
+            "low",
+            "low.black",
+            "low.white",
+            "low.white.gamma",
+        ):
+            graph.add_module(module)
+
+        # Add some 'legal' imports.
+        graph.add_import(importer="high.green", imported="medium.orange")
+        graph.add_import(importer="high.green", imported="low.white.gamma")
+        graph.add_import(importer="medium.orange", imported="low.white")
+        graph.add_import(importer="high.blue", imported="utils")
+        graph.add_import(importer="utils", imported="medium.red")
+
+        return graph
+
+    def _analyze(self, graph: ImportGraph) -> frozenset[PackageDependency]:
+        return graph.find_illegal_dependencies_for_layers(
+            layers=("high", "medium", "low"),
+        )
+
+
+class TestMultipleContainers:
+    def test_no_illegal_imports(self):
+        graph = self._build_legal_graph()
+
+        result = self._analyze(graph)
+
+        assert result == frozenset()
+
+    def test_multiple_illegal_imports(self):
+        graph = self._build_legal_graph()
+        graph.add_import(importer="one.low.white", imported="one.high.green")
+        graph.add_import(
+            importer="one.low.white",
+            imported="two.medium.pink",
+        )
+        graph.add_import(
+            importer="two.medium.pink",
+            imported="one.high.green",
+        )
+        graph.add_import(importer="one.low.white", imported="one.high.brown")
+        graph.add_import(
+            importer="two.medium.pink.delta", imported="two.high.yellow.gamma"
+        )
+
+        result = self._analyze(graph)
+
+        assert result == frozenset(
+            {
+                PackageDependency(
+                    upstream="one.low",
+                    downstream="one.high",
+                    routes=frozenset(
+                        {
+                            _single_chain_route("one.low.white", "one.high.green"),
+                            _single_chain_route("one.low.white", "one.high.brown"),
+                            Route(
+                                heads=frozenset({"one.low.white"}),
+                                middle=("two.medium.pink",),
+                                # N.B. two.medium.pink ->  one.high.blue is in the
+                                # legal imports added in _build_legal_graph.
+                                tails=frozenset({"one.high.green", "one.high.blue"}),
+                            ),
+                        }
+                    ),
+                ),
+                PackageDependency(
+                    upstream="two.medium",
+                    downstream="two.high",
+                    routes=frozenset(
+                        {
+                            _single_chain_route(
+                                "two.medium.pink.delta", "two.high.yellow.gamma"
+                            ),
+                        }
+                    ),
+                ),
+            }
+        )
+
+    def _build_legal_graph(self):
+        graph = ImportGraph()
+        for module in (
+            "one",
+            "one.high",
+            "one.high.green",
+            "one.high.blue",
+            "one.high.yellow",
+            "one.high.yellow.alpha",
+            "one.medium",
+            "one.medium.orange",
+            "one.medium.orange.beta",
+            "one.medium.red",
+            "one.low",
+            "one.low.black",
+            "one.low.white",
+            "one.low.white.gamma",
+            "two",
+            "two.high",
+            "two.high.brown",
+            "two.high.yellow",
+            "two.high.yellow.gamma",
+            "two.medium",
+            "two.medium.pink",
+            "two.medium.pink.delta",
+            "two.medium.purple",
+            "two.low",
+            "two.low.black",
+            "two.low.black.epsilon",
+        ):
+            graph.add_module(module)
+
+        # Add some 'legal' imports.
+        graph.add_import(importer="one.high.yellow", imported="one.low.white.gamma")
+        graph.add_import(importer="one.high.brown", imported="one.utils")
+        graph.add_import(importer="one.utils", imported="one.medium.pink")
+        graph.add_import(importer="two.medium", imported="two.low")
+        graph.add_import(importer="two.medium.purple", imported="two.low")
+        graph.add_import(importer="two.medium", imported="two.low.black.epsilon")
+        # Imports between low layers to high layers across containers aren't illegal.
+        graph.add_import(importer="two.medium.pink", imported="one.high.blue")
+
+        return graph
+
+    def _analyze(self, graph: ImportGraph) -> frozenset[PackageDependency]:
+        return graph.find_illegal_dependencies_for_layers(
+            layers=("high", "medium", "low"),
+            containers={"one", "two"},
+        )
+
+
+class TestInvalidContainers:
+    @pytest.mark.parametrize("missing_container", ("one", "two"))
+    def test_single_missing_container(self, missing_container: str):
+        graph = ImportGraph()
+        containers = {"one", "two"}
+
+        for container in containers - {missing_container}:
+            graph.add_module(container)
+
+        with pytest.raises(
+            NoSuchContainer, match=f"Container {missing_container} does not exist."
+        ):
+            graph.find_illegal_dependencies_for_layers(
+                layers=("high", "medium", "low"),
+                containers=containers,
+            )
+
+
+class TestMissingLayers:
+    @pytest.mark.parametrize("specify_container", (True, False))
+    def test_missing_layer_is_ignored_with_single_or_no_container(
+        self, specify_container: bool
+    ):
+        graph = ImportGraph()
+
+        # Add an import, but the rest of the layers don't exist.
+        graph.add_module("mypackage")
+        graph.add_module("mypackage.medium")
+        graph.add_module("mypackage.high")
+        graph.add_import(
+            importer="mypackage.medium.blue", imported="mypackage.high.green"
+        )
+
+        if specify_container:
+            result = graph.find_illegal_dependencies_for_layers(
+                layers=("high", "medium", "low"),
+                containers={"mypackage"},
+            )
+        else:
+            result = graph.find_illegal_dependencies_for_layers(
+                layers=("mypackage.high", "mypackage.medium", "mypackage.low"),
+            )
+
+        assert result == frozenset(
+            {
+                PackageDependency(
+                    upstream="mypackage.medium",
+                    downstream="mypackage.high",
+                    routes=frozenset(
+                        {
+                            _single_chain_route(
+                                "mypackage.medium.blue", "mypackage.high.green"
+                            )
+                        }
+                    ),
+                )
+            }
+        )
+
+    def test_missing_layer_is_ignored_with_multiple_containers(self):
+        graph = ImportGraph()
+        containers = {"one", "two"}
+        for container in containers:
+            graph.add_module(container)
+
+        # Add an import, but the rest of the layers don't exist.
+        graph.add_module("two.medium")
+        graph.add_module("two.high")
+        graph.add_import(importer="two.medium.blue", imported="two.high.green")
+
+        result = graph.find_illegal_dependencies_for_layers(
+            layers=("high", "medium", "low"),
+            containers=containers,
+        )
+
+        assert result == frozenset(
+            {
+                PackageDependency(
+                    upstream="two.medium",
+                    downstream="two.high",
+                    routes=frozenset(
+                        {_single_chain_route("two.medium.blue", "two.high.green")}
+                    ),
+                )
+            }
+        )
+
+
+def _pairwise(iterable):
+    """
+    Return successive overlapping pairs taken from the input iterable.
+    pairwise('ABCDEFG') --> AB BC CD DE EF FG
+
+    TODO: Replace with itertools.pairwise once on Python 3.10.
+    """
+    a, b = itertools.tee(iterable)
+    next(b, None)
+    return zip(a, b)


### PR DESCRIPTION
Adds a `find_illegal_dependencies_for_layers` method to the graph.

This will be able to be used by Import Linter to do its layer checking. 
