### PR TITLE
Adapt / remove unit tests of private methods

### DIFF
--- a/tests/unit/adaptors/test_importscanner.py
+++ b/tests/unit/adaptors/test_importscanner.py
@@ -1,9 +1,9 @@
 from typing import Set
 
+
 import pytest  # type: ignore
 
-from textwrap import dedent
-from grimp.adaptors.importscanner import ImportScanner, _ImportedObject
+from grimp.adaptors.importscanner import ImportScanner
 from grimp.application.ports.modulefinder import FoundPackage, ModuleFile
 from grimp.domain.valueobjects import DirectImport, Module
 from tests.adaptors.filesystem import FakeFileSystem
@@ -76,6 +76,59 @@ def test_absolute_imports(include_external_packages, expected_result):
     result = import_scanner.scan_for_imports(Module("foo.one"))
 
     assert expected_result == result
+
+
+def test_non_ascii():
+    blue_module = Module("mypackage.blue")
+    non_ascii_modules = {Module("mypackage.ñon_ascii_变"), Module("mypackage.ñon_ascii_变.ラーメン")}
+    file_system = FakeFileSystem(
+        content_map={
+            "/path/to/mypackage/blue.py": """
+                from ñon_ascii_变 import *
+                from . import ñon_ascii_变
+                import mypackage.ñon_ascii_变.ラーメン
+            """,
+            "/path/to/mypackage/ñon_ascii_变/__init__.py": "",
+            "/path/to/mypackage/ñon_ascii_变/ラーメン.py": "",
+        },
+    )
+
+    import_scanner = ImportScanner(
+        found_packages={
+            FoundPackage(
+                name="mypackage",
+                directory="/path/to/mypackage",
+                module_files=frozenset(
+                    _modules_to_module_files({blue_module} | non_ascii_modules)
+                ),
+            )
+        },
+        file_system=file_system,
+        include_external_packages=True,
+    )
+
+    result = import_scanner.scan_for_imports(blue_module)
+
+    assert result == {
+        DirectImport(
+            importer="mypackage.blue",
+            imported="ñon_ascii_变",
+            line_number=1,
+            line_contents="from ñon_ascii_变 import *",
+        ),
+        DirectImport(
+            importer="mypackage.blue",
+            imported="mypackage.ñon_ascii_变",
+            line_number=2,
+            line_contents="from . import ñon_ascii_变",
+        ),
+        DirectImport(
+            importer="mypackage.blue",
+            imported="mypackage.ñon_ascii_变.ラーメン",
+            line_number=3,
+            line_contents="import mypackage.ñon_ascii_变.ラーメン",
+        ),
+    }
 
 
 def test_single_namespace_package_portion():
@@ -843,110 +896,3 @@ def test_exclude_type_checking_imports(
 def _modules_to_module_files(modules: Set[Module]) -> Set[ModuleFile]:
     some_mtime = 100933.4
     return {ModuleFile(module=module, mtime=some_mtime) for module in modules}
-
-
-class TestGetRawImportedObjects:
-    def test_get_raw_imports(self):
-        module_contents = dedent(
-            """\
-            import a
-            if TYPE_CHECKING:
-                import b
-            from c import d
-            from .e import f
-            from . import g
-            from .. import h
-            from i import *
-            from ñon_ascii_变 import *
-            from . import ñon_ascii_变
-            import ñon_ascii_变.ラーメン
-            """
-        )
-        raw_imported_objects = ImportScanner._get_raw_imported_objects(module_contents)
-
-        assert raw_imported_objects == {
-            _ImportedObject(
-                name="a",
-                line_number=1,
-                line_contents="import a",
-                typechecking_only=False,
-            ),
-            _ImportedObject(
-                name="b",
-                line_number=3,
-                line_contents="import b",
-                typechecking_only=True,
-            ),
-            _ImportedObject(
-                name="c.d",
-                line_number=4,
-                line_contents="from c import d",
-                typechecking_only=False,
-            ),
-            _ImportedObject(
-                name=".e.f",
-                line_number=5,
-                line_contents="from .e import f",
-                typechecking_only=False,
-            ),
-            _ImportedObject(
-                name=".g",
-                line_number=6,
-                line_contents="from . import g",
-                typechecking_only=False,
-            ),
-            _ImportedObject(
-                name="..h",
-                line_number=7,
-                line_contents="from .. import h",
-                typechecking_only=False,
-            ),
-            _ImportedObject(
-                name="i.*",
-                line_number=8,
-                line_contents="from i import *",
-                typechecking_only=False,
-            ),
-            _ImportedObject(
-                name="ñon_ascii_变.*",
-                line_number=9,
-                line_contents="from ñon_ascii_变 import *",
-                typechecking_only=False,
-            ),
-            _ImportedObject(
-                name=".ñon_ascii_变",
-                line_number=10,
-                line_contents="from . import ñon_ascii_变",
-                typechecking_only=False,
-            ),
-            _ImportedObject(
-                name="ñon_ascii_变.ラーメン",
-                line_number=11,
-                line_contents="import ñon_ascii_变.ラーメン",
-                typechecking_only=False,
-            ),
-        }
-
-
-@pytest.mark.parametrize(
-    "is_package,imported_object_name,expected_absolute_imported_object_name",
-    [
-        [True, "a.b", "a.b"],
-        [True, ".a.b", "foo.bar.baz.a.b"],
-        [True, "..a.b", "foo.bar.a.b"],
-        [False, "a.b", "a.b"],
-        [False, ".a.b", "foo.bar.a.b"],
-        [False, "..a.b", "foo.a.b"],
-    ],
-)
-def test_get_absolute_imported_object_name(
-    is_package, imported_object_name, expected_absolute_imported_object_name
-):
-    assert (
-        ImportScanner._get_absolute_imported_object_name(
-            module=Module("foo.bar.baz"),
-            is_package=is_package,
-            imported_object_name=imported_object_name,
-        )
-        == expected_absolute_imported_object_name
-    )


### PR DESCRIPTION
We're going to move to a Rust-based ImportScanner class - we don't want to have to expose this private method. This moves the tests for non-ascii based scanning to a higher level test, and removes the rest. There are already lower level Rust tests.