### PR TITLE
Add conditional imports to import graph class

### DIFF
--- a/tests/unit/adaptors/graph/test_direct_imports.py
+++ b/tests/unit/adaptors/graph/test_direct_imports.py
@@ -202,6 +202,20 @@ class TestCountImports:
 
         assert graph.count_imports() == 3
 
+    @pytest.mark.parametrize("should_import, total_count", [(True, 1), (False, 0)])
+    def test_count_conditional_imports(self, should_import, total_count):
+        """
+        if should_import:
+            import foo.two
+        """
+        graph = ImportGraph()
+
+        graph.add_conditional_import(
+            importer="foo.one", imported="foo.two", should_import=should_import
+        )
+
+        assert graph.count_imports() == total_count
+
 
 class TestGetImportDetails:
     def test_happy_path(self):


### PR DESCRIPTION
    This PR is a notional POC attempting to capture the following scenario.
    if TYPE_CHECKING:
        from package import module

    This is motivated by wanting to lint for certain forbidden imports but allow the contracts to be kept if the if condition evaluates to false.