### PR TITLE
Add `exclude_stdlib` argument to `build_graph`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ authors = [
 requires-python = ">=3.8"
 dependencies = [
     "typing-extensions>=3.10.0.0",
+    "stdlibs; python_version < '3.10'",
 ]
 classifiers = [
     "Development Status :: 5 - Production/Stable",

--- a/src/grimp/adaptors/caching.py
+++ b/src/grimp/adaptors/caching.py
@@ -25,9 +25,13 @@ class CacheFileNamer:
         found_packages: Set[FoundPackage],
         include_external_packages: bool,
         exclude_type_checking_imports: bool,
+        exclude_stdlib: bool,
     ) -> str:
         identifier = cls.make_data_file_unique_string(
-            found_packages, include_external_packages, exclude_type_checking_imports
+            found_packages,
+            include_external_packages,
+            exclude_type_checking_imports,
+            exclude_stdlib,
         )
 
         bytes_identifier = identifier.encode()
@@ -43,6 +47,7 @@ class CacheFileNamer:
         found_packages: Set[FoundPackage],
         include_external_packages: bool,
         exclude_type_checking_imports: bool,
+        exclude_stdlib: bool,
     ) -> str:
         """
         Construct a unique string that identifies the analysis parameters.
@@ -55,8 +60,12 @@ class CacheFileNamer:
         exclude_type_checking_imports_option = (
             ":no_type_checking" if exclude_type_checking_imports else ""
         )
+        exclude_stdlib = ":exclude_stdlib" if exclude_stdlib else ""
         return (
-            csv_packages + include_external_packages_option + exclude_type_checking_imports_option
+            csv_packages
+            + include_external_packages_option
+            + exclude_type_checking_imports_option
+            + exclude_stdlib
         )
 
 
@@ -79,6 +88,7 @@ class Cache(AbstractCache):
         found_packages: Set[FoundPackage],
         include_external_packages: bool,
         exclude_type_checking_imports: bool = False,
+        exclude_stdlib: bool = False,
         cache_dir: Optional[str] = None,
         namer: Type[CacheFileNamer] = CacheFileNamer,
     ) -> "Cache":
@@ -87,6 +97,7 @@ class Cache(AbstractCache):
             found_packages=found_packages,
             include_external_packages=include_external_packages,
             exclude_type_checking_imports=exclude_type_checking_imports,
+            exclude_stdlib=exclude_stdlib,
             cache_dir=cls.cache_dir_or_default(cache_dir),
             namer=namer,
         )
@@ -142,6 +153,7 @@ class Cache(AbstractCache):
                 found_packages=self.found_packages,
                 include_external_packages=self.include_external_packages,
                 exclude_type_checking_imports=self.exclude_type_checking_imports,
+                exclude_stdlib=self.exclude_stdlib,
             ),
         )
         self.file_system.write(data_cache_filename, serialized)
@@ -196,6 +208,7 @@ class Cache(AbstractCache):
                 found_packages=self.found_packages,
                 include_external_packages=self.include_external_packages,
                 exclude_type_checking_imports=self.exclude_type_checking_imports,
+                exclude_stdlib=self.exclude_stdlib,
             ),
         )
         try:

--- a/src/grimp/application/ports/caching.py
+++ b/src/grimp/application/ports/caching.py
@@ -16,6 +16,7 @@ class Cache:
         file_system: AbstractFileSystem,
         include_external_packages: bool,
         exclude_type_checking_imports: bool,
+        exclude_stdlib: bool,
         found_packages: Set[FoundPackage],
         cache_dir: str,
     ) -> None:
@@ -26,6 +27,7 @@ class Cache:
         self.found_packages = found_packages
         self.include_external_packages = include_external_packages
         self.exclude_type_checking_imports = exclude_type_checking_imports
+        self.exclude_stdlib = exclude_stdlib
         self.cache_dir = cache_dir
 
     @classmethod
@@ -36,6 +38,7 @@ class Cache:
         *,
         include_external_packages: bool,
         exclude_type_checking_imports: bool = False,
+        exclude_stdlib: bool = False,
         cache_dir: Optional[str] = None,
     ) -> "Cache":
         cache = cls(
@@ -43,6 +46,7 @@ class Cache:
             found_packages=found_packages,
             include_external_packages=include_external_packages,
             exclude_type_checking_imports=exclude_type_checking_imports,
+            exclude_stdlib=exclude_stdlib,
             cache_dir=cls.cache_dir_or_default(cache_dir),
         )
         return cache

--- a/src/grimp/application/ports/importscanner.py
+++ b/src/grimp/application/ports/importscanner.py
@@ -16,6 +16,7 @@ class AbstractImportScanner(abc.ABC):
         file_system: AbstractFileSystem,
         found_packages: Set[FoundPackage],
         include_external_packages: bool = False,
+        exclude_stdlib: bool = False,
     ) -> None:
         """
         Args:
@@ -25,9 +26,12 @@ class AbstractImportScanner(abc.ABC):
             - include_external_packages:     Whether to include imports of external modules (i.e.
                                              modules not contained in modules_by_package_directory)
                                              in the results.
+            - exclude_stdlib:                Whether to exclude imports of stdlib modules
+                                             (only used when `include_external_packages` is `True`)
         """
         self.file_system = file_system
         self.include_external_packages = include_external_packages
+        self.exclude_stdlib = exclude_stdlib
         self.found_packages = found_packages
 
         # Flatten all the modules into a set.

--- a/src/grimp/application/usecases.py
+++ b/src/grimp/application/usecases.py
@@ -22,6 +22,7 @@ def build_graph(
     *additional_package_names,
     include_external_packages: bool = False,
     exclude_type_checking_imports: bool = False,
+    exclude_stdlib: bool = False,
     cache_dir: Union[str, Type[NotSupplied], None] = NotSupplied,
 ) -> ImportGraph:
     """
@@ -29,9 +30,11 @@ def build_graph(
 
     Args:
         - package_name: the name of the top level package for which to build the graph.
-        - additional_package_names: tuple of the
+        - additional_package_names: tuple of additional package names
         - include_external_packages: whether to include any external packages in the graph.
         - exclude_type_checking_imports: whether to exclude imports made in type checking guards.
+        - exclude_stdlib: whether to exclude standard library packages in the graph. Only used when
+            `include_external_packages` is `True`.
         - cache_dir: The directory to use for caching the graph.
     Examples:
 
@@ -59,6 +62,7 @@ def build_graph(
         file_system=file_system,
         include_external_packages=include_external_packages,
         exclude_type_checking_imports=exclude_type_checking_imports,
+        exclude_stdlib=exclude_stdlib,
         cache_dir=cache_dir,
     )
 
@@ -104,6 +108,7 @@ def _scan_packages(
     file_system: AbstractFileSystem,
     include_external_packages: bool,
     exclude_type_checking_imports: bool,
+    exclude_stdlib: bool,
     cache_dir: Union[str, Type[NotSupplied], None],
 ) -> Dict[Module, Set[DirectImport]]:
     imports_by_module: Dict[Module, Set[DirectImport]] = {}
@@ -114,12 +119,14 @@ def _scan_packages(
             found_packages=found_packages,
             include_external_packages=include_external_packages,
             exclude_type_checking_imports=exclude_type_checking_imports,
+            exclude_stdlib=exclude_stdlib,
             cache_dir=cache_dir_if_supplied,
         )
     import_scanner: AbstractImportScanner = settings.IMPORT_SCANNER_CLASS(
         file_system=file_system,
         found_packages=found_packages,
         include_external_packages=include_external_packages,
+        exclude_stdlib=exclude_stdlib,
     )
 
     for found_package in found_packages:


### PR DESCRIPTION
Implementation for https://github.com/seddonym/grimp/issues/143

Before finishing up with tests etc. checking if you are ok with temporarily adding the `stdlibs` backport. In Python 3.10  `sys.stdlib_module_names` becomes available. 

In my opinion including this light dependency for legacy Python version is not an issue, but it's your choice.