### PR TITLE
Retry publishing 3.13 wheels

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         python-version: [
-          "3.9", "3.10", "3.11", "3.12", "3.13-dev"
+          "3.12", "3.13"
         ]
         os: [ubuntu-latest, macos-latest, windows-latest]
 
@@ -43,25 +43,25 @@ jobs:
       - name: Run tox targets for ${{ matrix.python-version }}
         run: python -m tox
 
-  benchmarks:
-      runs-on: ubuntu-latest
-      steps:
-        - uses: actions/checkout@v3
-
-        - uses: actions/setup-python@v4
-          with:
-            python-version: "3.13"
-            allow-prereleases: true
-
-        - name: Install dependencies
-          run: |
-            python -VV
-            python -m site
-            python -m pip install --upgrade pip setuptools wheel
-            python -m pip install --upgrade tox tox-gh-actions          
-
-        - name: Run benchmarks
-          uses: CodSpeedHQ/action@v2
-          with:
-            token: ${{ secrets.CODSPEED_TOKEN }}
-            run: tox -ecodspeed
+#  benchmarks:
+#      runs-on: ubuntu-latest
+#      steps:
+#        - uses: actions/checkout@v3
+#
+#        - uses: actions/setup-python@v4
+#          with:
+#            python-version: "3.13"
+#            allow-prereleases: true
+#
+#        - name: Install dependencies
+#          run: |
+#            python -VV
+#            python -m site
+#            python -m pip install --upgrade pip setuptools wheel
+#            python -m pip install --upgrade tox tox-gh-actions
+#
+#        - name: Run benchmarks
+#          uses: CodSpeedHQ/action@v2
+#          with:
+#            token: ${{ secrets.CODSPEED_TOKEN }}
+#            run: tox -ecodspeed

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,10 +37,6 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: |
-            3.9
-            3.10
-            3.11
-            3.12
             3.13
           allow-prereleases: true
       - name: Build wheels
@@ -74,10 +70,6 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: |
-            3.9
-            3.10
-            3.11
-            3.12
             3.13
           allow-prereleases: true
       - name: Build wheels
@@ -91,39 +83,6 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: wheels-musllinux-${{ matrix.platform.target }}
-          path: dist
-
-  windows:
-    runs-on: ${{ matrix.platform.runner }}
-    strategy:
-      matrix:
-        platform:
-          - runner: windows-latest
-            target: x64
-          - runner: windows-latest
-            target: x86
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: |
-            3.9
-            3.10
-            3.11
-            3.12
-            3.13
-          allow-prereleases: true
-          architecture: ${{ matrix.platform.target }}
-      - name: Build wheels
-        uses: PyO3/maturin-action@v1
-        with:
-          target: ${{ matrix.platform.target }}
-          args: --release --out dist --find-interpreter
-          sccache: 'true'
-      - name: Upload wheels
-        uses: actions/upload-artifact@v4
-        with:
-          name: wheels-windows-${{ matrix.platform.target }}
           path: dist
 
   macos:
@@ -140,10 +99,6 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: |
-            3.9
-            3.10
-            3.11
-            3.12
             3.13
           allow-prereleases: true
       - name: Build wheels
@@ -158,26 +113,11 @@ jobs:
           name: wheels-macos-${{ matrix.platform.target }}
           path: dist
 
-  sdist:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Build sdist
-        uses: PyO3/maturin-action@v1
-        with:
-          command: sdist
-          args: --out dist
-      - name: Upload sdist
-        uses: actions/upload-artifact@v4
-        with:
-          name: wheels-sdist
-          path: dist
-
   release:
     name: Release
     runs-on: ubuntu-latest
-    if: "startsWith(github.ref, 'refs/tags/')"
-    needs: [linux, musllinux, windows, macos, sdist]
+    #if: "startsWith(github.ref, 'refs/tags/')"
+    needs: [linux, musllinux, macos]
     steps:
       - uses: actions/download-artifact@v4
       - name: Publish to PyPI

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,14 +98,13 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: |
-            3.13
+          python-version: 3.13
           allow-prereleases: true
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.platform.target }}
-          args: --release --out dist --find-interpreter
+          args: --release --out dist --interpreter python3.13
           sccache: 'true'
       - name: Upload wheels
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,14 +36,13 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: |
-            3.13
+          python-version: 3.13
           allow-prereleases: true
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.platform.target }}
-          args: --release --out dist --find-interpreter
+          args: --release --out dist --interpreter python3.13
           sccache: 'true'
           manylinux: auto
       - name: Upload wheels
@@ -69,14 +68,13 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: |
-            3.13
+          python-version: 3.13
           allow-prereleases: true
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.platform.target }}
-          args: --release --out dist --find-interpreter
+          args: --release --out dist --interpreter python3.13
           sccache: 'true'
           manylinux: musllinux_1_2
       - name: Upload wheels


### PR DESCRIPTION
Don't merge!

This is a temporary branch just intended to attempt to publish 3.13 wheels for the latest version of Grimp.