### PR TITLE
Address issue with setting up the partial cache in benchmark

### DIFF
--- a/tests/benchmarking/adaptors.py
+++ b/tests/benchmarking/adaptors.py
@@ -1,0 +1,20 @@
+from grimp.adaptors.caching import Cache, CacheMiss
+from typing import Set
+
+from grimp.application.ports.modulefinder import ModuleFile
+from grimp.domain.valueobjects import DirectImport
+
+
+class PrefixMissingCache(Cache):
+    """
+    Test double of the real cache that will miss caching any module that begins with
+    a special prefix.
+    """
+
+    MISSING_PREFIX = "miss_marker_8772f06d64b6_"  # Arbitrary prefix.
+
+    def read_imports(self, module_file: ModuleFile) -> Set[DirectImport]:
+        leaf_name = module_file.module.name.split(".")[-1]
+        if leaf_name.startswith(self.MISSING_PREFIX):
+            raise CacheMiss
+        return super().read_imports(module_file)


### PR DESCRIPTION
Prior to this, we would set up the state for the first iteration, but future iterations would be able to use the fully-populated cache.