### PR TITLE
Multiprocessing env disable

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,12 @@
 Changelog
 =========
 
+latest
+------
+
+* Provide more control of multiprocessing via ``GRIMP_MIN_MULTIPROCESSING_MODULES``
+  environment variable.
+
 3.8.1 (2025-04-23)
 ------------------
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -82,7 +82,12 @@ Building the graph
     :param str, optional cache_dir: The directory to use for caching the graph. Defaults to ``.grimp_cache``. To disable caching,
         pass ``None``. See :doc:`caching`.
     :return: An import graph that you can use to analyse the package.
-    :rtype: ImportGraph
+    :rtype: ``ImportGraph``
+
+    This method uses multiple operating system processes to build the graph, if the number of modules to scan (not
+    including modules in the cache) is 50 or more. This threshold can be adjusted by setting the ``GRIMP_MIN_MULTIPROCESSING_MODULES``
+    environment variable to a different number. To disable multiprocessing altogether, set it to a large number (more than
+    the number of modules in the codebase being analyzed).
 
 .. _typing module documentation: https://docs.python.org/3/library/typing.html#typing.TYPE_CHECKING
 

--- a/tests/adaptors/modulefinder.py
+++ b/tests/adaptors/modulefinder.py
@@ -1,0 +1,16 @@
+from grimp.application.ports.modulefinder import AbstractModuleFinder, FoundPackage, ModuleFile
+from grimp.application.ports.filesystem import AbstractFileSystem
+from typing import FrozenSet, Dict
+
+
+class BaseFakeModuleFinder(AbstractModuleFinder):
+    module_files_by_package_name: Dict[str, FrozenSet[ModuleFile]] = {}
+
+    def find_package(
+        self, package_name: str, package_directory: str, file_system: AbstractFileSystem
+    ) -> FoundPackage:
+        return FoundPackage(
+            name=package_name,
+            directory=package_directory,
+            module_files=self.module_files_by_package_name[package_name],
+        )

--- a/tests/functional/test_build_and_use_graph.py
+++ b/tests/functional/test_build_and_use_graph.py
@@ -4,6 +4,7 @@ import pytest
 from unittest.mock import patch
 from grimp.application import usecases
 
+
 """
 For ease of reference, these are the imports of all the files:
 
@@ -55,7 +56,7 @@ def test_modules():
     }
 
 
-@patch.object(usecases, "MIN_NUMBER_OF_MODULES_TO_SCAN_USING_MULTIPROCESSING", 0)
+@patch.object(usecases, "DEFAULT_MIN_NUMBER_OF_MODULES_TO_SCAN_USING_MULTIPROCESSING", 0)
 def test_modules_multiprocessing():
     """
     This test runs relatively slowly, but it's important we cover the multiprocessing code.


### PR DESCRIPTION
The multiprocessing doesn't seem to work reliably in all environments; also the optimization of the threshold of when to start doing it is somewhat arbitrary.

This exposes an environment variable to allow callers to control it. We imagine this will go away once import scanning is moved into Rust, hence the decision just to use an environment variable rather than add it to the method arguments.

<img width="753" alt="image" src="https://github.com/user-attachments/assets/cd8a8245-58aa-4b4f-ab38-167a7ffcd52b" />
