### PR TITLE
Fix handling of within-descendant-imports when squashing modules

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog
 =========
 
+Unreleased
+----------
+
+* Fixed handling of within-descendant-imports when squashing modules (see `Issue 195 <https://github.com/seddonym/grimp/issues/195>`_).
+
 3.7 (2025-03-07)
 ----------------
 

--- a/rust/src/graph/graph_manipulation.rs
+++ b/rust/src/graph/graph_manipulation.rs
@@ -178,11 +178,6 @@ impl Graph {
             })
             .collect();
 
-        // Remove any descendants.
-        for descendant in descendants {
-            self.remove_module(descendant);
-        }
-
         // Add descendants and imports to parent module.
         for imported in modules_imported_by_descendants {
             self.add_import(module, imported);
@@ -190,6 +185,11 @@ impl Graph {
 
         for importer in modules_that_import_descendants {
             self.add_import(importer, module);
+        }
+
+        // Remove any descendants.
+        for descendant in descendants {
+            self.remove_module(descendant);
         }
 
         self.mark_module_squashed(module);

--- a/tests/unit/adaptors/graph/test_manipulation.py
+++ b/tests/unit/adaptors/graph/test_manipulation.py
@@ -448,7 +448,6 @@ class TestSquashModule:
         with pytest.raises(ModuleNotPresent):
             graph.squash_module("foo")
 
-    @pytest.mark.xfail(strict=True, reason="raises PanicException")
     def test_correctly_handles_imports_within_descendants(self):
         graph = ImportGraph()
 


### PR DESCRIPTION
Fixes https://github.com/seddonym/grimp/issues/195 (I'm pretty sure - hard to be 100% certain without seeing the respository in question).