### PR TITLE
Don't parallelize scanning for small codebases

### DIFF
--- a/src/grimp/application/usecases.py
+++ b/src/grimp/application/usecases.py
@@ -20,6 +20,10 @@ class NotSupplied:
     pass
 
 
+# This is an arbitrary number, but setting it too low slows down our functional tests considerably.
+MIN_NUMBER_OF_MODULES_TO_SCAN_USING_MULTIPROCESSING = 50
+
+
 def build_graph(
     package_name,
     *additional_package_names,
@@ -233,6 +237,9 @@ def _create_chunks(module_files: Collection[ModuleFile]) -> tuple[tuple[ModuleFi
 
 
 def _decide_number_of_of_processes(number_of_module_files: int) -> int:
+    if number_of_module_files < MIN_NUMBER_OF_MODULES_TO_SCAN_USING_MULTIPROCESSING:
+        # Don't incur the overhead of multiprocessing.
+        return 1
     return min(multiprocessing.cpu_count(), number_of_module_files)
 
 

--- a/tests/functional/test_build_and_use_graph.py
+++ b/tests/functional/test_build_and_use_graph.py
@@ -1,6 +1,8 @@
 from grimp import build_graph
 from typing import Set, Tuple, Optional
 import pytest
+from unittest.mock import patch
+from grimp.application import usecases
 
 """
 For ease of reference, these are the imports of all the files:
@@ -31,6 +33,33 @@ testpackage.three.gamma: testpackage.two.beta, testpackage.utils
 
 
 def test_modules():
+    graph = build_graph("testpackage", cache_dir=None)
+
+    assert graph.modules == {
+        "testpackage",
+        "testpackage.one",
+        "testpackage.one.alpha",
+        "testpackage.one.beta",
+        "testpackage.one.gamma",
+        "testpackage.one.delta",
+        "testpackage.one.delta.blue",
+        "testpackage.two",
+        "testpackage.two.alpha",
+        "testpackage.two.beta",
+        "testpackage.two.gamma",
+        "testpackage.utils",
+        "testpackage.three",
+        "testpackage.three.beta",
+        "testpackage.three.gamma",
+        "testpackage.three.alpha",
+    }
+
+
+@patch.object(usecases, "MIN_NUMBER_OF_MODULES_TO_SCAN_USING_MULTIPROCESSING", 0)
+def test_modules_multiprocessing():
+    """
+    This test runs relatively slowly, but it's important we cover the multiprocessing code.
+    """
     graph = build_graph("testpackage", cache_dir=None)
 
     assert graph.modules == {


### PR DESCRIPTION
The recently-introduced multiprocessing work had slowed down the test suite, because we were spawning multiple processes for each functional test that scanned relatively small packages.

This introduces a constant defining the minimum number of modules before using multiprocessing, returning the test suite to its previous speed.

`pytest --benchmark-skip`
Before: 13.85s.
After: 4.91s

We can see there's a regression here for scanning Django with 15 cache misses: as it happens, the same size as the `testpackage` that is sped up. I think the reason for that is that the test package has very little AST parsing to do as the Python modules are almost empty, whereas the Django benchmark includes 15 quite complex modules. We could adjust this a bit (or even run it at a higher threshold when running tests), but given that scanning 50 modules in a single process is still quite fast, I doubt it will impact users in practice. We can easily revisit this later if need be.

 