### PR TITLE
Add benchmark for "..." in graph.modules

### DIFF
--- a/tests/benchmarking/test_benchmarking.py
+++ b/tests/benchmarking/test_benchmarking.py
@@ -430,3 +430,11 @@ def test_graph_contains_module(large_graph, benchmark):
             _ = f"foo{i}" in large_graph.modules
 
     _run_benchmark(benchmark, f, 100)
+
+
+def test_iterate_over_modules_in_graph(large_graph, benchmark):
+    def f():
+        for module in large_graph.modules:
+            _ = module
+
+    _run_benchmark(benchmark, f)

--- a/tests/benchmarking/test_benchmarking.py
+++ b/tests/benchmarking/test_benchmarking.py
@@ -44,7 +44,6 @@ DEEP_LAYERS = (
     f"{DEEP_PACKAGE}.application.3242334296.2454157946",
 )
 
-
 TOP_LEVEL_PACKAGE_DEPENDENCIES = {
     PackageDependency(
         importer="mypackage.domain",
@@ -423,3 +422,11 @@ class TestFindShortestChains:
 
 def test_copy_graph(large_graph, benchmark):
     _run_benchmark(benchmark, lambda: deepcopy(large_graph))
+
+
+def test_graph_contains_module(large_graph, benchmark):
+    def f(n):
+        for i in range(n):
+            _ = f"foo{i}" in large_graph.modules
+
+    _run_benchmark(benchmark, f, 100)


### PR DESCRIPTION
In the rust backed implementation this is significantly slower (currently), so lets add a benchmark to track this.

Related: https://github.com/seddonym/grimp/pull/175