### PR TITLE
Don't warn when encountering non-Python files with multiple dots

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,8 @@ Unreleased
 ----------
 
 * Allow configuring sibling layer independence.
+* Fix bug where a warning would be logged if a non-Python file with multiple dots
+  in the filename was encountered.
 
 3.1 (2023-10-13)
 ----------------

--- a/src/grimp/adaptors/modulefinder.py
+++ b/src/grimp/adaptors/modulefinder.py
@@ -74,6 +74,9 @@ class ModuleFinder(modulefinder.AbstractModuleFinder):
         if filename.startswith("."):
             return False
 
+        if not filename.endswith(".py"):
+            return False
+
         # Ignore files like some.module.py.
         if filename.count(".") > 1:
             logger.warning(
@@ -82,7 +85,7 @@ class ModuleFinder(modulefinder.AbstractModuleFinder):
             )
             return False
 
-        return filename.endswith(".py")
+        return True
 
     def _module_name_from_filename(
         self, package_name: str, filename_and_path: str, package_directory: str

--- a/tox.ini
+++ b/tox.ini
@@ -20,24 +20,25 @@ passenv =
     *
 usedevelop = false
 deps =
-    pytest==7.1.2
+    pytest==7.4.4
     PyYAML==6.0
     pytest-cov==3.0.0
     # External packages to attempt to build the graph from.
-    django
-    flask
+    Django
+    Flask
     requests
-    sqlalchemy
+    SQLAlchemy
     google-cloud-audit-log
 commands =
     {posargs:pytest --cov --cov-report=term-missing -vv tests}
 
 [testenv:check]
 deps =
-    black~=23.9.1
-    flake8
-    mypy
-    types-PyYAML
+    black==23.9.1
+    flake8==7.0.0
+    mypy==1.8.0
+    pytest-stub==1.1.0
+    types-PyYAML==6.0.12.12
 skip_install = true
 commands =
     black --check src tests

--- a/tox.ini
+++ b/tox.ini
@@ -33,6 +33,7 @@ commands =
     {posargs:pytest --cov --cov-report=term-missing -vv tests}
 
 [testenv:check]
+basepython = py311
 deps =
     black==23.9.1
     flake8==7.0.0


### PR DESCRIPTION
Fixes bug raised [here](https://github.com/seddonym/import-linter/issues/211). 