### PR TITLE
Improve benchmarking tests

### DIFF
--- a/rust/tests/large.rs
+++ b/rust/tests/large.rs
@@ -5,7 +5,7 @@ use std::collections::{HashMap, HashSet};
 use std::fs;
 
 #[test]
-fn test_large_graph() {
+fn test_large_graph_deep_layers() {
     let data = fs::read_to_string("tests/large_graph.json").expect("Unable to read file");
     let value: Value = serde_json::from_str(&data).unwrap();
     let items: &Map<String, Value> = value.as_object().unwrap();
@@ -19,29 +19,27 @@ fn test_large_graph() {
     }
     let graph = ImportGraph::new(importeds_by_importer);
 
-    let levels = vec![
-        Level {
-            independent: true,
-            layers: vec!["plugins".to_string()],
-        },
-        Level {
-            independent: true,
-            layers: vec!["interfaces".to_string()],
-        },
-        Level {
-            independent: true,
-            layers: vec!["application".to_string()],
-        },
-        Level {
-            independent: true,
-            layers: vec!["domain".to_string()],
-        },
-        Level {
-            independent: true,
-            layers: vec!["data".to_string()],
-        },
+    let deep_layers = vec![
+        "mypackage.plugins.5634303718.1007553798.8198145119.application.3242334296.1991886645",
+        "mypackage.plugins.5634303718.1007553798.8198145119.application.3242334296.6397984863",
+        "mypackage.plugins.5634303718.1007553798.8198145119.application.3242334296.9009030339",
+        "mypackage.plugins.5634303718.1007553798.8198145119.application.3242334296.6666171185",
+        "mypackage.plugins.5634303718.1007553798.8198145119.application.3242334296.1693068682",
+        "mypackage.plugins.5634303718.1007553798.8198145119.application.3242334296.1752284225",
+        "mypackage.plugins.5634303718.1007553798.8198145119.application.3242334296.9089085203",
+        "mypackage.plugins.5634303718.1007553798.8198145119.application.3242334296.5033127033",
+        "mypackage.plugins.5634303718.1007553798.8198145119.application.3242334296.2454157946",
     ];
-    let containers = HashSet::from(["mypackage".to_string()]);
+    let levels: Vec<Level> = deep_layers
+        .iter()
+        .map(|layer| Level {
+            independent: true,
+            layers: vec![layer.to_string()],
+        })
+        .collect();
+    let containers = HashSet::new();
 
-    find_illegal_dependencies(&graph, &levels, &containers);
+    let deps = find_illegal_dependencies(&graph, &levels, &containers);
+
+    assert_eq!(deps.len(), 8);
 }


### PR DESCRIPTION
- Add tests to the benchmarking tests which assert on the values returned - helps check we're still testing the same thing.
- Change the rust integration test to be for deep layers.