### PR TITLE
Include wheel for Python 3.13.0-beta.1 in release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
           x86_64, x86, aarch64, armv7, s390x, ppc64le
         ]
         python-version: [
-          "3.8", "3.9", "3.10", "3.11", "3.12"
+          "3.8", "3.9", "3.10", "3.11", "3.12", "3.13.0-beta.1"
         ]
     steps:
       - uses: actions/checkout@v3
@@ -47,7 +47,7 @@ jobs:
       matrix:
         target: [x64, x86]
         python-version: [
-          "3.8", "3.9", "3.10", "3.11", "3.12"
+          "3.8", "3.9", "3.10", "3.11", "3.12", "3.13.0-beta.1"
         ]
     steps:
       - uses: actions/checkout@v3
@@ -74,7 +74,7 @@ jobs:
       matrix:
         target: [x86_64, aarch64]
         python-version: [
-          "3.8", "3.9", "3.10", "3.11", "3.12"
+          "3.8", "3.9", "3.10", "3.11", "3.12", "3.13.0-beta.1"
         ]
     steps:
       - uses: actions/checkout@v3

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog
 =========
 
+latest
+------
+
+* Include wheel for Python 3.13.0-beta.1 in release.
+
 3.2 (2024-1-8)
 --------------
 


### PR DESCRIPTION
While Grimp doesn't yet formally support Python 3.13, this allows early adopters to install it.

As requested in https://github.com/seddonym/grimp/issues/146.