### PR TITLE
Include 3.13 wheel in release

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         python-version: [
-          "3.8", "3.9", "3.10", "3.11", "3.12", "3.13.0-beta.3"
+          "3.8", "3.9", "3.10", "3.11", "3.12", "3.13-dev"
         ]
         os: [ubuntu-latest, macos-latest, windows-latest]
 
@@ -50,7 +50,8 @@ jobs:
 
         - uses: actions/setup-python@v4
           with:
-            python-version: "3.12"
+            python-version: "3.13"
+            allow-prereleases: true
 
         - name: Install dependencies
           run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
             3.10
             3.11
             3.12
-            3.13.0-beta.3
+            3.13
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:
@@ -79,7 +79,7 @@ jobs:
             3.10
             3.11
             3.12
-            3.13.0-beta.3
+            3.13
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:
@@ -112,7 +112,7 @@ jobs:
             3.10
             3.11
             3.12
-            3.13.0-beta.3
+            3.13
           architecture: ${{ matrix.platform.target }}
       - name: Build wheels
         uses: PyO3/maturin-action@v1
@@ -145,7 +145,7 @@ jobs:
             3.10
             3.11
             3.12
-            3.13.0-beta.3
+            3.13
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ latest
 ------
 
 * Added `as_packages` option to the `find_shortest_chains` method.
+* Include 3.13 wheel in release.
 
 3.4.1 (2024-07-12)
 ------------------

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,6 @@ envlist =
     check,
     docs,
     {py38,py39,py310,py311,py312,py13},
-    report
 
 [testenv]
 basepython =

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ envlist =
     clean,
     check,
     docs,
-    {py38,py39,py310,py311,py312},
+    {py38,py39,py310,py311,py312,py13},
     report
 
 [testenv]
@@ -23,26 +23,26 @@ passenv =
 usedevelop = false
 deps =
     pytest==7.4.4
-    PyYAML==6.0.1
-    pytest-cov==3.0.0
+    pyyaml==6.0.1
+    pytest-cov==5.0.0
     pytest-benchmark==4.0.0
     # External packages to attempt to build the graph from.
-    Django
-    Flask
-    requests
-    SQLAlchemy
-    google-cloud-audit-log
+    django
+    flask==3.0.3
+    requests==2.32.3
+    sqlalchemy==2.0.35
+    google-cloud-audit-log==0.3.0
 commands =
     {posargs:pytest --cov --cov-report=term-missing --benchmark-skip -vv tests}
 
 [testenv:check]
-basepython = py312
+basepython = py313
 deps =
     black==23.9.1
-    flake8==7.0.0
-    mypy==1.8.0
+    flake8==7.1.1
+    mypy==1.11.2
     pytest-stub==1.1.0
-    types-PyYAML==6.0.12.12
+    types-pyyaml==6.0.12.20240917
 skip_install = true
 commands =
     black --check src tests
@@ -50,7 +50,7 @@ commands =
     mypy src/grimp tests
 
 [testenv:benchmark]
-basepython = py312
+basepython = py313
 setenv =
     PYTHONPATH={toxinidir}/tests
     PYTHONUNBUFFERED=yes
@@ -65,7 +65,7 @@ commands =
     {posargs:pytest --benchmark-only --benchmark-autosave}
 
 [testenv:codspeed]
-basepython = py312
+basepython = py313
 setenv =
     PYTHONPATH={toxinidir}/tests
     PYTHONUNBUFFERED=yes
@@ -74,7 +74,7 @@ passenv =
 usedevelop = false
 deps =
     pytest==7.4.4
-    PyYAML==6.0.1
+    pyyaml==6.0.1
     pytest-codspeed==2.2.1
 commands =
     {posargs:pytest --codspeed}
@@ -105,5 +105,5 @@ python =
     3.9: py39, report
     3.10: py310, report
     3.11: py311, report
-    3.12: py312, report, check, docs
-    3.13: py313
+    3.12: py312, report
+    3.13: py313, report, check, docs


### PR DESCRIPTION
Hopefully will close https://github.com/seddonym/grimp/issues/146, now Python 3.13 is officially released.