### PR TITLE
Add as_packages parameter to find_shortest_chains

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -8,3 +8,4 @@ Authors
 * NetworkX developers - The shortest path algorithm was adapted from the NetworkX library https://networkx.org/.
 * Peter Byfield - https://github.com/Peter554
 * Shane Smiskol - https://github.com/sshane
+* Nicholas Bunn - https://github.com/NicholasBunn

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog
 =========
 
+latest
+------
+
+* Added `as_packages` option to the `find_shortest_chains` method.
+
 3.3 (2024-06-13)
 ----------------
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -226,6 +226,9 @@ Methods for analysing import chains
 
     :param str importer: A module or subpackage within the graph.
     :param str imported: Another module or subpackage within the graph.
+    :param bool as_packages: Whether or not to treat the imported and importer as an individual module,
+                            or as a package (including any descendants, if there are any). If treating them as packages, all descendants
+                            of ``importer`` and ``imported`` will be checked too. Defaults to True.
     :return: The shortest import chains that exist between the ``importer`` and ``imported``, and between any modules
              contained within them. Only one chain per upstream/downstream pair will be included. Any chains that are
              contained within other chains in the result set will be excluded.

--- a/src/grimp/adaptors/graph.py
+++ b/src/grimp/adaptors/graph.py
@@ -304,8 +304,12 @@ class ImportGraph(graph.ImportGraph):
         """
         shortest_chains = set()
 
-        upstream_modules = self._all_modules_in_package(imported)
-        downstream_modules = self._all_modules_in_package(importer)
+        upstream_modules = (
+            {imported} if not as_packages else self._all_modules_in_package(imported)
+        )
+        downstream_modules = (
+            {importer} if not as_packages else self._all_modules_in_package(importer)
+        )
 
         if upstream_modules & downstream_modules:
             # If there are shared modules between the two, one of the modules is a descendant

--- a/src/grimp/adaptors/graph.py
+++ b/src/grimp/adaptors/graph.py
@@ -287,12 +287,17 @@ class ImportGraph(graph.ImportGraph):
 
         return self._find_shortest_chain(importer=importer, imported=imported)
 
-    def find_shortest_chains(self, importer: str, imported: str) -> Set[Tuple[str, ...]]:
+    def find_shortest_chains(
+        self, importer: str, imported: str, as_packages: bool = True
+    ) -> Set[Tuple[str, ...]]:
         """
         Find the shortest import chains that exist between the importer and imported, and
-        between any modules contained within them. Only one chain per upstream/downstream pair
-        will be included. Any chains that are contained within other chains in the result set
-        will be excluded.
+        between any modules contained within them if as_packages is True. Only one chain per
+        upstream/downstream pair will be included. Any chains that are contained within other
+        chains in the result set will be excluded.
+
+        The default behavior is to treat the import and imported as packages, however, if
+        as_packages is False, both the importer and imported will be treated as modules instead.
 
         Returns:
             A set of tuples of strings. Each tuple is ordered from importer to imported modules.

--- a/src/grimp/application/ports/graph.py
+++ b/src/grimp/application/ports/graph.py
@@ -231,12 +231,19 @@ class ImportGraph(abc.ABC):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def find_shortest_chains(self, importer: str, imported: str) -> Set[Tuple[str, ...]]:
+    def find_shortest_chains(
+        self, importer: str, imported: str, as_packages: bool = True
+    ) -> Set[Tuple[str, ...]]:
         """
         Find the shortest import chains that exist between the importer and imported, and
-        between any modules contained within them. Only one chain per upstream/downstream pair
-        will be included. Any chains that are contained within other chains in the result set
-        will be excluded.
+        between any modules contained within them if as_packages is True. Only one chain per
+        upstream/downstream pair will be included. Any chains that are contained within other
+        chains in the result set will be excluded.
+
+        The default behavior is to treat the import and imported as packages, however, if
+        as_packages is False, both the importer and imported will be treated as modules instead.
+
+
 
         Returns:
             A set of tuples of strings. Each tuple is ordered from importer to imported modules.

--- a/tests/assets/testpackage/three/__init__.py
+++ b/tests/assets/testpackage/three/__init__.py
@@ -1,0 +1,1 @@
+from ..one import alpha

--- a/tests/assets/testpackage/three/alpha.py
+++ b/tests/assets/testpackage/three/alpha.py
@@ -1,0 +1,3 @@
+from ..one import alpha
+
+BAR = alpha.BAR

--- a/tests/assets/testpackage/three/beta.py
+++ b/tests/assets/testpackage/three/beta.py
@@ -1,0 +1,5 @@
+from testpackage.one import alpha
+
+
+def foo():
+    return alpha.BAR

--- a/tests/assets/testpackage/three/gamma.py
+++ b/tests/assets/testpackage/three/gamma.py
@@ -1,0 +1,2 @@
+from .beta import foo
+from .. import utils

--- a/tests/unit/adaptors/graph/test_chains.py
+++ b/tests/unit/adaptors/graph/test_chains.py
@@ -442,18 +442,22 @@ class TestFindShortestChains:
         graph = ImportGraph()
         graph.add_module("green")
         graph.add_module("blue")
-        import_details = {
-            "importer": "green.foo",
-            "imported": "blue.bar",
-            "line_contents": "import blue.bar",
-            "line_number": 5,
-        }
-        graph.add_import(**import_details)
+        graph.add_import(
+            importer="green.foo",
+            imported="blue.bar",
+            line_contents="import blue.bar",
+            line_number=5,
+        )
 
         graph.find_shortest_chains(importer="green", imported="blue", as_packages=as_packages)
 
         assert graph.get_import_details(importer="green.foo", imported="blue.bar") == [
-            import_details
+            {
+                "importer": "green.foo",
+                "imported": "blue.bar",
+                "line_contents": "import blue.bar",
+                "line_number": 5,
+            }
         ]
 
     @pytest.mark.parametrize(

--- a/tests/unit/adaptors/graph/test_chains.py
+++ b/tests/unit/adaptors/graph/test_chains.py
@@ -1,3 +1,5 @@
+from typing import Set, Tuple
+
 import pytest  # type: ignore
 
 from grimp.adaptors.graph import ImportGraph
@@ -167,85 +169,188 @@ class TestFindShortestChain:
 
 
 class TestFindShortestChains:
-    def test_top_level_import(self):
+    @pytest.mark.parametrize(
+        "as_packages",
+        (
+            (False),
+            (True),
+        ),
+    )
+    def test_top_level_import(self, as_packages: bool):
         graph = ImportGraph()
         graph.add_import(importer="green", imported="blue")
 
-        result = graph.find_shortest_chains(importer="green", imported="blue")
+        result = graph.find_shortest_chains(
+            importer="green", imported="blue", as_packages=as_packages
+        )
 
         assert result == {("green", "blue")}
 
-    def test_first_level_child_import(self):
+    @pytest.mark.parametrize(
+        "as_packages, expected_result",
+        (
+            (False, set()),
+            (True, {("green.foo", "blue.bar")}),
+        ),
+    )
+    def test_first_level_child_import(self, as_packages: bool, expected_result: Set[Tuple]):
         graph = ImportGraph()
         graph.add_module("green")
         graph.add_module("blue")
         graph.add_import(importer="green.foo", imported="blue.bar")
 
-        result = graph.find_shortest_chains(importer="green", imported="blue")
+        result = graph.find_shortest_chains(
+            importer="green", imported="blue", as_packages=as_packages
+        )
 
-        assert result == {("green.foo", "blue.bar")}
+        assert result == expected_result
 
-    def test_no_results_in_reverse_direction(self):
+    @pytest.mark.parametrize(
+        "as_packages",
+        (
+            (False),
+            (True),
+        ),
+    )
+    def test_no_results_in_reverse_direction(self, as_packages: bool):
         graph = ImportGraph()
         graph.add_module("green")
         graph.add_module("blue")
         graph.add_import(importer="green.foo", imported="blue.bar")
 
-        result = graph.find_shortest_chains(importer="blue", imported="green")
+        result = graph.find_shortest_chains(
+            importer="blue", imported="green", as_packages=as_packages
+        )
 
         assert result == set()
 
-    def test_grandchildren_import(self):
+    @pytest.mark.parametrize(
+        "as_packages, expected_result",
+        (
+            (False, set()),
+            (True, {("green.foo.one", "blue.bar.two")}),
+        ),
+    )
+    def test_grandchildren_import(self, as_packages: bool, expected_result: Set[Tuple]):
         graph = ImportGraph()
         graph.add_module("green")
         graph.add_module("blue")
         graph.add_import(importer="green.foo.one", imported="blue.bar.two")
 
-        result = graph.find_shortest_chains(importer="green", imported="blue")
+        result = graph.find_shortest_chains(
+            importer="green", imported="blue", as_packages=as_packages
+        )
 
-        assert result == {("green.foo.one", "blue.bar.two")}
+        assert result == expected_result
 
-    def test_import_between_child_and_top_level(self):
+    @pytest.mark.parametrize(
+        "as_packages, expected_result",
+        (
+            (False, set()),
+            (True, {("green.foo", "blue")}),
+        ),
+    )
+    def test_import_between_child_and_top_level(
+        self, as_packages: bool, expected_result: Set[Tuple]
+    ):
         graph = ImportGraph()
         graph.add_module("green")
         graph.add_import(importer="green.foo", imported="blue")
 
-        result = graph.find_shortest_chains(importer="green", imported="blue")
+        result = graph.find_shortest_chains(
+            importer="green", imported="blue", as_packages=as_packages
+        )
 
-        assert result == {("green.foo", "blue")}
+        assert result == expected_result
 
-    def test_import_between_top_level_and_child(self):
+    @pytest.mark.parametrize(
+        "as_packages, expected_result",
+        (
+            (False, set()),
+            (True, {("green", "blue.foo")}),
+        ),
+    )
+    def test_import_between_top_level_and_child(
+        self, as_packages: bool, expected_result: Set[Tuple]
+    ):
         graph = ImportGraph()
         graph.add_module("blue")
         graph.add_import(importer="green", imported="blue.foo")
 
-        result = graph.find_shortest_chains(importer="green", imported="blue")
+        result = graph.find_shortest_chains(
+            importer="green", imported="blue", as_packages=as_packages
+        )
 
-        assert result == {("green", "blue.foo")}
+        assert result == expected_result
 
-    def test_short_indirect_import(self):
+    @pytest.mark.parametrize(
+        "as_packages, expected_result",
+        (
+            (False, {("green", "yellow", "red", "blue")}),
+            (
+                True,
+                {
+                    ("green.indirect", "purple", "blue.foo"),
+                    ("green", "yellow", "red", "blue"),
+                },
+            ),
+        ),
+    )
+    def test_short_indirect_import(self, as_packages: bool, expected_result: Set[Tuple]):
         graph = ImportGraph()
         graph.add_module("green")
         graph.add_module("blue")
+
+        # Test cases for indirect import as package
         graph.add_import(importer="green.indirect", imported="purple")
         graph.add_import(importer="purple", imported="blue.foo")
 
-        result = graph.find_shortest_chains(importer="green", imported="blue")
+        # Test cases for indirect import as module
+        graph.add_import(importer="green", imported="yellow")
+        graph.add_import(importer="yellow", imported="red")
+        graph.add_import(importer="red", imported="blue")
 
-        assert result == {("green.indirect", "purple", "blue.foo")}
+        result = graph.find_shortest_chains(
+            importer="green", imported="blue", as_packages=as_packages
+        )
 
-    def test_long_indirect_import(self):
+        assert result == expected_result
+
+    @pytest.mark.parametrize(
+        "as_packages, expected_result",
+        (
+            (False, {("green", "red.three", "red.two", "red.one", "blue")}),
+            (
+                True,
+                {
+                    ("green.baz", "yellow.three", "yellow.two", "yellow.one", "blue.foo"),
+                    ("green", "red.three", "red.two", "red.one", "blue"),
+                },
+            ),
+        ),
+    )
+    def test_long_indirect_import(self, as_packages: bool, expected_result: Set[Tuple]):
         graph = ImportGraph()
         graph.add_module("green")
         graph.add_module("blue")
+
+        # Test cases for indirect import as package
         graph.add_import(importer="green.baz", imported="yellow.three")
         graph.add_import(importer="yellow.three", imported="yellow.two")
         graph.add_import(importer="yellow.two", imported="yellow.one")
         graph.add_import(importer="yellow.one", imported="blue.foo")
 
-        result = graph.find_shortest_chains(importer="green", imported="blue")
+        # Test cases for indirect import as module
+        graph.add_import(importer="green", imported="red.three")
+        graph.add_import(importer="red.three", imported="red.two")
+        graph.add_import(importer="red.two", imported="red.one")
+        graph.add_import(importer="red.one", imported="blue")
 
-        assert result == {("green.baz", "yellow.three", "yellow.two", "yellow.one", "blue.foo")}
+        result = graph.find_shortest_chains(
+            importer="green", imported="blue", as_packages=as_packages
+        )
+
+        assert result == expected_result
 
     def test_chains_via_importer_package_dont_stop_longer_chains_being_included(self):
         graph = ImportGraph()
@@ -327,7 +432,11 @@ class TestFindShortestChains:
             ),
         }
 
-    def test_doesnt_lose_import_details(self):
+    @pytest.mark.parametrize(
+        "as_packages",
+        (False, True),
+    )
+    def test_doesnt_lose_import_details(self, as_packages: bool):
         # Find shortest chains uses hiding mechanisms, this checks that it doesn't
         # inadvertently delete import details for the things it hides.
         graph = ImportGraph()
@@ -341,13 +450,17 @@ class TestFindShortestChains:
         }
         graph.add_import(**import_details)
 
-        graph.find_shortest_chains(importer="green", imported="blue")
+        graph.find_shortest_chains(importer="green", imported="blue", as_packages=as_packages)
 
         assert graph.get_import_details(importer="green.foo", imported="blue.bar") == [
             import_details
         ]
 
-    def test_doesnt_change_import_count(self):
+    @pytest.mark.parametrize(
+        "as_packages",
+        (False, True),
+    )
+    def test_doesnt_change_import_count(self, as_packages: bool):
         # Find shortest chains uses hiding mechanisms, this checks that it doesn't
         # inadvertently change the import count.
         graph = ImportGraph()
@@ -356,7 +469,7 @@ class TestFindShortestChains:
         graph.add_import(importer="green.foo", imported="blue.bar")
         count_prior = graph.count_imports()
 
-        graph.find_shortest_chains(importer="green", imported="blue")
+        graph.find_shortest_chains(importer="green", imported="blue", as_packages=as_packages)
 
         assert graph.count_imports() == count_prior
 
@@ -370,12 +483,7 @@ class TestFindShortestChains:
         # Importer does not import the imported, even indirectly.
         ("a.two.green", "a.one", None, False),
         ("b.two", "c.one", None, False),  # Importer imports the child of the imported.
-        (
-            "b.two",
-            "b",
-            None,
-            False,
-        ),  # Importer is child of imported (but doesn't import).
+        ("b.two", "b", None, False),  # Importer is child of imported (but doesn't import).
         # Importer's child imports imported's child.
         ("b.two", "a.one", None, False),
         # Importer's grandchild directly imports imported's grandchild.


### PR DESCRIPTION
Adds the 'as_packages' option to the 'find_shortest_chains' methods. This allows the importer to be treated as a module rather than a package. The default behaviour is to treat it as a package so as to maintain backwards compatibility