### PR TITLE
Move codspeed tox installation to earlier step

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,9 +56,9 @@ jobs:
   benchmarks:
       runs-on: ubuntu-22.04
       steps:
-        - uses: actions/checkout@v3
+        - uses: actions/checkout@v4
 
-        - uses: actions/setup-python@v4
+        - uses: actions/setup-python@v5
           with:
             python-version: "3.13"
             allow-prereleases: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,20 +58,27 @@ jobs:
       steps:
         - uses: actions/checkout@v4
 
-        - uses: actions/setup-python@v5
+        - name: Install uv
+          uses: astral-sh/setup-uv@v5
+
+        - name: Setup python
+          uses: actions/setup-python@v5
           with:
             python-version: "3.13"
             allow-prereleases: true
 
+        # Temporarily install hardcoded dependencies here.
+        # Codspeed doesn't work well with tox, as it runs the tox installation process as part of the benchmarking
+        # process, which is very slow.
         - name: Install dependencies
           run: |
             python -VV
-            python -m site
-            python -m pip install --upgrade pip setuptools wheel
-            python -m pip install --upgrade tox tox-gh-actions          
+            uv venv
+            uv pip install pytest==7.4.4 pyyaml==6.0.1 pytest-codspeed==3.2.0 Django==5.1.1 /home/runner/work/grimp/grimp         
 
         - name: Run benchmarks
           uses: CodSpeedHQ/action@v3
           with:
             token: ${{ secrets.CODSPEED_TOKEN }}
-            run: tox -ecodspeed
+            run: |
+              uv run pytest tests/benchmarking/ --codspeed

--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ coverage.xml
 htmlcov
 
 .benchmarks
+.codspeed
 
 # Translations
 *.mo

--- a/tox.ini
+++ b/tox.ini
@@ -74,7 +74,7 @@ usedevelop = false
 deps =
     pytest==7.4.4
     pyyaml==6.0.1
-    pytest-codspeed==2.2.1
+    pytest-codspeed==3.2.0
     Django==5.1.1
 commands =
     {posargs:pytest --codspeed}

--- a/tox.ini
+++ b/tox.ini
@@ -71,13 +71,15 @@ setenv =
 passenv =
     *
 usedevelop = false
+# Note - these dependencies are duplicated in main.yml, make sure to change them there too.
+# TODO: switch to UV for dependency management.
 deps =
     pytest==7.4.4
     pyyaml==6.0.1
     pytest-codspeed==3.2.0
     Django==5.1.1
 commands =
-    {posargs:pytest --codspeed}
+    pytest --codspeed {posargs}
 
 
 [testenv:docs]


### PR DESCRIPTION
Speeds up the benchmarking step job in CI.

Prior to this, we would run pytest via `tox -ecodspeed`. This meant that codspeed would run the installation of packages under valgrind, which is much slower.

This is a quick-and-dirty approach which changes the codspeed action to use `uv` to install the packages. This seems to reduce the time from around 17 minutes to 10 minutes. For some reason it's still installing reinstalling grimp, but it's better than it was. 