### PR TITLE
Rename Level to Layer

### DIFF
--- a/src/grimp/__init__.py
+++ b/src/grimp/__init__.py
@@ -2,7 +2,7 @@ __version__ = "3.1"
 
 from .application.ports.graph import DetailedImport, ImportGraph
 from .domain.analysis import PackageDependency, Route
-from .domain.valueobjects import DirectImport, Module, Level
+from .domain.valueobjects import DirectImport, Module, Layer
 from .main import build_graph
 
 __all__ = [
@@ -13,5 +13,5 @@ __all__ = [
     "PackageDependency",
     "Route",
     "build_graph",
-    "Level",
+    "Layer",
 ]

--- a/src/grimp/adaptors/_layers.py
+++ b/src/grimp/adaptors/_layers.py
@@ -11,27 +11,27 @@ if TYPE_CHECKING:
 
 from grimp.domain.analysis import PackageDependency
 from grimp.exceptions import NoSuchContainer
-from grimp.domain.valueobjects import Level
+from grimp.domain.valueobjects import Layer
 
 
-def layers_to_levels(layers: Sequence[Level | str | set[str]]) -> tuple[Level, ...]:
+def parse_layers(layers: Sequence[Layer | str | set[str]]) -> tuple[Layer, ...]:
     """
-    Convert the levels within the passed `layers` into `Level`s.
+    Convert the passed raw `layers` into `Layer`s.
     """
     out_layers = []
     for layer in layers:
-        if isinstance(layer, Level):
+        if isinstance(layer, Layer):
             out_layers.append(layer)
         elif isinstance(layer, str):
-            out_layers.append(Level(layer, independent=True))
+            out_layers.append(Layer(layer, independent=True))
         else:
-            out_layers.append(Level(*tuple(layer), independent=True))
+            out_layers.append(Layer(*tuple(layer), independent=True))
     return tuple(out_layers)
 
 
 def find_illegal_dependencies(
     graph: ImportGraph,
-    levels: Sequence[Level],
+    layers: Sequence[Layer],
     containers: set[str],
 ) -> set[PackageDependency]:
     """
@@ -45,7 +45,8 @@ def find_illegal_dependencies(
     try:
         rust_package_dependency_tuple = rust.find_illegal_dependencies(
             levels=tuple(
-                {"layers": level.layers, "independent": level.independent} for level in levels
+                {"layers": layer.module_tails, "independent": layer.independent}
+                for layer in layers
             ),
             containers=set(containers),
             importeds_by_importer=graph._importeds_by_importer,

--- a/src/grimp/adaptors/graph.py
+++ b/src/grimp/adaptors/graph.py
@@ -6,7 +6,7 @@ from typing import Dict, List, Optional, Sequence, Set, Tuple, cast
 from grimp.algorithms.shortest_path import bidirectional_shortest_path
 from grimp.application.ports import graph
 from grimp.domain.analysis import PackageDependency
-from grimp.domain.valueobjects import Module, Level
+from grimp.domain.valueobjects import Module, Layer
 from grimp.exceptions import ModuleNotPresent
 
 from . import _layers
@@ -365,12 +365,12 @@ class ImportGraph(graph.ImportGraph):
 
     def find_illegal_dependencies_for_layers(
         self,
-        layers: Sequence[Level | str | set[str]],
+        layers: Sequence[Layer | str | set[str]],
         containers: set[str] | None = None,
     ) -> set[PackageDependency]:
-        levels = _layers.layers_to_levels(layers)
+        layers = _layers.parse_layers(layers)
         return _layers.find_illegal_dependencies(
-            graph=self, levels=levels, containers=containers or set()
+            graph=self, layers=layers, containers=containers or set()
         )
 
     # Private methods

--- a/src/grimp/application/ports/graph.py
+++ b/src/grimp/application/ports/graph.py
@@ -6,7 +6,7 @@ from typing import Iterator, List, Optional, Sequence, Set, Tuple
 from typing_extensions import TypedDict
 
 from grimp.domain.analysis import PackageDependency
-from grimp.domain.valueobjects import Level
+from grimp.domain.valueobjects import Layer
 
 
 class DetailedImport(TypedDict):
@@ -272,27 +272,29 @@ class ImportGraph(abc.ABC):
 
     def find_illegal_dependencies_for_layers(
         self,
-        layers: Sequence[Level | str | set[str]],
+        layers: Sequence[Layer | str | set[str]],
         containers: set[str] | None = None,
     ) -> set[PackageDependency]:
         """
         Find dependencies that don't conform to the supplied layered architecture.
 
-        'Layers' is an architectural pattern in which a list of sibling modules/packages
+        'Layers' is an architectural pattern in which a list of modules/packages
         have a dependency direction from high to low. In other words, a higher layer would
         be allowed to import a lower layer, but not the other way around.
 
-        Additionally, multiple layers can be grouped together at the same level; for example
-        `mypackage.utils` and `mypackage.logging` might sit at the bottom, so they cannot
-        import from any other layers. When a simple set of sibling layers is passed then they
-        must be independent, so any dependencies in either direction will be treated as illegal.
-        To allow imports between siblings in a layer then an explicit `Level` can be passed instead,
-        and `independent` set to `False`.
+        Additionally, multiple modules can be grouped together at the same layer;
+        for example `mypackage.utils` and `mypackage.logging` might sit at the bottom, so they
+        cannot import from any other layers. To specify that multiple modules should
+        be treated as siblings within a single layer, pass a `Layer`. The `Layer.independent`
+        field can be used to specify whether the sibling modules should be treated as independent
+        - should imports between sibling modules be forbidden (default) or allowed? For backwards
+        compatibility it is also possible to pass a simple `set[str]` to describe a layer. In this
+        case the sibling modules within the layer will be considered independent.
 
         Arguments:
 
-        - layers:     A sequence, each element of which consists either of the name of a layer
-                      module, a set of sibling layers, or a `Level`. If containers
+        - layers:     A sequence, each element of which consists either of a `Layer`, the name
+                      of a layer module or a set of sibling modules. If containers
                       are also specified, then these names must be relative to the container.
                       The order is from higher to lower level layers. Any layers that don't
                       exist in the graph will be ignored.

--- a/src/grimp/domain/valueobjects.py
+++ b/src/grimp/domain/valueobjects.py
@@ -86,21 +86,21 @@ class DirectImport(ValueObject):
         return hash((str(self), self.line_contents))
 
 
-class Level(ValueObject):
+class Layer(ValueObject):
     """
-    A level within a layered architecture.
+    A layer within a layered architecture.
 
-    If level.independent is True then the layers within the level are considered
+    If layer.independent is True then the modules within the layer are considered
     independent. This is the default.
     """
 
     def __init__(
         self,
-        *layers: str,
+        *module_tails: str,
         independent: bool = True,
     ) -> None:
-        self.layers = set(layers)
+        self.module_tails = set(module_tails)
         self.independent = independent
 
     def __str__(self) -> str:
-        return f"{self.layers}, independent={self.independent}"
+        return f"{self.module_tails}, independent={self.independent}"

--- a/tests/unit/adaptors/graph/test_layers.py
+++ b/tests/unit/adaptors/graph/test_layers.py
@@ -9,7 +9,7 @@ import pytest  # type: ignore
 from grimp import PackageDependency, Route
 from grimp.adaptors.graph import ImportGraph
 from grimp.exceptions import NoSuchContainer
-from grimp.domain.valueobjects import Level
+from grimp.domain.valueobjects import Layer
 
 
 class TestSingleOrNoContainer:
@@ -398,8 +398,8 @@ class TestIndependentLayers:
     @pytest.mark.parametrize(
         "sequence_type, expect_independent",
         (
-            (lambda layers: Level(*layers), True),
-            (lambda layers: Level(*layers, independent=False), False),
+            (lambda layers: Layer(*layers), True),
+            (lambda layers: Layer(*layers, independent=False), False),
             (set, True),
             (frozenset, True),
             (tuple, True),


### PR DESCRIPTION
Following discussions with @seddonym. A suggested renaming:

* `grimp.Level` to `grimp.Layer` - since a "level" is actually a layer (these terms are currently mixed and used to mean the same thing, lets just use one terminology).
* `grimp.Level.layers` to `grimp.Layer.module_tails` - since there are no "layers" _within_ a layer/level, the items within a layer are actually modules (or the "tails" of modules, in the case of `containers`).

Right now this is just the python changes - we should probably align the rust code too, although for this PR these python changes might be enough, so that we can prioritise tidying the package public API (so it is publishable) and also unblock https://github.com/seddonym/import-linter/pull/209.