### PR TITLE
Correct error with downstream/upstream

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog
 =========
 
+latest
+------
+
+* Correct error in find_illegal_dependencies_for_layers where upstream/downstream were reversed.
+
 2.5 (2023-7-6)
 --------------
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -284,8 +284,8 @@ Higher level analysis
         import, such as ``mypackage.foo``. (Optional.)
     :return: The illegal dependencies in the form of a set of :class:`.PackageDependency` objects. Each package
              dependency is for a different permutation of two layers for which there is a violation, and contains
-             information about the illegal chains of imports from the lower layer (the 'upstream') to the higher layer
-             (the 'downstream').
+             information about the illegal chains of imports from the lower layer (the 'downstream') to the higher layer
+             (the 'upstream').
     :rtype: ``set[PackageDependency]``.
     :raises grimp.exceptions.NoSuchContainer: if a container is not a module in the graph.
 
@@ -293,17 +293,19 @@ Higher level analysis
 
       A collection of import dependencies from one Python package to another.
 
-      .. attribute:: upstream
-
-        ``str``: The full name of the package within which all the routes start, e.g. "mypackage.foo".
-
       .. attribute:: downstream
 
-        ``str``: The full name of the package within which all the routes end, e.g. "mypackage.bar".
+        ``str``: The full name of the package within which all the routes start; the importer package.
+           E.g. "mypackage.foo".
+
+      .. attribute:: upstream
+
+        ``str``: The full name of the package within which all the routes end; the imported package.
+            E.g. "mypackage.bar".
 
       .. attribute:: routes
 
-        ``frozenset[grimp.Route]``: A set of :class:`.Route` objects from upstream to downstream.
+        ``frozenset[grimp.Route]``: A set of :class:`.Route` objects from downstream to upstream.
 
     .. class:: Route
 

--- a/src/grimp/adaptors/_layers.py
+++ b/src/grimp/adaptors/_layers.py
@@ -191,8 +191,8 @@ def _search_for_package_dependency(
 
     if routes:
         return PackageDependency(
-            upstream=lower_layer_package.name,
-            downstream=higher_layer_package.name,
+            downstream=lower_layer_package.name,
+            upstream=higher_layer_package.name,
             routes=frozenset(routes),
         )
     else:

--- a/src/grimp/domain/analysis.py
+++ b/src/grimp/domain/analysis.py
@@ -9,7 +9,8 @@ class Route:
     """
     A set of 'chains' that share the same middle.
 
-    A chain is a sequence of modules linked by imports, for example:
+    A chain is a sequence of modules linked by imports, from importer to imported,
+    for example:
     mypackage.foo -> mypackage.bar -> mypackage.baz.
 
     The route fans in at the head and out at the tail, but the middle of the chain just links
@@ -68,17 +69,21 @@ class PackageDependency:
     Dependencies from one package to another.
     """
 
-    # The full name of the package from which all the routes start.
-    upstream: str
-    # The full name of the package from which all the routes end.
+    # The full name of the package from which all the routes start;
+    # the importer package.
+    # It's called 'downstream' because it depends on the upstream.
     downstream: str
+    # The full name of the package from which all the routes end;
+    # the imported package.
+    upstream: str
+
     routes: frozenset[Route]
 
     @classmethod
     def new(
         cls,
-        upstream: str,
         downstream: str,
+        upstream: str,
         routes: Iterable[Route],
     ) -> PackageDependency:
         """
@@ -87,10 +92,10 @@ class PackageDependency:
         Example:
 
             PackageDependency.new(
-                upstream="foo",
-                downstream="bar",
+                downstream="foo",
+                upstream="bar",
                 routes={Route.single_chained("foo", "bar")},
             )
 
         """
-        return cls(upstream=upstream, downstream=downstream, routes=frozenset(routes))
+        return cls(downstream=downstream, upstream=upstream, routes=frozenset(routes))

--- a/tests/unit/adaptors/graph/test_layers.py
+++ b/tests/unit/adaptors/graph/test_layers.py
@@ -37,11 +37,10 @@ class TestSingleOrNoContainer:
         graph.add_import(importer=importer, imported=imported)
 
         result = self._analyze(graph, specify_container=specify_container)
-
         assert result == {
             PackageDependency.new(
-                upstream="mypackage.medium",
-                downstream="mypackage.high",
+                downstream="mypackage.medium",
+                upstream="mypackage.high",
                 routes={Route.single_chained(importer, imported)},
             ),
         }
@@ -85,8 +84,8 @@ class TestSingleOrNoContainer:
 
         assert result == {
             PackageDependency.new(
-                upstream="mypackage.medium",
-                downstream="mypackage.high",
+                downstream="mypackage.medium",
+                upstream="mypackage.high",
                 routes={
                     Route.new(
                         heads={start},
@@ -110,8 +109,8 @@ class TestSingleOrNoContainer:
 
         assert result == {
             PackageDependency.new(
-                upstream="mypackage.low",
-                downstream="mypackage.medium",
+                downstream="mypackage.low",
+                upstream="mypackage.medium",
                 routes={
                     Route.single_chained(
                         "mypackage.low.white", "mypackage.medium.orange.beta"
@@ -119,8 +118,8 @@ class TestSingleOrNoContainer:
                 },
             ),
             PackageDependency.new(
-                upstream="mypackage.medium",
-                downstream="mypackage.high",
+                downstream="mypackage.medium",
+                upstream="mypackage.high",
                 routes={
                     Route.single_chained(
                         "mypackage.medium.orange", "mypackage.high.green"
@@ -149,8 +148,8 @@ class TestSingleOrNoContainer:
 
         assert result == {
             PackageDependency.new(
-                upstream="mypackage.medium",
-                downstream="mypackage.high",
+                downstream="mypackage.medium",
+                upstream="mypackage.high",
                 routes={
                     Route.single_chained(
                         "mypackage.medium.orange",
@@ -187,8 +186,8 @@ class TestSingleOrNoContainer:
 
         assert result == {
             PackageDependency.new(
-                upstream="mypackage.medium",
-                downstream="mypackage.high",
+                downstream="mypackage.medium",
+                upstream="mypackage.high",
                 routes={
                     Route.single_chained(
                         "mypackage.medium.orange",
@@ -228,8 +227,8 @@ class TestSingleOrNoContainer:
 
         assert result == {
             PackageDependency.new(
-                upstream="mypackage.medium",
-                downstream="mypackage.high",
+                downstream="mypackage.medium",
+                upstream="mypackage.high",
                 routes={
                     Route.new(
                         heads={
@@ -276,8 +275,8 @@ class TestSingleOrNoContainer:
 
         assert result == {
             PackageDependency.new(
-                upstream="low",
-                downstream="high",
+                downstream="low",
+                upstream="high",
                 routes={
                     Route.single_chained(source, a, b, destination),
                     Route.single_chained(source, c, d, destination),
@@ -309,8 +308,8 @@ class TestSingleOrNoContainer:
 
         assert result == {
             PackageDependency.new(
-                upstream="low",
-                downstream="high",
+                downstream="low",
+                upstream="high",
                 routes={
                     Route.single_chained(source, a, b, destination),
                 },
@@ -344,8 +343,8 @@ class TestSingleOrNoContainer:
 
         first_option = {
             PackageDependency.new(
-                upstream="low",
-                downstream="high",
+                downstream="low",
+                upstream="high",
                 routes={
                     Route.single_chained(source, a, b, destination),
                 },
@@ -354,8 +353,8 @@ class TestSingleOrNoContainer:
 
         second_option = {
             PackageDependency.new(
-                upstream="low",
-                downstream="high",
+                downstream="low",
+                upstream="high",
                 routes={
                     Route.single_chained(source, a, c, destination),
                 },
@@ -430,8 +429,8 @@ class TestMultiplePackages:
 
         assert result == {
             PackageDependency.new(
-                upstream="medium",
-                downstream="high",
+                downstream="medium",
+                upstream="high",
                 routes={Route.single_chained(importer, imported)},
             ),
         }
@@ -474,8 +473,8 @@ class TestMultiplePackages:
 
         assert result == {
             PackageDependency.new(
-                upstream="medium",
-                downstream="high",
+                downstream="medium",
+                upstream="high",
                 routes={
                     Route.new(
                         heads={start},
@@ -548,8 +547,8 @@ class TestMultipleContainers:
 
         assert result == {
             PackageDependency.new(
-                upstream="one.low",
-                downstream="one.high",
+                downstream="one.low",
+                upstream="one.high",
                 routes={
                     Route.single_chained("one.low.white", "one.high.green"),
                     Route.single_chained("one.low.white", "one.high.brown"),
@@ -563,8 +562,8 @@ class TestMultipleContainers:
                 },
             ),
             PackageDependency.new(
-                upstream="two.medium",
-                downstream="two.high",
+                downstream="two.medium",
+                upstream="two.high",
                 routes={
                     Route.single_chained(
                         "two.medium.pink.delta", "two.high.yellow.gamma"
@@ -724,8 +723,8 @@ class TestMissingLayers:
 
         assert result == {
             PackageDependency.new(
-                upstream="mypackage.medium",
-                downstream="mypackage.high",
+                downstream="mypackage.medium",
+                upstream="mypackage.high",
                 routes={
                     Route.single_chained(
                         "mypackage.medium.blue", "mypackage.high.green"
@@ -752,8 +751,8 @@ class TestMissingLayers:
 
         assert result == {
             PackageDependency.new(
-                upstream="two.medium",
-                downstream="two.high",
+                downstream="two.medium",
+                upstream="two.high",
                 routes={Route.single_chained("two.medium.blue", "two.high.green")},
             )
         }


### PR DESCRIPTION
This PR corrects a mistake in which `find_illegal_dependencies_for_layers`, and the `PackageDependency` object, reversed the meaning of downstream/upstream in a way that was inconsistent with the rest of Grimp.

It's likely that no-one is using this method yet so I'm planning to be pragmatic and just fix it in a new release. 