### PR TITLE
Remove contains_module from public API

### DIFF
--- a/src/grimp/application/ports/graph.py
+++ b/src/grimp/application/ports/graph.py
@@ -33,13 +33,6 @@ class ImportGraph(abc.ABC):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def contains_module(self, module: str) -> bool:
-        """
-        Determine whether a module exists within the graph.
-        """
-        raise NotImplementedError
-
-    @abc.abstractmethod
     def add_module(self, module: str, is_squashed: bool = False) -> None:
         """
         Add a module to the graph.


### PR DESCRIPTION
The rust graph contains an optimised `contains_module` method, but right now we don't want to commit to adding this to the public API.