### PR TITLE
Revert "Correct error with downstream/upstream"

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,11 +2,6 @@
 Changelog
 =========
 
-latest
-------
-
-* Correct error in find_illegal_dependencies_for_layers where upstream/downstream were reversed.
-
 2.5 (2023-7-6)
 --------------
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -284,8 +284,8 @@ Higher level analysis
         import, such as ``mypackage.foo``. (Optional.)
     :return: The illegal dependencies in the form of a set of :class:`.PackageDependency` objects. Each package
              dependency is for a different permutation of two layers for which there is a violation, and contains
-             information about the illegal chains of imports from the lower layer (the 'downstream') to the higher layer
-             (the 'upstream').
+             information about the illegal chains of imports from the lower layer (the 'upstream') to the higher layer
+             (the 'downstream').
     :rtype: ``set[PackageDependency]``.
     :raises grimp.exceptions.NoSuchContainer: if a container is not a module in the graph.
 
@@ -293,19 +293,17 @@ Higher level analysis
 
       A collection of import dependencies from one Python package to another.
 
-      .. attribute:: downstream
-
-        ``str``: The full name of the package within which all the routes start; the importer package.
-           E.g. "mypackage.foo".
-
       .. attribute:: upstream
 
-        ``str``: The full name of the package within which all the routes end; the imported package.
-            E.g. "mypackage.bar".
+        ``str``: The full name of the package within which all the routes start, e.g. "mypackage.foo".
+
+      .. attribute:: downstream
+
+        ``str``: The full name of the package within which all the routes end, e.g. "mypackage.bar".
 
       .. attribute:: routes
 
-        ``frozenset[grimp.Route]``: A set of :class:`.Route` objects from downstream to upstream.
+        ``frozenset[grimp.Route]``: A set of :class:`.Route` objects from upstream to downstream.
 
     .. class:: Route
 

--- a/src/grimp/adaptors/_layers.py
+++ b/src/grimp/adaptors/_layers.py
@@ -191,8 +191,8 @@ def _search_for_package_dependency(
 
     if routes:
         return PackageDependency(
-            downstream=lower_layer_package.name,
-            upstream=higher_layer_package.name,
+            upstream=lower_layer_package.name,
+            downstream=higher_layer_package.name,
             routes=frozenset(routes),
         )
     else:

--- a/src/grimp/domain/analysis.py
+++ b/src/grimp/domain/analysis.py
@@ -9,8 +9,7 @@ class Route:
     """
     A set of 'chains' that share the same middle.
 
-    A chain is a sequence of modules linked by imports, from importer to imported,
-    for example:
+    A chain is a sequence of modules linked by imports, for example:
     mypackage.foo -> mypackage.bar -> mypackage.baz.
 
     The route fans in at the head and out at the tail, but the middle of the chain just links
@@ -69,21 +68,17 @@ class PackageDependency:
     Dependencies from one package to another.
     """
 
-    # The full name of the package from which all the routes start;
-    # the importer package.
-    # It's called 'downstream' because it depends on the upstream.
-    downstream: str
-    # The full name of the package from which all the routes end;
-    # the imported package.
+    # The full name of the package from which all the routes start.
     upstream: str
-
+    # The full name of the package from which all the routes end.
+    downstream: str
     routes: frozenset[Route]
 
     @classmethod
     def new(
         cls,
-        downstream: str,
         upstream: str,
+        downstream: str,
         routes: Iterable[Route],
     ) -> PackageDependency:
         """
@@ -92,10 +87,10 @@ class PackageDependency:
         Example:
 
             PackageDependency.new(
-                downstream="foo",
-                upstream="bar",
+                upstream="foo",
+                downstream="bar",
                 routes={Route.single_chained("foo", "bar")},
             )
 
         """
-        return cls(downstream=downstream, upstream=upstream, routes=frozenset(routes))
+        return cls(upstream=upstream, downstream=downstream, routes=frozenset(routes))

--- a/tests/unit/adaptors/graph/test_layers.py
+++ b/tests/unit/adaptors/graph/test_layers.py
@@ -37,10 +37,11 @@ class TestSingleOrNoContainer:
         graph.add_import(importer=importer, imported=imported)
 
         result = self._analyze(graph, specify_container=specify_container)
+
         assert result == {
             PackageDependency.new(
-                downstream="mypackage.medium",
-                upstream="mypackage.high",
+                upstream="mypackage.medium",
+                downstream="mypackage.high",
                 routes={Route.single_chained(importer, imported)},
             ),
         }
@@ -84,8 +85,8 @@ class TestSingleOrNoContainer:
 
         assert result == {
             PackageDependency.new(
-                downstream="mypackage.medium",
-                upstream="mypackage.high",
+                upstream="mypackage.medium",
+                downstream="mypackage.high",
                 routes={
                     Route.new(
                         heads={start},
@@ -109,8 +110,8 @@ class TestSingleOrNoContainer:
 
         assert result == {
             PackageDependency.new(
-                downstream="mypackage.low",
-                upstream="mypackage.medium",
+                upstream="mypackage.low",
+                downstream="mypackage.medium",
                 routes={
                     Route.single_chained(
                         "mypackage.low.white", "mypackage.medium.orange.beta"
@@ -118,8 +119,8 @@ class TestSingleOrNoContainer:
                 },
             ),
             PackageDependency.new(
-                downstream="mypackage.medium",
-                upstream="mypackage.high",
+                upstream="mypackage.medium",
+                downstream="mypackage.high",
                 routes={
                     Route.single_chained(
                         "mypackage.medium.orange", "mypackage.high.green"
@@ -148,8 +149,8 @@ class TestSingleOrNoContainer:
 
         assert result == {
             PackageDependency.new(
-                downstream="mypackage.medium",
-                upstream="mypackage.high",
+                upstream="mypackage.medium",
+                downstream="mypackage.high",
                 routes={
                     Route.single_chained(
                         "mypackage.medium.orange",
@@ -186,8 +187,8 @@ class TestSingleOrNoContainer:
 
         assert result == {
             PackageDependency.new(
-                downstream="mypackage.medium",
-                upstream="mypackage.high",
+                upstream="mypackage.medium",
+                downstream="mypackage.high",
                 routes={
                     Route.single_chained(
                         "mypackage.medium.orange",
@@ -227,8 +228,8 @@ class TestSingleOrNoContainer:
 
         assert result == {
             PackageDependency.new(
-                downstream="mypackage.medium",
-                upstream="mypackage.high",
+                upstream="mypackage.medium",
+                downstream="mypackage.high",
                 routes={
                     Route.new(
                         heads={
@@ -275,8 +276,8 @@ class TestSingleOrNoContainer:
 
         assert result == {
             PackageDependency.new(
-                downstream="low",
-                upstream="high",
+                upstream="low",
+                downstream="high",
                 routes={
                     Route.single_chained(source, a, b, destination),
                     Route.single_chained(source, c, d, destination),
@@ -308,8 +309,8 @@ class TestSingleOrNoContainer:
 
         assert result == {
             PackageDependency.new(
-                downstream="low",
-                upstream="high",
+                upstream="low",
+                downstream="high",
                 routes={
                     Route.single_chained(source, a, b, destination),
                 },
@@ -343,8 +344,8 @@ class TestSingleOrNoContainer:
 
         first_option = {
             PackageDependency.new(
-                downstream="low",
-                upstream="high",
+                upstream="low",
+                downstream="high",
                 routes={
                     Route.single_chained(source, a, b, destination),
                 },
@@ -353,8 +354,8 @@ class TestSingleOrNoContainer:
 
         second_option = {
             PackageDependency.new(
-                downstream="low",
-                upstream="high",
+                upstream="low",
+                downstream="high",
                 routes={
                     Route.single_chained(source, a, c, destination),
                 },
@@ -429,8 +430,8 @@ class TestMultiplePackages:
 
         assert result == {
             PackageDependency.new(
-                downstream="medium",
-                upstream="high",
+                upstream="medium",
+                downstream="high",
                 routes={Route.single_chained(importer, imported)},
             ),
         }
@@ -473,8 +474,8 @@ class TestMultiplePackages:
 
         assert result == {
             PackageDependency.new(
-                downstream="medium",
-                upstream="high",
+                upstream="medium",
+                downstream="high",
                 routes={
                     Route.new(
                         heads={start},
@@ -547,8 +548,8 @@ class TestMultipleContainers:
 
         assert result == {
             PackageDependency.new(
-                downstream="one.low",
-                upstream="one.high",
+                upstream="one.low",
+                downstream="one.high",
                 routes={
                     Route.single_chained("one.low.white", "one.high.green"),
                     Route.single_chained("one.low.white", "one.high.brown"),
@@ -562,8 +563,8 @@ class TestMultipleContainers:
                 },
             ),
             PackageDependency.new(
-                downstream="two.medium",
-                upstream="two.high",
+                upstream="two.medium",
+                downstream="two.high",
                 routes={
                     Route.single_chained(
                         "two.medium.pink.delta", "two.high.yellow.gamma"
@@ -723,8 +724,8 @@ class TestMissingLayers:
 
         assert result == {
             PackageDependency.new(
-                downstream="mypackage.medium",
-                upstream="mypackage.high",
+                upstream="mypackage.medium",
+                downstream="mypackage.high",
                 routes={
                     Route.single_chained(
                         "mypackage.medium.blue", "mypackage.high.green"
@@ -751,8 +752,8 @@ class TestMissingLayers:
 
         assert result == {
             PackageDependency.new(
-                downstream="two.medium",
-                upstream="two.high",
+                upstream="two.medium",
+                downstream="two.high",
                 routes={Route.single_chained("two.medium.blue", "two.high.green")},
             )
         }


### PR DESCRIPTION
Reverts seddonym/grimp#121

Rather than reverse the names, which has a bit more potential to cause silent bugs, I'm going to change the names to less confusing ones. 