### PR TITLE
Rename AbstractImportGraph to ImportGraph

### DIFF
--- a/src/grimp/__init__.py
+++ b/src/grimp/__init__.py
@@ -1,7 +1,7 @@
 __version__ = "2.4"
 
-from .domain.valueobjects import Module, DirectImport
-from .application.ports.graph import DetailedImport
+from .application.ports.graph import DetailedImport, ImportGraph
+from .domain.valueobjects import DirectImport, Module
 from .main import build_graph
 
-__all__ = ["Module", "DetailedImport", "DirectImport", "build_graph"]
+__all__ = ["Module", "DetailedImport", "DirectImport", "ImportGraph", "build_graph"]

--- a/src/grimp/adaptors/graph.py
+++ b/src/grimp/adaptors/graph.py
@@ -7,7 +7,7 @@ from grimp.domain.valueobjects import Module
 from grimp.exceptions import ModuleNotPresent
 
 
-class ImportGraph(graph.AbstractImportGraph):
+class ImportGraph(graph.ImportGraph):
     """
     Pure Python implementation of the ImportGraph.
     """

--- a/src/grimp/application/ports/graph.py
+++ b/src/grimp/application/ports/graph.py
@@ -11,7 +11,7 @@ class DetailedImport(TypedDict):
     line_contents: str
 
 
-class AbstractImportGraph(abc.ABC):
+class ImportGraph(abc.ABC):
     """
     A Directed Graph of imports between Python modules.
     """

--- a/src/grimp/application/usecases.py
+++ b/src/grimp/application/usecases.py
@@ -5,7 +5,7 @@ from typing import Dict, Sequence, Set, Type, Union, cast
 
 from ..application.ports import caching
 from ..application.ports.filesystem import AbstractFileSystem
-from ..application.ports.graph import AbstractImportGraph
+from ..application.ports.graph import ImportGraph
 from ..application.ports.importscanner import AbstractImportScanner
 from ..application.ports.modulefinder import AbstractModuleFinder, FoundPackage
 from ..application.ports.packagefinder import AbstractPackageFinder
@@ -22,7 +22,7 @@ def build_graph(
     *additional_package_names,
     include_external_packages: bool = False,
     cache_dir: Union[str, Type[NotSupplied], None] = NotSupplied,
-) -> AbstractImportGraph:
+) -> ImportGraph:
     """
     Build and return an import graph for the supplied package name(s).
 
@@ -140,8 +140,8 @@ def _scan_packages(
 def _assemble_graph(
     found_packages: Set[FoundPackage],
     imports_by_module: Dict[Module, Set[DirectImport]],
-) -> AbstractImportGraph:
-    graph: AbstractImportGraph = settings.IMPORT_GRAPH_CLASS()
+) -> ImportGraph:
+    graph: ImportGraph = settings.IMPORT_GRAPH_CLASS()
     for module, direct_imports in imports_by_module.items():
         graph.add_module(module.name)
         for direct_import in direct_imports:


### PR DESCRIPTION
Renames `AbstractImportGraph` to `ImportGraph` and adds it to grimp's root namespace so it's available as `grimp.ImportGraph`, for type checkers.