### PR TITLE
Fix CodSpeed action by updating to CodSpeedHQ/action@v3

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -71,7 +71,7 @@ jobs:
             python -m pip install --upgrade tox tox-gh-actions          
 
         - name: Run benchmarks
-          uses: CodSpeedHQ/action@v2
+          uses: CodSpeedHQ/action@v3
           with:
             token: ${{ secrets.CODSPEED_TOKEN }}
             run: tox -ecodspeed


### PR DESCRIPTION
Hey @seddonym, @Peter554, I am a co-founder @CodSpeedHQ.

The latest CodSpeed runs on the repo were not processed because you are using an older version of the action. Upgrading to the v3 will make it work!