### PR TITLE
Use joblib for more robust parallel import scanning

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,8 @@ Changelog
 Unreleased
 ----------
 
+* Use joblib instead of multiprocessing for CPU parallelism. Fixes https://github.com/seddonym/grimp/issues/208.
+
 3.8 (2025-04-11)
 ----------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ authors = [
 ]
 requires-python = ">=3.9"
 dependencies = [
+    "joblib>=1.3.0",
     "typing-extensions>=3.10.0.0",
 ]
 classifiers = [

--- a/tox.ini
+++ b/tox.ini
@@ -4,21 +4,9 @@ envlist =
     check,
     docs,
     {py39,py310,py311,py312,py13},
+    py13-joblib-earliest,
 
-[testenv]
-basepython =
-    py39: {env:TOXPYTHON:python3.9}
-    py310: {env:TOXPYTHON:python3.10}
-    py311: {env:TOXPYTHON:python3.11}
-    py312: {env:TOXPYTHON:python3.12}
-    py313: {env:TOXPYTHON:python3.13}
-    {clean,check,docs,report}: {env:TOXPYTHON:python3}
-setenv =
-    PYTHONPATH={toxinidir}/tests
-    PYTHONUNBUFFERED=yes
-passenv =
-    *
-usedevelop = false
+[base]
 deps =
     pytest==7.4.4
     pyyaml==6.0.1
@@ -30,8 +18,32 @@ deps =
     requests==2.32.3
     sqlalchemy==2.0.35
     google-cloud-audit-log==0.3.0
+
+[testenv]
+basepython =
+    py39: {env:TOXPYTHON:python3.9}
+    py310: {env:TOXPYTHON:python3.10}
+    py311: {env:TOXPYTHON:python3.11}
+    py312: {env:TOXPYTHON:python3.12}
+    py313: {env:TOXPYTHON:python3.13}
+    py313-joblib-earliest: {env:TOXPYTHON:python3.13}
+    {clean,check,docs,report}: {env:TOXPYTHON:python3}
+setenv =
+    PYTHONPATH={toxinidir}/tests
+    PYTHONUNBUFFERED=yes
+passenv =
+    *
+usedevelop = false
+deps =
+    {[base]deps}
+    joblib==1.4.2
 commands =
     {posargs:pytest --cov --cov-report=term-missing --benchmark-skip -vv tests}
+
+[testenv:py313-joblib-earliest]
+deps =
+    {[base]deps}
+    joblib==1.3.0
 
 [testenv:check]
 basepython = py313
@@ -107,4 +119,4 @@ python =
     3.10: py310, report
     3.11: py311, report
     3.12: py312, report
-    3.13: py313, report, check, docs
+    3.13: py313, py313-joblib-earliest, report, check, docs


### PR DESCRIPTION
Prior to this, import scanning would crash on large codebases when
running in a container with only one available CPU when the host had
a large number of CPUs. Joblib is better than the stdlib multiprocessing
package at determining the number of available CPUs in this context.

Should fix https://github.com/seddonym/grimp/issues/208, and possibly https://github.com/seddonym/import-linter/issues/261.