### PR TITLE
Revert "Use wall time runner"

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,7 +54,7 @@ jobs:
         working-directory: ./rust
 
   benchmarks:
-      runs-on: codspeed-macro
+      runs-on: ubuntu-22.04
       steps:
         - uses: actions/checkout@v4
 
@@ -74,7 +74,7 @@ jobs:
           run: |
             python -VV
             uv venv
-            uv pip install pytest==7.4.4 pyyaml==6.0.1 pytest-codspeed==3.2.0 Django==5.1.1         
+            uv pip install pytest==7.4.4 pyyaml==6.0.1 pytest-codspeed==3.2.0 Django==5.1.1 /home/runner/work/grimp/grimp         
 
         - name: Run benchmarks
           uses: CodSpeedHQ/action@v3


### PR DESCRIPTION
Reverts seddonym/grimp#203

Wall time is faster, but it doesn't include flamegraphs which I would miss too much!

![image](https://github.com/user-attachments/assets/1953ad7b-87b4-4a85-8118-24718fcdfae1)
