### PR TITLE
Add clippy to lint rust code

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,7 +50,7 @@ jobs:
         run: cargo test --no-default-features
         working-directory: ./rust
       - name: Run linter (clippy)
-        run: cargo clippy --all-targets --all-features
+        run: cargo clippy --all-targets --all-features -- -D warnings
         working-directory: ./rust
 
   benchmarks:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,8 +9,8 @@ on:
   workflow_dispatch:
 
 jobs:
-  tests:
-    name: Python ${{ matrix.python-version }}, ${{ matrix.os }}
+  check_python:
+    name: Check Python ${{ matrix.python-version }}, ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
 
     strategy:
@@ -22,14 +22,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
-
-      - run: cargo test --no-default-features
-        working-directory: ./rust
-
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
@@ -42,6 +37,17 @@ jobs:
 
       - name: Run tox targets for ${{ matrix.python-version }}
         run: python -m tox
+
+  check_rust:
+    name: Check Rust
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+      - run: cargo test --no-default-features
+        working-directory: ./rust
 
   benchmarks:
       runs-on: ubuntu-22.04

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,7 +46,11 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
-      - run: cargo test --no-default-features
+      - name: Run tests
+        run: cargo test --no-default-features
+        working-directory: ./rust
+      - name: Run linter (clippy)
+        run: cargo clippy --all-targets --all-features
         working-directory: ./rust
 
   benchmarks:

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -61,6 +61,16 @@ To set up `grimp` for local development:
 
 6. Submit a pull request through the GitHub website.
 
+Rust code
+---------
+
+When working with the rust code (in the ``rust/`` directory):
+
+* Run tests with ``cargo test --no-default-features``.
+  The ``--no-default-features`` flag is needed to due to `this PYO3 issue <https://pyo3.rs/main/faq#i-cant-run-cargo-test-or-i-cant-build-in-a-cargo-workspace-im-having-linker-issues-like-symbol-not-found-or-undefined-reference-to-_pyexc_systemerror>`_.
+* Run `clippy <https://doc.rust-lang.org/clippy/index.html>`_ (a linter for rust) with ``cargo clippy --all-targets --all-features -- -D warnings``.
+  It's often possible to apply automatic fixes to clippy issues with the ``--fix`` flag e.g. ``cargo clippy --all-targets --all-features --fix --allow-staged``.
+
 Pull Request Guidelines
 -----------------------
 


### PR DESCRIPTION
* https://github.com/rust-lang/rust-clippy
* https://doc.rust-lang.org/clippy/index.html

Clippy is a very popular linter for rust code. The default configuration is good. Clippy can help us to catch issues related to code correctness, style and performance. It's often possible to apply automatic fixes via the `--fix` flag.

