### PR TITLE
Add snapshot test for import scanning on real packages

### DIFF
--- a/tests/functional/__snapshots__/test_build_graph_on_real_packages.ambr
+++ b/tests/functional/__snapshots__/test_build_graph_on_real_packages.ambr
@@ -1,0 +1,21457 @@
+# serializer version: 1
+# name: test_build_graph_on_real_package[django]
+  list([
+    dict({
+      'imported': 'django.apps',
+      'importer': 'django',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django',
+    }),
+    dict({
+      'imported': 'django.urls',
+      'importer': 'django',
+    }),
+    dict({
+      'imported': 'django.utils.log',
+      'importer': 'django',
+    }),
+    dict({
+      'imported': 'django.utils.version',
+      'importer': 'django',
+    }),
+    dict({
+      'imported': 'django.core.management',
+      'importer': 'django.__main__',
+    }),
+    dict({
+      'imported': 'django.apps.config',
+      'importer': 'django.apps',
+    }),
+    dict({
+      'imported': 'django.apps.registry',
+      'importer': 'django.apps',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.apps.config',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.apps.config',
+    }),
+    dict({
+      'imported': 'django.utils.functional',
+      'importer': 'django.apps.config',
+    }),
+    dict({
+      'imported': 'django.utils.module_loading',
+      'importer': 'django.apps.config',
+    }),
+    dict({
+      'imported': 'django.apps.config',
+      'importer': 'django.apps.registry',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.apps.registry',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.apps.registry',
+    }),
+    dict({
+      'imported': 'django',
+      'importer': 'django.conf',
+    }),
+    dict({
+      'imported': 'django.conf.global_settings',
+      'importer': 'django.conf',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.conf',
+    }),
+    dict({
+      'imported': 'django.urls',
+      'importer': 'django.conf',
+    }),
+    dict({
+      'imported': 'django.utils.deprecation',
+      'importer': 'django.conf',
+    }),
+    dict({
+      'imported': 'django.utils.functional',
+      'importer': 'django.conf',
+    }),
+    dict({
+      'imported': 'django.urls',
+      'importer': 'django.conf.urls',
+    }),
+    dict({
+      'imported': 'django.views.defaults',
+      'importer': 'django.conf.urls',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.conf.urls.i18n',
+    }),
+    dict({
+      'imported': 'django.urls',
+      'importer': 'django.conf.urls.i18n',
+    }),
+    dict({
+      'imported': 'django.views.i18n',
+      'importer': 'django.conf.urls.i18n',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.conf.urls.static',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.conf.urls.static',
+    }),
+    dict({
+      'imported': 'django.urls',
+      'importer': 'django.conf.urls.static',
+    }),
+    dict({
+      'imported': 'django.views.static',
+      'importer': 'django.conf.urls.static',
+    }),
+    dict({
+      'imported': 'django.contrib.admin.decorators',
+      'importer': 'django.contrib.admin',
+    }),
+    dict({
+      'imported': 'django.contrib.admin.filters',
+      'importer': 'django.contrib.admin',
+    }),
+    dict({
+      'imported': 'django.contrib.admin.options',
+      'importer': 'django.contrib.admin',
+    }),
+    dict({
+      'imported': 'django.contrib.admin.sites',
+      'importer': 'django.contrib.admin',
+    }),
+    dict({
+      'imported': 'django.utils.module_loading',
+      'importer': 'django.contrib.admin',
+    }),
+    dict({
+      'imported': 'django.contrib.admin.decorators',
+      'importer': 'django.contrib.admin.actions',
+    }),
+    dict({
+      'imported': 'django.contrib.admin.helpers',
+      'importer': 'django.contrib.admin.actions',
+    }),
+    dict({
+      'imported': 'django.contrib.admin.utils',
+      'importer': 'django.contrib.admin.actions',
+    }),
+    dict({
+      'imported': 'django.contrib.messages',
+      'importer': 'django.contrib.admin.actions',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.contrib.admin.actions',
+    }),
+    dict({
+      'imported': 'django.template.response',
+      'importer': 'django.contrib.admin.actions',
+    }),
+    dict({
+      'imported': 'django.utils.translation',
+      'importer': 'django.contrib.admin.actions',
+    }),
+    dict({
+      'imported': 'django.apps',
+      'importer': 'django.contrib.admin.apps',
+    }),
+    dict({
+      'imported': 'django.contrib.admin.checks',
+      'importer': 'django.contrib.admin.apps',
+    }),
+    dict({
+      'imported': 'django.core.checks',
+      'importer': 'django.contrib.admin.apps',
+    }),
+    dict({
+      'imported': 'django.utils.translation',
+      'importer': 'django.contrib.admin.apps',
+    }),
+    dict({
+      'imported': 'django.apps',
+      'importer': 'django.contrib.admin.checks',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.contrib.admin.checks',
+    }),
+    dict({
+      'imported': 'django.contrib.admin',
+      'importer': 'django.contrib.admin.checks',
+    }),
+    dict({
+      'imported': 'django.contrib.admin.options',
+      'importer': 'django.contrib.admin.checks',
+    }),
+    dict({
+      'imported': 'django.contrib.admin.sites',
+      'importer': 'django.contrib.admin.checks',
+    }),
+    dict({
+      'imported': 'django.contrib.admin.utils',
+      'importer': 'django.contrib.admin.checks',
+    }),
+    dict({
+      'imported': 'django.core.checks',
+      'importer': 'django.contrib.admin.checks',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.contrib.admin.checks',
+    }),
+    dict({
+      'imported': 'django.db.models',
+      'importer': 'django.contrib.admin.checks',
+    }),
+    dict({
+      'imported': 'django.db.models.constants',
+      'importer': 'django.contrib.admin.checks',
+    }),
+    dict({
+      'imported': 'django.db.models.expressions',
+      'importer': 'django.contrib.admin.checks',
+    }),
+    dict({
+      'imported': 'django.forms.models',
+      'importer': 'django.contrib.admin.checks',
+    }),
+    dict({
+      'imported': 'django.template',
+      'importer': 'django.contrib.admin.checks',
+    }),
+    dict({
+      'imported': 'django.template.backends.django',
+      'importer': 'django.contrib.admin.checks',
+    }),
+    dict({
+      'imported': 'django.utils.module_loading',
+      'importer': 'django.contrib.admin.checks',
+    }),
+    dict({
+      'imported': 'django.contrib.admin',
+      'importer': 'django.contrib.admin.decorators',
+    }),
+    dict({
+      'imported': 'django.contrib.admin.sites',
+      'importer': 'django.contrib.admin.decorators',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.contrib.admin.exceptions',
+    }),
+    dict({
+      'imported': 'django.contrib.admin.options',
+      'importer': 'django.contrib.admin.filters',
+    }),
+    dict({
+      'imported': 'django.contrib.admin.utils',
+      'importer': 'django.contrib.admin.filters',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.contrib.admin.filters',
+    }),
+    dict({
+      'imported': 'django.db.models',
+      'importer': 'django.contrib.admin.filters',
+    }),
+    dict({
+      'imported': 'django.utils.timezone',
+      'importer': 'django.contrib.admin.filters',
+    }),
+    dict({
+      'imported': 'django.utils.translation',
+      'importer': 'django.contrib.admin.filters',
+    }),
+    dict({
+      'imported': 'django.contrib.auth.forms',
+      'importer': 'django.contrib.admin.forms',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.contrib.admin.forms',
+    }),
+    dict({
+      'imported': 'django.utils.translation',
+      'importer': 'django.contrib.admin.forms',
+    }),
+    dict({
+      'imported': 'django.contrib.admin.templatetags.admin_list',
+      'importer': 'django.contrib.admin.helpers',
+    }),
+    dict({
+      'imported': 'django.contrib.admin.utils',
+      'importer': 'django.contrib.admin.helpers',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.contrib.admin.helpers',
+    }),
+    dict({
+      'imported': 'django.db.models.fields.related',
+      'importer': 'django.contrib.admin.helpers',
+    }),
+    dict({
+      'imported': 'django.forms',
+      'importer': 'django.contrib.admin.helpers',
+    }),
+    dict({
+      'imported': 'django.forms.formsets',
+      'importer': 'django.contrib.admin.helpers',
+    }),
+    dict({
+      'imported': 'django.forms.utils',
+      'importer': 'django.contrib.admin.helpers',
+    }),
+    dict({
+      'imported': 'django.template.defaultfilters',
+      'importer': 'django.contrib.admin.helpers',
+    }),
+    dict({
+      'imported': 'django.urls',
+      'importer': 'django.contrib.admin.helpers',
+    }),
+    dict({
+      'imported': 'django.utils.html',
+      'importer': 'django.contrib.admin.helpers',
+    }),
+    dict({
+      'imported': 'django.utils.safestring',
+      'importer': 'django.contrib.admin.helpers',
+    }),
+    dict({
+      'imported': 'django.utils.translation',
+      'importer': 'django.contrib.admin.helpers',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.contrib.admin.migrations.0001_initial',
+    }),
+    dict({
+      'imported': 'django.contrib.admin.models',
+      'importer': 'django.contrib.admin.migrations.0001_initial',
+    }),
+    dict({
+      'imported': 'django.db.migrations',
+      'importer': 'django.contrib.admin.migrations.0001_initial',
+    }),
+    dict({
+      'imported': 'django.db.models',
+      'importer': 'django.contrib.admin.migrations.0001_initial',
+    }),
+    dict({
+      'imported': 'django.db.migrations',
+      'importer': 'django.contrib.admin.migrations.0002_logentry_remove_auto_add',
+    }),
+    dict({
+      'imported': 'django.db.models',
+      'importer': 'django.contrib.admin.migrations.0002_logentry_remove_auto_add',
+    }),
+    dict({
+      'imported': 'django.utils.timezone',
+      'importer': 'django.contrib.admin.migrations.0002_logentry_remove_auto_add',
+    }),
+    dict({
+      'imported': 'django.db.migrations',
+      'importer': 'django.contrib.admin.migrations.0003_logentry_add_action_flag_choices',
+    }),
+    dict({
+      'imported': 'django.db.models',
+      'importer': 'django.contrib.admin.migrations.0003_logentry_add_action_flag_choices',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.contrib.admin.models',
+    }),
+    dict({
+      'imported': 'django.contrib.admin.utils',
+      'importer': 'django.contrib.admin.models',
+    }),
+    dict({
+      'imported': 'django.contrib.contenttypes.models',
+      'importer': 'django.contrib.admin.models',
+    }),
+    dict({
+      'imported': 'django.db.models',
+      'importer': 'django.contrib.admin.models',
+    }),
+    dict({
+      'imported': 'django.urls',
+      'importer': 'django.contrib.admin.models',
+    }),
+    dict({
+      'imported': 'django.utils.text',
+      'importer': 'django.contrib.admin.models',
+    }),
+    dict({
+      'imported': 'django.utils.timezone',
+      'importer': 'django.contrib.admin.models',
+    }),
+    dict({
+      'imported': 'django.utils.translation',
+      'importer': 'django.contrib.admin.models',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.contrib.admin.options',
+    }),
+    dict({
+      'imported': 'django.contrib.admin.checks',
+      'importer': 'django.contrib.admin.options',
+    }),
+    dict({
+      'imported': 'django.contrib.admin.decorators',
+      'importer': 'django.contrib.admin.options',
+    }),
+    dict({
+      'imported': 'django.contrib.admin.exceptions',
+      'importer': 'django.contrib.admin.options',
+    }),
+    dict({
+      'imported': 'django.contrib.admin.filters',
+      'importer': 'django.contrib.admin.options',
+    }),
+    dict({
+      'imported': 'django.contrib.admin.helpers',
+      'importer': 'django.contrib.admin.options',
+    }),
+    dict({
+      'imported': 'django.contrib.admin.models',
+      'importer': 'django.contrib.admin.options',
+    }),
+    dict({
+      'imported': 'django.contrib.admin.templatetags.admin_urls',
+      'importer': 'django.contrib.admin.options',
+    }),
+    dict({
+      'imported': 'django.contrib.admin.utils',
+      'importer': 'django.contrib.admin.options',
+    }),
+    dict({
+      'imported': 'django.contrib.admin.views.main',
+      'importer': 'django.contrib.admin.options',
+    }),
+    dict({
+      'imported': 'django.contrib.admin.widgets',
+      'importer': 'django.contrib.admin.options',
+    }),
+    dict({
+      'imported': 'django.contrib.auth',
+      'importer': 'django.contrib.admin.options',
+    }),
+    dict({
+      'imported': 'django.contrib.contenttypes.models',
+      'importer': 'django.contrib.admin.options',
+    }),
+    dict({
+      'imported': 'django.contrib.messages',
+      'importer': 'django.contrib.admin.options',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.contrib.admin.options',
+    }),
+    dict({
+      'imported': 'django.core.paginator',
+      'importer': 'django.contrib.admin.options',
+    }),
+    dict({
+      'imported': 'django.db',
+      'importer': 'django.contrib.admin.options',
+    }),
+    dict({
+      'imported': 'django.db.models',
+      'importer': 'django.contrib.admin.options',
+    }),
+    dict({
+      'imported': 'django.db.models.constants',
+      'importer': 'django.contrib.admin.options',
+    }),
+    dict({
+      'imported': 'django.db.transaction',
+      'importer': 'django.contrib.admin.options',
+    }),
+    dict({
+      'imported': 'django.forms',
+      'importer': 'django.contrib.admin.options',
+    }),
+    dict({
+      'imported': 'django.forms.formsets',
+      'importer': 'django.contrib.admin.options',
+    }),
+    dict({
+      'imported': 'django.forms.models',
+      'importer': 'django.contrib.admin.options',
+    }),
+    dict({
+      'imported': 'django.forms.widgets',
+      'importer': 'django.contrib.admin.options',
+    }),
+    dict({
+      'imported': 'django.http',
+      'importer': 'django.contrib.admin.options',
+    }),
+    dict({
+      'imported': 'django.http.response',
+      'importer': 'django.contrib.admin.options',
+    }),
+    dict({
+      'imported': 'django.template.response',
+      'importer': 'django.contrib.admin.options',
+    }),
+    dict({
+      'imported': 'django.urls',
+      'importer': 'django.contrib.admin.options',
+    }),
+    dict({
+      'imported': 'django.utils.decorators',
+      'importer': 'django.contrib.admin.options',
+    }),
+    dict({
+      'imported': 'django.utils.html',
+      'importer': 'django.contrib.admin.options',
+    }),
+    dict({
+      'imported': 'django.utils.http',
+      'importer': 'django.contrib.admin.options',
+    }),
+    dict({
+      'imported': 'django.utils.safestring',
+      'importer': 'django.contrib.admin.options',
+    }),
+    dict({
+      'imported': 'django.utils.text',
+      'importer': 'django.contrib.admin.options',
+    }),
+    dict({
+      'imported': 'django.utils.translation',
+      'importer': 'django.contrib.admin.options',
+    }),
+    dict({
+      'imported': 'django.views.decorators.csrf',
+      'importer': 'django.contrib.admin.options',
+    }),
+    dict({
+      'imported': 'django.views.generic',
+      'importer': 'django.contrib.admin.options',
+    }),
+    dict({
+      'imported': 'django.apps',
+      'importer': 'django.contrib.admin.sites',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.contrib.admin.sites',
+    }),
+    dict({
+      'imported': 'django.contrib.admin',
+      'importer': 'django.contrib.admin.sites',
+    }),
+    dict({
+      'imported': 'django.contrib.admin.actions',
+      'importer': 'django.contrib.admin.sites',
+    }),
+    dict({
+      'imported': 'django.contrib.admin.forms',
+      'importer': 'django.contrib.admin.sites',
+    }),
+    dict({
+      'imported': 'django.contrib.admin.views.autocomplete',
+      'importer': 'django.contrib.admin.sites',
+    }),
+    dict({
+      'imported': 'django.contrib.auth',
+      'importer': 'django.contrib.admin.sites',
+    }),
+    dict({
+      'imported': 'django.contrib.auth.views',
+      'importer': 'django.contrib.admin.sites',
+    }),
+    dict({
+      'imported': 'django.contrib.contenttypes.views',
+      'importer': 'django.contrib.admin.sites',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.contrib.admin.sites',
+    }),
+    dict({
+      'imported': 'django.db.models.base',
+      'importer': 'django.contrib.admin.sites',
+    }),
+    dict({
+      'imported': 'django.http',
+      'importer': 'django.contrib.admin.sites',
+    }),
+    dict({
+      'imported': 'django.template.response',
+      'importer': 'django.contrib.admin.sites',
+    }),
+    dict({
+      'imported': 'django.urls',
+      'importer': 'django.contrib.admin.sites',
+    }),
+    dict({
+      'imported': 'django.utils.decorators',
+      'importer': 'django.contrib.admin.sites',
+    }),
+    dict({
+      'imported': 'django.utils.functional',
+      'importer': 'django.contrib.admin.sites',
+    }),
+    dict({
+      'imported': 'django.utils.module_loading',
+      'importer': 'django.contrib.admin.sites',
+    }),
+    dict({
+      'imported': 'django.utils.text',
+      'importer': 'django.contrib.admin.sites',
+    }),
+    dict({
+      'imported': 'django.utils.translation',
+      'importer': 'django.contrib.admin.sites',
+    }),
+    dict({
+      'imported': 'django.views.decorators.cache',
+      'importer': 'django.contrib.admin.sites',
+    }),
+    dict({
+      'imported': 'django.views.decorators.common',
+      'importer': 'django.contrib.admin.sites',
+    }),
+    dict({
+      'imported': 'django.views.decorators.csrf',
+      'importer': 'django.contrib.admin.sites',
+    }),
+    dict({
+      'imported': 'django.views.i18n',
+      'importer': 'django.contrib.admin.sites',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.contrib.admin.templatetags.admin_list',
+    }),
+    dict({
+      'imported': 'django.contrib.admin.templatetags.admin_urls',
+      'importer': 'django.contrib.admin.templatetags.admin_list',
+    }),
+    dict({
+      'imported': 'django.contrib.admin.templatetags.base',
+      'importer': 'django.contrib.admin.templatetags.admin_list',
+    }),
+    dict({
+      'imported': 'django.contrib.admin.utils',
+      'importer': 'django.contrib.admin.templatetags.admin_list',
+    }),
+    dict({
+      'imported': 'django.contrib.admin.views.main',
+      'importer': 'django.contrib.admin.templatetags.admin_list',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.contrib.admin.templatetags.admin_list',
+    }),
+    dict({
+      'imported': 'django.db.models',
+      'importer': 'django.contrib.admin.templatetags.admin_list',
+    }),
+    dict({
+      'imported': 'django.template',
+      'importer': 'django.contrib.admin.templatetags.admin_list',
+    }),
+    dict({
+      'imported': 'django.template.loader',
+      'importer': 'django.contrib.admin.templatetags.admin_list',
+    }),
+    dict({
+      'imported': 'django.templatetags.static',
+      'importer': 'django.contrib.admin.templatetags.admin_list',
+    }),
+    dict({
+      'imported': 'django.urls',
+      'importer': 'django.contrib.admin.templatetags.admin_list',
+    }),
+    dict({
+      'imported': 'django.utils.formats',
+      'importer': 'django.contrib.admin.templatetags.admin_list',
+    }),
+    dict({
+      'imported': 'django.utils.html',
+      'importer': 'django.contrib.admin.templatetags.admin_list',
+    }),
+    dict({
+      'imported': 'django.utils.safestring',
+      'importer': 'django.contrib.admin.templatetags.admin_list',
+    }),
+    dict({
+      'imported': 'django.utils.text',
+      'importer': 'django.contrib.admin.templatetags.admin_list',
+    }),
+    dict({
+      'imported': 'django.utils.timezone',
+      'importer': 'django.contrib.admin.templatetags.admin_list',
+    }),
+    dict({
+      'imported': 'django.utils.translation',
+      'importer': 'django.contrib.admin.templatetags.admin_list',
+    }),
+    dict({
+      'imported': 'django.contrib.admin.templatetags.base',
+      'importer': 'django.contrib.admin.templatetags.admin_modify',
+    }),
+    dict({
+      'imported': 'django.template',
+      'importer': 'django.contrib.admin.templatetags.admin_modify',
+    }),
+    dict({
+      'imported': 'django.template.context',
+      'importer': 'django.contrib.admin.templatetags.admin_modify',
+    }),
+    dict({
+      'imported': 'django.contrib.admin.options',
+      'importer': 'django.contrib.admin.templatetags.admin_urls',
+    }),
+    dict({
+      'imported': 'django.contrib.admin.utils',
+      'importer': 'django.contrib.admin.templatetags.admin_urls',
+    }),
+    dict({
+      'imported': 'django.template',
+      'importer': 'django.contrib.admin.templatetags.admin_urls',
+    }),
+    dict({
+      'imported': 'django.urls',
+      'importer': 'django.contrib.admin.templatetags.admin_urls',
+    }),
+    dict({
+      'imported': 'django.utils.http',
+      'importer': 'django.contrib.admin.templatetags.admin_urls',
+    }),
+    dict({
+      'imported': 'django.template.library',
+      'importer': 'django.contrib.admin.templatetags.base',
+    }),
+    dict({
+      'imported': 'django.contrib.admin.models',
+      'importer': 'django.contrib.admin.templatetags.log',
+    }),
+    dict({
+      'imported': 'django.template',
+      'importer': 'django.contrib.admin.templatetags.log',
+    }),
+    dict({
+      'imported': 'django.contrib.staticfiles.testing',
+      'importer': 'django.contrib.admin.tests',
+    }),
+    dict({
+      'imported': 'django.test',
+      'importer': 'django.contrib.admin.tests',
+    }),
+    dict({
+      'imported': 'django.test.selenium',
+      'importer': 'django.contrib.admin.tests',
+    }),
+    dict({
+      'imported': 'django.utils.deprecation',
+      'importer': 'django.contrib.admin.tests',
+    }),
+    dict({
+      'imported': 'django.utils.translation',
+      'importer': 'django.contrib.admin.tests',
+    }),
+    dict({
+      'imported': 'django.contrib.admin.templatetags.admin_list',
+      'importer': 'django.contrib.admin.utils',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.contrib.admin.utils',
+    }),
+    dict({
+      'imported': 'django.db',
+      'importer': 'django.contrib.admin.utils',
+    }),
+    dict({
+      'imported': 'django.db.models',
+      'importer': 'django.contrib.admin.utils',
+    }),
+    dict({
+      'imported': 'django.db.models.constants',
+      'importer': 'django.contrib.admin.utils',
+    }),
+    dict({
+      'imported': 'django.db.models.deletion',
+      'importer': 'django.contrib.admin.utils',
+    }),
+    dict({
+      'imported': 'django.forms.utils',
+      'importer': 'django.contrib.admin.utils',
+    }),
+    dict({
+      'imported': 'django.urls',
+      'importer': 'django.contrib.admin.utils',
+    }),
+    dict({
+      'imported': 'django.utils.formats',
+      'importer': 'django.contrib.admin.utils',
+    }),
+    dict({
+      'imported': 'django.utils.hashable',
+      'importer': 'django.contrib.admin.utils',
+    }),
+    dict({
+      'imported': 'django.utils.html',
+      'importer': 'django.contrib.admin.utils',
+    }),
+    dict({
+      'imported': 'django.utils.regex_helper',
+      'importer': 'django.contrib.admin.utils',
+    }),
+    dict({
+      'imported': 'django.utils.text',
+      'importer': 'django.contrib.admin.utils',
+    }),
+    dict({
+      'imported': 'django.utils.timezone',
+      'importer': 'django.contrib.admin.utils',
+    }),
+    dict({
+      'imported': 'django.utils.translation',
+      'importer': 'django.contrib.admin.utils',
+    }),
+    dict({
+      'imported': 'django.apps',
+      'importer': 'django.contrib.admin.views.autocomplete',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.contrib.admin.views.autocomplete',
+    }),
+    dict({
+      'imported': 'django.http',
+      'importer': 'django.contrib.admin.views.autocomplete',
+    }),
+    dict({
+      'imported': 'django.views.generic.list',
+      'importer': 'django.contrib.admin.views.autocomplete',
+    }),
+    dict({
+      'imported': 'django.contrib.auth',
+      'importer': 'django.contrib.admin.views.decorators',
+    }),
+    dict({
+      'imported': 'django.contrib.auth.decorators',
+      'importer': 'django.contrib.admin.views.decorators',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.contrib.admin.views.main',
+    }),
+    dict({
+      'imported': 'django.contrib.admin',
+      'importer': 'django.contrib.admin.views.main',
+    }),
+    dict({
+      'imported': 'django.contrib.admin.exceptions',
+      'importer': 'django.contrib.admin.views.main',
+    }),
+    dict({
+      'imported': 'django.contrib.admin.options',
+      'importer': 'django.contrib.admin.views.main',
+    }),
+    dict({
+      'imported': 'django.contrib.admin.utils',
+      'importer': 'django.contrib.admin.views.main',
+    }),
+    dict({
+      'imported': 'django.contrib.messages',
+      'importer': 'django.contrib.admin.views.main',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.contrib.admin.views.main',
+    }),
+    dict({
+      'imported': 'django.core.paginator',
+      'importer': 'django.contrib.admin.views.main',
+    }),
+    dict({
+      'imported': 'django.db.models',
+      'importer': 'django.contrib.admin.views.main',
+    }),
+    dict({
+      'imported': 'django.db.models.expressions',
+      'importer': 'django.contrib.admin.views.main',
+    }),
+    dict({
+      'imported': 'django.forms',
+      'importer': 'django.contrib.admin.views.main',
+    }),
+    dict({
+      'imported': 'django.urls',
+      'importer': 'django.contrib.admin.views.main',
+    }),
+    dict({
+      'imported': 'django.utils.http',
+      'importer': 'django.contrib.admin.views.main',
+    }),
+    dict({
+      'imported': 'django.utils.timezone',
+      'importer': 'django.contrib.admin.views.main',
+    }),
+    dict({
+      'imported': 'django.utils.translation',
+      'importer': 'django.contrib.admin.views.main',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.contrib.admin.widgets',
+    }),
+    dict({
+      'imported': 'django.contrib.admin.views.main',
+      'importer': 'django.contrib.admin.widgets',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.contrib.admin.widgets',
+    }),
+    dict({
+      'imported': 'django.core.validators',
+      'importer': 'django.contrib.admin.widgets',
+    }),
+    dict({
+      'imported': 'django.db.models',
+      'importer': 'django.contrib.admin.widgets',
+    }),
+    dict({
+      'imported': 'django.forms',
+      'importer': 'django.contrib.admin.widgets',
+    }),
+    dict({
+      'imported': 'django.urls',
+      'importer': 'django.contrib.admin.widgets',
+    }),
+    dict({
+      'imported': 'django.urls.exceptions',
+      'importer': 'django.contrib.admin.widgets',
+    }),
+    dict({
+      'imported': 'django.utils.html',
+      'importer': 'django.contrib.admin.widgets',
+    }),
+    dict({
+      'imported': 'django.utils.http',
+      'importer': 'django.contrib.admin.widgets',
+    }),
+    dict({
+      'imported': 'django.utils.text',
+      'importer': 'django.contrib.admin.widgets',
+    }),
+    dict({
+      'imported': 'django.utils.translation',
+      'importer': 'django.contrib.admin.widgets',
+    }),
+    dict({
+      'imported': 'django.apps',
+      'importer': 'django.contrib.admindocs.apps',
+    }),
+    dict({
+      'imported': 'django.utils.translation',
+      'importer': 'django.contrib.admindocs.apps',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.contrib.admindocs.middleware',
+    }),
+    dict({
+      'imported': 'django.contrib.admindocs.utils',
+      'importer': 'django.contrib.admindocs.middleware',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.contrib.admindocs.middleware',
+    }),
+    dict({
+      'imported': 'django.http',
+      'importer': 'django.contrib.admindocs.middleware',
+    }),
+    dict({
+      'imported': 'django.utils.deprecation',
+      'importer': 'django.contrib.admindocs.middleware',
+    }),
+    dict({
+      'imported': 'django.contrib.admindocs.views',
+      'importer': 'django.contrib.admindocs.urls',
+    }),
+    dict({
+      'imported': 'django.urls',
+      'importer': 'django.contrib.admindocs.urls',
+    }),
+    dict({
+      'imported': 'django.urls',
+      'importer': 'django.contrib.admindocs.utils',
+    }),
+    dict({
+      'imported': 'django.utils.regex_helper',
+      'importer': 'django.contrib.admindocs.utils',
+    }),
+    dict({
+      'imported': 'django.utils.safestring',
+      'importer': 'django.contrib.admindocs.utils',
+    }),
+    dict({
+      'imported': 'django.apps',
+      'importer': 'django.contrib.admindocs.views',
+    }),
+    dict({
+      'imported': 'django.contrib.admin',
+      'importer': 'django.contrib.admindocs.views',
+    }),
+    dict({
+      'imported': 'django.contrib.admin.views.decorators',
+      'importer': 'django.contrib.admindocs.views',
+    }),
+    dict({
+      'imported': 'django.contrib.admindocs.utils',
+      'importer': 'django.contrib.admindocs.views',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.contrib.admindocs.views',
+    }),
+    dict({
+      'imported': 'django.db.models',
+      'importer': 'django.contrib.admindocs.views',
+    }),
+    dict({
+      'imported': 'django.http',
+      'importer': 'django.contrib.admindocs.views',
+    }),
+    dict({
+      'imported': 'django.template.engine',
+      'importer': 'django.contrib.admindocs.views',
+    }),
+    dict({
+      'imported': 'django.urls',
+      'importer': 'django.contrib.admindocs.views',
+    }),
+    dict({
+      'imported': 'django.utils._os',
+      'importer': 'django.contrib.admindocs.views',
+    }),
+    dict({
+      'imported': 'django.utils.decorators',
+      'importer': 'django.contrib.admindocs.views',
+    }),
+    dict({
+      'imported': 'django.utils.functional',
+      'importer': 'django.contrib.admindocs.views',
+    }),
+    dict({
+      'imported': 'django.utils.inspect',
+      'importer': 'django.contrib.admindocs.views',
+    }),
+    dict({
+      'imported': 'django.utils.translation',
+      'importer': 'django.contrib.admindocs.views',
+    }),
+    dict({
+      'imported': 'django.views.generic',
+      'importer': 'django.contrib.admindocs.views',
+    }),
+    dict({
+      'imported': 'django.apps',
+      'importer': 'django.contrib.auth',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.contrib.auth',
+    }),
+    dict({
+      'imported': 'django.contrib.auth.models',
+      'importer': 'django.contrib.auth',
+    }),
+    dict({
+      'imported': 'django.contrib.auth.signals',
+      'importer': 'django.contrib.auth',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.contrib.auth',
+    }),
+    dict({
+      'imported': 'django.middleware.csrf',
+      'importer': 'django.contrib.auth',
+    }),
+    dict({
+      'imported': 'django.utils.crypto',
+      'importer': 'django.contrib.auth',
+    }),
+    dict({
+      'imported': 'django.utils.module_loading',
+      'importer': 'django.contrib.auth',
+    }),
+    dict({
+      'imported': 'django.views.decorators.debug',
+      'importer': 'django.contrib.auth',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.contrib.auth.admin',
+    }),
+    dict({
+      'imported': 'django.contrib.admin',
+      'importer': 'django.contrib.auth.admin',
+    }),
+    dict({
+      'imported': 'django.contrib.admin.options',
+      'importer': 'django.contrib.auth.admin',
+    }),
+    dict({
+      'imported': 'django.contrib.admin.utils',
+      'importer': 'django.contrib.auth.admin',
+    }),
+    dict({
+      'imported': 'django.contrib.auth',
+      'importer': 'django.contrib.auth.admin',
+    }),
+    dict({
+      'imported': 'django.contrib.auth.forms',
+      'importer': 'django.contrib.auth.admin',
+    }),
+    dict({
+      'imported': 'django.contrib.auth.models',
+      'importer': 'django.contrib.auth.admin',
+    }),
+    dict({
+      'imported': 'django.contrib.messages',
+      'importer': 'django.contrib.auth.admin',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.contrib.auth.admin',
+    }),
+    dict({
+      'imported': 'django.db',
+      'importer': 'django.contrib.auth.admin',
+    }),
+    dict({
+      'imported': 'django.db.transaction',
+      'importer': 'django.contrib.auth.admin',
+    }),
+    dict({
+      'imported': 'django.http',
+      'importer': 'django.contrib.auth.admin',
+    }),
+    dict({
+      'imported': 'django.template.response',
+      'importer': 'django.contrib.auth.admin',
+    }),
+    dict({
+      'imported': 'django.urls',
+      'importer': 'django.contrib.auth.admin',
+    }),
+    dict({
+      'imported': 'django.utils.decorators',
+      'importer': 'django.contrib.auth.admin',
+    }),
+    dict({
+      'imported': 'django.utils.html',
+      'importer': 'django.contrib.auth.admin',
+    }),
+    dict({
+      'imported': 'django.utils.translation',
+      'importer': 'django.contrib.auth.admin',
+    }),
+    dict({
+      'imported': 'django.views.decorators.csrf',
+      'importer': 'django.contrib.auth.admin',
+    }),
+    dict({
+      'imported': 'django.views.decorators.debug',
+      'importer': 'django.contrib.auth.admin',
+    }),
+    dict({
+      'imported': 'django.apps',
+      'importer': 'django.contrib.auth.apps',
+    }),
+    dict({
+      'imported': 'django.contrib.auth',
+      'importer': 'django.contrib.auth.apps',
+    }),
+    dict({
+      'imported': 'django.contrib.auth.checks',
+      'importer': 'django.contrib.auth.apps',
+    }),
+    dict({
+      'imported': 'django.contrib.auth.management',
+      'importer': 'django.contrib.auth.apps',
+    }),
+    dict({
+      'imported': 'django.contrib.auth.models',
+      'importer': 'django.contrib.auth.apps',
+    }),
+    dict({
+      'imported': 'django.contrib.auth.signals',
+      'importer': 'django.contrib.auth.apps',
+    }),
+    dict({
+      'imported': 'django.core.checks',
+      'importer': 'django.contrib.auth.apps',
+    }),
+    dict({
+      'imported': 'django.db.models.query_utils',
+      'importer': 'django.contrib.auth.apps',
+    }),
+    dict({
+      'imported': 'django.db.models.signals',
+      'importer': 'django.contrib.auth.apps',
+    }),
+    dict({
+      'imported': 'django.utils.translation',
+      'importer': 'django.contrib.auth.apps',
+    }),
+    dict({
+      'imported': 'django.contrib.auth',
+      'importer': 'django.contrib.auth.backends',
+    }),
+    dict({
+      'imported': 'django.contrib.auth.models',
+      'importer': 'django.contrib.auth.backends',
+    }),
+    dict({
+      'imported': 'django.db.models',
+      'importer': 'django.contrib.auth.backends',
+    }),
+    dict({
+      'imported': 'django.utils.deprecation',
+      'importer': 'django.contrib.auth.backends',
+    }),
+    dict({
+      'imported': 'django.utils.inspect',
+      'importer': 'django.contrib.auth.backends',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.contrib.auth.base_user',
+    }),
+    dict({
+      'imported': 'django.contrib.auth.hashers',
+      'importer': 'django.contrib.auth.base_user',
+    }),
+    dict({
+      'imported': 'django.contrib.auth.password_validation',
+      'importer': 'django.contrib.auth.base_user',
+    }),
+    dict({
+      'imported': 'django.db.models',
+      'importer': 'django.contrib.auth.base_user',
+    }),
+    dict({
+      'imported': 'django.utils.crypto',
+      'importer': 'django.contrib.auth.base_user',
+    }),
+    dict({
+      'imported': 'django.utils.deprecation',
+      'importer': 'django.contrib.auth.base_user',
+    }),
+    dict({
+      'imported': 'django.utils.translation',
+      'importer': 'django.contrib.auth.base_user',
+    }),
+    dict({
+      'imported': 'django.apps',
+      'importer': 'django.contrib.auth.checks',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.contrib.auth.checks',
+    }),
+    dict({
+      'imported': 'django.contrib.auth.management',
+      'importer': 'django.contrib.auth.checks',
+    }),
+    dict({
+      'imported': 'django.core.checks',
+      'importer': 'django.contrib.auth.checks',
+    }),
+    dict({
+      'imported': 'django.contrib.auth.models',
+      'importer': 'django.contrib.auth.context_processors',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.contrib.auth.decorators',
+    }),
+    dict({
+      'imported': 'django.contrib.auth',
+      'importer': 'django.contrib.auth.decorators',
+    }),
+    dict({
+      'imported': 'django.contrib.auth.views',
+      'importer': 'django.contrib.auth.decorators',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.contrib.auth.decorators',
+    }),
+    dict({
+      'imported': 'django.shortcuts',
+      'importer': 'django.contrib.auth.decorators',
+    }),
+    dict({
+      'imported': 'django.contrib.auth',
+      'importer': 'django.contrib.auth.forms',
+    }),
+    dict({
+      'imported': 'django.contrib.auth.hashers',
+      'importer': 'django.contrib.auth.forms',
+    }),
+    dict({
+      'imported': 'django.contrib.auth.models',
+      'importer': 'django.contrib.auth.forms',
+    }),
+    dict({
+      'imported': 'django.contrib.auth.password_validation',
+      'importer': 'django.contrib.auth.forms',
+    }),
+    dict({
+      'imported': 'django.contrib.auth.tokens',
+      'importer': 'django.contrib.auth.forms',
+    }),
+    dict({
+      'imported': 'django.contrib.sites.shortcuts',
+      'importer': 'django.contrib.auth.forms',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.contrib.auth.forms',
+    }),
+    dict({
+      'imported': 'django.core.mail',
+      'importer': 'django.contrib.auth.forms',
+    }),
+    dict({
+      'imported': 'django.forms',
+      'importer': 'django.contrib.auth.forms',
+    }),
+    dict({
+      'imported': 'django.template.loader',
+      'importer': 'django.contrib.auth.forms',
+    }),
+    dict({
+      'imported': 'django.utils.encoding',
+      'importer': 'django.contrib.auth.forms',
+    }),
+    dict({
+      'imported': 'django.utils.http',
+      'importer': 'django.contrib.auth.forms',
+    }),
+    dict({
+      'imported': 'django.utils.text',
+      'importer': 'django.contrib.auth.forms',
+    }),
+    dict({
+      'imported': 'django.utils.translation',
+      'importer': 'django.contrib.auth.forms',
+    }),
+    dict({
+      'imported': 'django.contrib.auth',
+      'importer': 'django.contrib.auth.handlers.modwsgi',
+    }),
+    dict({
+      'imported': 'django.db',
+      'importer': 'django.contrib.auth.handlers.modwsgi',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.contrib.auth.hashers',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.contrib.auth.hashers',
+    }),
+    dict({
+      'imported': 'django.core.signals',
+      'importer': 'django.contrib.auth.hashers',
+    }),
+    dict({
+      'imported': 'django.dispatch',
+      'importer': 'django.contrib.auth.hashers',
+    }),
+    dict({
+      'imported': 'django.utils.crypto',
+      'importer': 'django.contrib.auth.hashers',
+    }),
+    dict({
+      'imported': 'django.utils.deprecation',
+      'importer': 'django.contrib.auth.hashers',
+    }),
+    dict({
+      'imported': 'django.utils.module_loading',
+      'importer': 'django.contrib.auth.hashers',
+    }),
+    dict({
+      'imported': 'django.utils.translation',
+      'importer': 'django.contrib.auth.hashers',
+    }),
+    dict({
+      'imported': 'django.apps',
+      'importer': 'django.contrib.auth.management',
+    }),
+    dict({
+      'imported': 'django.contrib.auth',
+      'importer': 'django.contrib.auth.management',
+    }),
+    dict({
+      'imported': 'django.contrib.auth.models',
+      'importer': 'django.contrib.auth.management',
+    }),
+    dict({
+      'imported': 'django.contrib.contenttypes.management',
+      'importer': 'django.contrib.auth.management',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.contrib.auth.management',
+    }),
+    dict({
+      'imported': 'django.db',
+      'importer': 'django.contrib.auth.management',
+    }),
+    dict({
+      'imported': 'django.contrib.auth',
+      'importer': 'django.contrib.auth.management.commands.changepassword',
+    }),
+    dict({
+      'imported': 'django.contrib.auth.password_validation',
+      'importer': 'django.contrib.auth.management.commands.changepassword',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.contrib.auth.management.commands.changepassword',
+    }),
+    dict({
+      'imported': 'django.core.management.base',
+      'importer': 'django.contrib.auth.management.commands.changepassword',
+    }),
+    dict({
+      'imported': 'django.db',
+      'importer': 'django.contrib.auth.management.commands.changepassword',
+    }),
+    dict({
+      'imported': 'django.contrib.auth',
+      'importer': 'django.contrib.auth.management.commands.createsuperuser',
+    }),
+    dict({
+      'imported': 'django.contrib.auth.management',
+      'importer': 'django.contrib.auth.management.commands.createsuperuser',
+    }),
+    dict({
+      'imported': 'django.contrib.auth.password_validation',
+      'importer': 'django.contrib.auth.management.commands.createsuperuser',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.contrib.auth.management.commands.createsuperuser',
+    }),
+    dict({
+      'imported': 'django.core.management.base',
+      'importer': 'django.contrib.auth.management.commands.createsuperuser',
+    }),
+    dict({
+      'imported': 'django.db',
+      'importer': 'django.contrib.auth.management.commands.createsuperuser',
+    }),
+    dict({
+      'imported': 'django.utils.functional',
+      'importer': 'django.contrib.auth.management.commands.createsuperuser',
+    }),
+    dict({
+      'imported': 'django.utils.text',
+      'importer': 'django.contrib.auth.management.commands.createsuperuser',
+    }),
+    dict({
+      'imported': 'django.contrib.auth',
+      'importer': 'django.contrib.auth.middleware',
+    }),
+    dict({
+      'imported': 'django.contrib.auth.backends',
+      'importer': 'django.contrib.auth.middleware',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.contrib.auth.middleware',
+    }),
+    dict({
+      'imported': 'django.utils.deprecation',
+      'importer': 'django.contrib.auth.middleware',
+    }),
+    dict({
+      'imported': 'django.utils.functional',
+      'importer': 'django.contrib.auth.middleware',
+    }),
+    dict({
+      'imported': 'django.contrib.auth.models',
+      'importer': 'django.contrib.auth.migrations.0001_initial',
+    }),
+    dict({
+      'imported': 'django.contrib.auth.validators',
+      'importer': 'django.contrib.auth.migrations.0001_initial',
+    }),
+    dict({
+      'imported': 'django.db.migrations',
+      'importer': 'django.contrib.auth.migrations.0001_initial',
+    }),
+    dict({
+      'imported': 'django.db.models',
+      'importer': 'django.contrib.auth.migrations.0001_initial',
+    }),
+    dict({
+      'imported': 'django.utils.timezone',
+      'importer': 'django.contrib.auth.migrations.0001_initial',
+    }),
+    dict({
+      'imported': 'django.db.migrations',
+      'importer': 'django.contrib.auth.migrations.0002_alter_permission_name_max_length',
+    }),
+    dict({
+      'imported': 'django.db.models',
+      'importer': 'django.contrib.auth.migrations.0002_alter_permission_name_max_length',
+    }),
+    dict({
+      'imported': 'django.db.migrations',
+      'importer': 'django.contrib.auth.migrations.0003_alter_user_email_max_length',
+    }),
+    dict({
+      'imported': 'django.db.models',
+      'importer': 'django.contrib.auth.migrations.0003_alter_user_email_max_length',
+    }),
+    dict({
+      'imported': 'django.contrib.auth.validators',
+      'importer': 'django.contrib.auth.migrations.0004_alter_user_username_opts',
+    }),
+    dict({
+      'imported': 'django.db.migrations',
+      'importer': 'django.contrib.auth.migrations.0004_alter_user_username_opts',
+    }),
+    dict({
+      'imported': 'django.db.models',
+      'importer': 'django.contrib.auth.migrations.0004_alter_user_username_opts',
+    }),
+    dict({
+      'imported': 'django.db.migrations',
+      'importer': 'django.contrib.auth.migrations.0005_alter_user_last_login_null',
+    }),
+    dict({
+      'imported': 'django.db.models',
+      'importer': 'django.contrib.auth.migrations.0005_alter_user_last_login_null',
+    }),
+    dict({
+      'imported': 'django.db.migrations',
+      'importer': 'django.contrib.auth.migrations.0006_require_contenttypes_0002',
+    }),
+    dict({
+      'imported': 'django.contrib.auth.validators',
+      'importer': 'django.contrib.auth.migrations.0007_alter_validators_add_error_messages',
+    }),
+    dict({
+      'imported': 'django.db.migrations',
+      'importer': 'django.contrib.auth.migrations.0007_alter_validators_add_error_messages',
+    }),
+    dict({
+      'imported': 'django.db.models',
+      'importer': 'django.contrib.auth.migrations.0007_alter_validators_add_error_messages',
+    }),
+    dict({
+      'imported': 'django.contrib.auth.validators',
+      'importer': 'django.contrib.auth.migrations.0008_alter_user_username_max_length',
+    }),
+    dict({
+      'imported': 'django.db.migrations',
+      'importer': 'django.contrib.auth.migrations.0008_alter_user_username_max_length',
+    }),
+    dict({
+      'imported': 'django.db.models',
+      'importer': 'django.contrib.auth.migrations.0008_alter_user_username_max_length',
+    }),
+    dict({
+      'imported': 'django.db.migrations',
+      'importer': 'django.contrib.auth.migrations.0009_alter_user_last_name_max_length',
+    }),
+    dict({
+      'imported': 'django.db.models',
+      'importer': 'django.contrib.auth.migrations.0009_alter_user_last_name_max_length',
+    }),
+    dict({
+      'imported': 'django.db.migrations',
+      'importer': 'django.contrib.auth.migrations.0010_alter_group_name_max_length',
+    }),
+    dict({
+      'imported': 'django.db.models',
+      'importer': 'django.contrib.auth.migrations.0010_alter_group_name_max_length',
+    }),
+    dict({
+      'imported': 'django.core.management.color',
+      'importer': 'django.contrib.auth.migrations.0011_update_proxy_permissions',
+    }),
+    dict({
+      'imported': 'django.db',
+      'importer': 'django.contrib.auth.migrations.0011_update_proxy_permissions',
+    }),
+    dict({
+      'imported': 'django.db.migrations',
+      'importer': 'django.contrib.auth.migrations.0011_update_proxy_permissions',
+    }),
+    dict({
+      'imported': 'django.db.models',
+      'importer': 'django.contrib.auth.migrations.0011_update_proxy_permissions',
+    }),
+    dict({
+      'imported': 'django.db.transaction',
+      'importer': 'django.contrib.auth.migrations.0011_update_proxy_permissions',
+    }),
+    dict({
+      'imported': 'django.db.migrations',
+      'importer': 'django.contrib.auth.migrations.0012_alter_user_first_name_max_length',
+    }),
+    dict({
+      'imported': 'django.db.models',
+      'importer': 'django.contrib.auth.migrations.0012_alter_user_first_name_max_length',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.contrib.auth.mixins',
+    }),
+    dict({
+      'imported': 'django.contrib.auth',
+      'importer': 'django.contrib.auth.mixins',
+    }),
+    dict({
+      'imported': 'django.contrib.auth.views',
+      'importer': 'django.contrib.auth.mixins',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.contrib.auth.mixins',
+    }),
+    dict({
+      'imported': 'django.shortcuts',
+      'importer': 'django.contrib.auth.mixins',
+    }),
+    dict({
+      'imported': 'django.apps',
+      'importer': 'django.contrib.auth.models',
+    }),
+    dict({
+      'imported': 'django.contrib.auth',
+      'importer': 'django.contrib.auth.models',
+    }),
+    dict({
+      'imported': 'django.contrib.auth.base_user',
+      'importer': 'django.contrib.auth.models',
+    }),
+    dict({
+      'imported': 'django.contrib.auth.hashers',
+      'importer': 'django.contrib.auth.models',
+    }),
+    dict({
+      'imported': 'django.contrib.auth.validators',
+      'importer': 'django.contrib.auth.models',
+    }),
+    dict({
+      'imported': 'django.contrib.contenttypes.models',
+      'importer': 'django.contrib.auth.models',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.contrib.auth.models',
+    }),
+    dict({
+      'imported': 'django.core.mail',
+      'importer': 'django.contrib.auth.models',
+    }),
+    dict({
+      'imported': 'django.db.models',
+      'importer': 'django.contrib.auth.models',
+    }),
+    dict({
+      'imported': 'django.db.models.manager',
+      'importer': 'django.contrib.auth.models',
+    }),
+    dict({
+      'imported': 'django.utils.itercompat',
+      'importer': 'django.contrib.auth.models',
+    }),
+    dict({
+      'imported': 'django.utils.timezone',
+      'importer': 'django.contrib.auth.models',
+    }),
+    dict({
+      'imported': 'django.utils.translation',
+      'importer': 'django.contrib.auth.models',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.contrib.auth.password_validation',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.contrib.auth.password_validation',
+    }),
+    dict({
+      'imported': 'django.utils.functional',
+      'importer': 'django.contrib.auth.password_validation',
+    }),
+    dict({
+      'imported': 'django.utils.html',
+      'importer': 'django.contrib.auth.password_validation',
+    }),
+    dict({
+      'imported': 'django.utils.module_loading',
+      'importer': 'django.contrib.auth.password_validation',
+    }),
+    dict({
+      'imported': 'django.utils.translation',
+      'importer': 'django.contrib.auth.password_validation',
+    }),
+    dict({
+      'imported': 'django.dispatch',
+      'importer': 'django.contrib.auth.signals',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.contrib.auth.tokens',
+    }),
+    dict({
+      'imported': 'django.utils.crypto',
+      'importer': 'django.contrib.auth.tokens',
+    }),
+    dict({
+      'imported': 'django.utils.http',
+      'importer': 'django.contrib.auth.tokens',
+    }),
+    dict({
+      'imported': 'django.contrib.auth.views',
+      'importer': 'django.contrib.auth.urls',
+    }),
+    dict({
+      'imported': 'django.urls',
+      'importer': 'django.contrib.auth.urls',
+    }),
+    dict({
+      'imported': 'django.core.validators',
+      'importer': 'django.contrib.auth.validators',
+    }),
+    dict({
+      'imported': 'django.utils.deconstruct',
+      'importer': 'django.contrib.auth.validators',
+    }),
+    dict({
+      'imported': 'django.utils.translation',
+      'importer': 'django.contrib.auth.validators',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.contrib.auth.views',
+    }),
+    dict({
+      'imported': 'django.contrib.auth',
+      'importer': 'django.contrib.auth.views',
+    }),
+    dict({
+      'imported': 'django.contrib.auth.decorators',
+      'importer': 'django.contrib.auth.views',
+    }),
+    dict({
+      'imported': 'django.contrib.auth.forms',
+      'importer': 'django.contrib.auth.views',
+    }),
+    dict({
+      'imported': 'django.contrib.auth.tokens',
+      'importer': 'django.contrib.auth.views',
+    }),
+    dict({
+      'imported': 'django.contrib.sites.shortcuts',
+      'importer': 'django.contrib.auth.views',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.contrib.auth.views',
+    }),
+    dict({
+      'imported': 'django.http',
+      'importer': 'django.contrib.auth.views',
+    }),
+    dict({
+      'imported': 'django.shortcuts',
+      'importer': 'django.contrib.auth.views',
+    }),
+    dict({
+      'imported': 'django.urls',
+      'importer': 'django.contrib.auth.views',
+    }),
+    dict({
+      'imported': 'django.utils.decorators',
+      'importer': 'django.contrib.auth.views',
+    }),
+    dict({
+      'imported': 'django.utils.deprecation',
+      'importer': 'django.contrib.auth.views',
+    }),
+    dict({
+      'imported': 'django.utils.http',
+      'importer': 'django.contrib.auth.views',
+    }),
+    dict({
+      'imported': 'django.utils.translation',
+      'importer': 'django.contrib.auth.views',
+    }),
+    dict({
+      'imported': 'django.views.decorators.cache',
+      'importer': 'django.contrib.auth.views',
+    }),
+    dict({
+      'imported': 'django.views.decorators.csrf',
+      'importer': 'django.contrib.auth.views',
+    }),
+    dict({
+      'imported': 'django.views.decorators.debug',
+      'importer': 'django.contrib.auth.views',
+    }),
+    dict({
+      'imported': 'django.views.generic.base',
+      'importer': 'django.contrib.auth.views',
+    }),
+    dict({
+      'imported': 'django.views.generic.edit',
+      'importer': 'django.contrib.auth.views',
+    }),
+    dict({
+      'imported': 'django.contrib.admin.checks',
+      'importer': 'django.contrib.contenttypes.admin',
+    }),
+    dict({
+      'imported': 'django.contrib.admin.options',
+      'importer': 'django.contrib.contenttypes.admin',
+    }),
+    dict({
+      'imported': 'django.contrib.contenttypes.fields',
+      'importer': 'django.contrib.contenttypes.admin',
+    }),
+    dict({
+      'imported': 'django.contrib.contenttypes.forms',
+      'importer': 'django.contrib.contenttypes.admin',
+    }),
+    dict({
+      'imported': 'django.core.checks',
+      'importer': 'django.contrib.contenttypes.admin',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.contrib.contenttypes.admin',
+    }),
+    dict({
+      'imported': 'django.forms',
+      'importer': 'django.contrib.contenttypes.admin',
+    }),
+    dict({
+      'imported': 'django.forms.models',
+      'importer': 'django.contrib.contenttypes.admin',
+    }),
+    dict({
+      'imported': 'django.apps',
+      'importer': 'django.contrib.contenttypes.apps',
+    }),
+    dict({
+      'imported': 'django.contrib.contenttypes.checks',
+      'importer': 'django.contrib.contenttypes.apps',
+    }),
+    dict({
+      'imported': 'django.contrib.contenttypes.management',
+      'importer': 'django.contrib.contenttypes.apps',
+    }),
+    dict({
+      'imported': 'django.core.checks',
+      'importer': 'django.contrib.contenttypes.apps',
+    }),
+    dict({
+      'imported': 'django.db.models.signals',
+      'importer': 'django.contrib.contenttypes.apps',
+    }),
+    dict({
+      'imported': 'django.utils.translation',
+      'importer': 'django.contrib.contenttypes.apps',
+    }),
+    dict({
+      'imported': 'django.apps',
+      'importer': 'django.contrib.contenttypes.checks',
+    }),
+    dict({
+      'imported': 'django.contrib.contenttypes.fields',
+      'importer': 'django.contrib.contenttypes.checks',
+    }),
+    dict({
+      'imported': 'django.core.checks',
+      'importer': 'django.contrib.contenttypes.checks',
+    }),
+    dict({
+      'imported': 'django.contrib.contenttypes.models',
+      'importer': 'django.contrib.contenttypes.fields',
+    }),
+    dict({
+      'imported': 'django.core.checks',
+      'importer': 'django.contrib.contenttypes.fields',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.contrib.contenttypes.fields',
+    }),
+    dict({
+      'imported': 'django.db',
+      'importer': 'django.contrib.contenttypes.fields',
+    }),
+    dict({
+      'imported': 'django.db.models',
+      'importer': 'django.contrib.contenttypes.fields',
+    }),
+    dict({
+      'imported': 'django.db.models.base',
+      'importer': 'django.contrib.contenttypes.fields',
+    }),
+    dict({
+      'imported': 'django.db.models.fields.mixins',
+      'importer': 'django.contrib.contenttypes.fields',
+    }),
+    dict({
+      'imported': 'django.db.models.fields.related',
+      'importer': 'django.contrib.contenttypes.fields',
+    }),
+    dict({
+      'imported': 'django.db.models.query_utils',
+      'importer': 'django.contrib.contenttypes.fields',
+    }),
+    dict({
+      'imported': 'django.db.models.sql',
+      'importer': 'django.contrib.contenttypes.fields',
+    }),
+    dict({
+      'imported': 'django.db.models.sql.where',
+      'importer': 'django.contrib.contenttypes.fields',
+    }),
+    dict({
+      'imported': 'django.db.models.utils',
+      'importer': 'django.contrib.contenttypes.fields',
+    }),
+    dict({
+      'imported': 'django.db.transaction',
+      'importer': 'django.contrib.contenttypes.fields',
+    }),
+    dict({
+      'imported': 'django.utils.functional',
+      'importer': 'django.contrib.contenttypes.fields',
+    }),
+    dict({
+      'imported': 'django.contrib.contenttypes.models',
+      'importer': 'django.contrib.contenttypes.forms',
+    }),
+    dict({
+      'imported': 'django.db.models',
+      'importer': 'django.contrib.contenttypes.forms',
+    }),
+    dict({
+      'imported': 'django.forms',
+      'importer': 'django.contrib.contenttypes.forms',
+    }),
+    dict({
+      'imported': 'django.forms.models',
+      'importer': 'django.contrib.contenttypes.forms',
+    }),
+    dict({
+      'imported': 'django.apps',
+      'importer': 'django.contrib.contenttypes.management',
+    }),
+    dict({
+      'imported': 'django.db',
+      'importer': 'django.contrib.contenttypes.management',
+    }),
+    dict({
+      'imported': 'django.db.migrations',
+      'importer': 'django.contrib.contenttypes.management',
+    }),
+    dict({
+      'imported': 'django.db.transaction',
+      'importer': 'django.contrib.contenttypes.management',
+    }),
+    dict({
+      'imported': 'django.apps',
+      'importer': 'django.contrib.contenttypes.management.commands.remove_stale_contenttypes',
+    }),
+    dict({
+      'imported': 'django.contrib.contenttypes.models',
+      'importer': 'django.contrib.contenttypes.management.commands.remove_stale_contenttypes',
+    }),
+    dict({
+      'imported': 'django.core.management',
+      'importer': 'django.contrib.contenttypes.management.commands.remove_stale_contenttypes',
+    }),
+    dict({
+      'imported': 'django.db',
+      'importer': 'django.contrib.contenttypes.management.commands.remove_stale_contenttypes',
+    }),
+    dict({
+      'imported': 'django.db.models.deletion',
+      'importer': 'django.contrib.contenttypes.management.commands.remove_stale_contenttypes',
+    }),
+    dict({
+      'imported': 'django.contrib.contenttypes.models',
+      'importer': 'django.contrib.contenttypes.migrations.0001_initial',
+    }),
+    dict({
+      'imported': 'django.db.migrations',
+      'importer': 'django.contrib.contenttypes.migrations.0001_initial',
+    }),
+    dict({
+      'imported': 'django.db.models',
+      'importer': 'django.contrib.contenttypes.migrations.0001_initial',
+    }),
+    dict({
+      'imported': 'django.db.migrations',
+      'importer': 'django.contrib.contenttypes.migrations.0002_remove_content_type_name',
+    }),
+    dict({
+      'imported': 'django.db.models',
+      'importer': 'django.contrib.contenttypes.migrations.0002_remove_content_type_name',
+    }),
+    dict({
+      'imported': 'django.apps',
+      'importer': 'django.contrib.contenttypes.models',
+    }),
+    dict({
+      'imported': 'django.db.models',
+      'importer': 'django.contrib.contenttypes.models',
+    }),
+    dict({
+      'imported': 'django.utils.translation',
+      'importer': 'django.contrib.contenttypes.models',
+    }),
+    dict({
+      'imported': 'django.apps',
+      'importer': 'django.contrib.contenttypes.views',
+    }),
+    dict({
+      'imported': 'django.contrib.contenttypes.models',
+      'importer': 'django.contrib.contenttypes.views',
+    }),
+    dict({
+      'imported': 'django.contrib.sites.shortcuts',
+      'importer': 'django.contrib.contenttypes.views',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.contrib.contenttypes.views',
+    }),
+    dict({
+      'imported': 'django.http',
+      'importer': 'django.contrib.contenttypes.views',
+    }),
+    dict({
+      'imported': 'django.utils.translation',
+      'importer': 'django.contrib.contenttypes.views',
+    }),
+    dict({
+      'imported': 'django.contrib.admin',
+      'importer': 'django.contrib.flatpages.admin',
+    }),
+    dict({
+      'imported': 'django.contrib.flatpages.forms',
+      'importer': 'django.contrib.flatpages.admin',
+    }),
+    dict({
+      'imported': 'django.contrib.flatpages.models',
+      'importer': 'django.contrib.flatpages.admin',
+    }),
+    dict({
+      'imported': 'django.utils.translation',
+      'importer': 'django.contrib.flatpages.admin',
+    }),
+    dict({
+      'imported': 'django.apps',
+      'importer': 'django.contrib.flatpages.apps',
+    }),
+    dict({
+      'imported': 'django.utils.translation',
+      'importer': 'django.contrib.flatpages.apps',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.contrib.flatpages.forms',
+    }),
+    dict({
+      'imported': 'django.contrib.flatpages.models',
+      'importer': 'django.contrib.flatpages.forms',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.contrib.flatpages.forms',
+    }),
+    dict({
+      'imported': 'django.forms',
+      'importer': 'django.contrib.flatpages.forms',
+    }),
+    dict({
+      'imported': 'django.utils.translation',
+      'importer': 'django.contrib.flatpages.forms',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.contrib.flatpages.middleware',
+    }),
+    dict({
+      'imported': 'django.contrib.flatpages.views',
+      'importer': 'django.contrib.flatpages.middleware',
+    }),
+    dict({
+      'imported': 'django.http',
+      'importer': 'django.contrib.flatpages.middleware',
+    }),
+    dict({
+      'imported': 'django.utils.deprecation',
+      'importer': 'django.contrib.flatpages.middleware',
+    }),
+    dict({
+      'imported': 'django.db.migrations',
+      'importer': 'django.contrib.flatpages.migrations.0001_initial',
+    }),
+    dict({
+      'imported': 'django.db.models',
+      'importer': 'django.contrib.flatpages.migrations.0001_initial',
+    }),
+    dict({
+      'imported': 'django.contrib.flatpages.views',
+      'importer': 'django.contrib.flatpages.models',
+    }),
+    dict({
+      'imported': 'django.contrib.sites.models',
+      'importer': 'django.contrib.flatpages.models',
+    }),
+    dict({
+      'imported': 'django.db.models',
+      'importer': 'django.contrib.flatpages.models',
+    }),
+    dict({
+      'imported': 'django.urls',
+      'importer': 'django.contrib.flatpages.models',
+    }),
+    dict({
+      'imported': 'django.utils.encoding',
+      'importer': 'django.contrib.flatpages.models',
+    }),
+    dict({
+      'imported': 'django.utils.translation',
+      'importer': 'django.contrib.flatpages.models',
+    }),
+    dict({
+      'imported': 'django.apps',
+      'importer': 'django.contrib.flatpages.sitemaps',
+    }),
+    dict({
+      'imported': 'django.contrib.sitemaps',
+      'importer': 'django.contrib.flatpages.sitemaps',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.contrib.flatpages.sitemaps',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.contrib.flatpages.templatetags.flatpages',
+    }),
+    dict({
+      'imported': 'django.contrib.flatpages.models',
+      'importer': 'django.contrib.flatpages.templatetags.flatpages',
+    }),
+    dict({
+      'imported': 'django.contrib.sites.shortcuts',
+      'importer': 'django.contrib.flatpages.templatetags.flatpages',
+    }),
+    dict({
+      'imported': 'django.template',
+      'importer': 'django.contrib.flatpages.templatetags.flatpages',
+    }),
+    dict({
+      'imported': 'django.contrib.flatpages.views',
+      'importer': 'django.contrib.flatpages.urls',
+    }),
+    dict({
+      'imported': 'django.urls',
+      'importer': 'django.contrib.flatpages.urls',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.contrib.flatpages.views',
+    }),
+    dict({
+      'imported': 'django.contrib.auth.views',
+      'importer': 'django.contrib.flatpages.views',
+    }),
+    dict({
+      'imported': 'django.contrib.flatpages.models',
+      'importer': 'django.contrib.flatpages.views',
+    }),
+    dict({
+      'imported': 'django.contrib.sites.shortcuts',
+      'importer': 'django.contrib.flatpages.views',
+    }),
+    dict({
+      'imported': 'django.http',
+      'importer': 'django.contrib.flatpages.views',
+    }),
+    dict({
+      'imported': 'django.shortcuts',
+      'importer': 'django.contrib.flatpages.views',
+    }),
+    dict({
+      'imported': 'django.template.loader',
+      'importer': 'django.contrib.flatpages.views',
+    }),
+    dict({
+      'imported': 'django.utils.safestring',
+      'importer': 'django.contrib.flatpages.views',
+    }),
+    dict({
+      'imported': 'django.views.decorators.csrf',
+      'importer': 'django.contrib.flatpages.views',
+    }),
+    dict({
+      'imported': 'django.contrib.admin',
+      'importer': 'django.contrib.gis.admin',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.admin.options',
+      'importer': 'django.contrib.gis.admin',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.admin.widgets',
+      'importer': 'django.contrib.gis.admin',
+    }),
+    dict({
+      'imported': 'django.contrib.admin',
+      'importer': 'django.contrib.gis.admin.options',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.admin.widgets',
+      'importer': 'django.contrib.gis.admin.options',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.db.models',
+      'importer': 'django.contrib.gis.admin.options',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.forms',
+      'importer': 'django.contrib.gis.admin.options',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.gdal',
+      'importer': 'django.contrib.gis.admin.options',
+    }),
+    dict({
+      'imported': 'django.forms',
+      'importer': 'django.contrib.gis.admin.options',
+    }),
+    dict({
+      'imported': 'django.utils.deprecation',
+      'importer': 'django.contrib.gis.admin.options',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.gdal',
+      'importer': 'django.contrib.gis.admin.widgets',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.geos',
+      'importer': 'django.contrib.gis.admin.widgets',
+    }),
+    dict({
+      'imported': 'django.forms.widgets',
+      'importer': 'django.contrib.gis.admin.widgets',
+    }),
+    dict({
+      'imported': 'django.utils.deprecation',
+      'importer': 'django.contrib.gis.admin.widgets',
+    }),
+    dict({
+      'imported': 'django.utils.translation',
+      'importer': 'django.contrib.gis.admin.widgets',
+    }),
+    dict({
+      'imported': 'django.apps',
+      'importer': 'django.contrib.gis.apps',
+    }),
+    dict({
+      'imported': 'django.core.serializers',
+      'importer': 'django.contrib.gis.apps',
+    }),
+    dict({
+      'imported': 'django.utils.translation',
+      'importer': 'django.contrib.gis.apps',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.db.models',
+      'importer': 'django.contrib.gis.db.backends.base.features',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.gdal',
+      'importer': 'django.contrib.gis.db.backends.base.models',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.db.models',
+      'importer': 'django.contrib.gis.db.backends.base.operations',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.db.models.functions',
+      'importer': 'django.contrib.gis.db.backends.base.operations',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.measure',
+      'importer': 'django.contrib.gis.db.backends.base.operations',
+    }),
+    dict({
+      'imported': 'django.db',
+      'importer': 'django.contrib.gis.db.backends.base.operations',
+    }),
+    dict({
+      'imported': 'django.utils.functional',
+      'importer': 'django.contrib.gis.db.backends.base.operations',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.db.backends.mysql.features',
+      'importer': 'django.contrib.gis.db.backends.mysql.base',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.db.backends.mysql.introspection',
+      'importer': 'django.contrib.gis.db.backends.mysql.base',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.db.backends.mysql.operations',
+      'importer': 'django.contrib.gis.db.backends.mysql.base',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.db.backends.mysql.schema',
+      'importer': 'django.contrib.gis.db.backends.mysql.base',
+    }),
+    dict({
+      'imported': 'django.db.backends.mysql.base',
+      'importer': 'django.contrib.gis.db.backends.mysql.base',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.db.backends.base.features',
+      'importer': 'django.contrib.gis.db.backends.mysql.features',
+    }),
+    dict({
+      'imported': 'django.db.backends.mysql.features',
+      'importer': 'django.contrib.gis.db.backends.mysql.features',
+    }),
+    dict({
+      'imported': 'django.utils.functional',
+      'importer': 'django.contrib.gis.db.backends.mysql.features',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.gdal',
+      'importer': 'django.contrib.gis.db.backends.mysql.introspection',
+    }),
+    dict({
+      'imported': 'django.db.backends.mysql.introspection',
+      'importer': 'django.contrib.gis.db.backends.mysql.introspection',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.db.backends.base.adapter',
+      'importer': 'django.contrib.gis.db.backends.mysql.operations',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.db.backends.base.operations',
+      'importer': 'django.contrib.gis.db.backends.mysql.operations',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.db.backends.utils',
+      'importer': 'django.contrib.gis.db.backends.mysql.operations',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.db.models',
+      'importer': 'django.contrib.gis.db.backends.mysql.operations',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.geos.geometry',
+      'importer': 'django.contrib.gis.db.backends.mysql.operations',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.geos.prototypes.io',
+      'importer': 'django.contrib.gis.db.backends.mysql.operations',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.measure',
+      'importer': 'django.contrib.gis.db.backends.mysql.operations',
+    }),
+    dict({
+      'imported': 'django.db.backends.mysql.operations',
+      'importer': 'django.contrib.gis.db.backends.mysql.operations',
+    }),
+    dict({
+      'imported': 'django.utils.functional',
+      'importer': 'django.contrib.gis.db.backends.mysql.operations',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.db.models',
+      'importer': 'django.contrib.gis.db.backends.mysql.schema',
+    }),
+    dict({
+      'imported': 'django.db',
+      'importer': 'django.contrib.gis.db.backends.mysql.schema',
+    }),
+    dict({
+      'imported': 'django.db.backends.mysql.schema',
+      'importer': 'django.contrib.gis.db.backends.mysql.schema',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.db.backends.base.adapter',
+      'importer': 'django.contrib.gis.db.backends.oracle.adapter',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.geos',
+      'importer': 'django.contrib.gis.db.backends.oracle.adapter',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.db.backends.oracle.features',
+      'importer': 'django.contrib.gis.db.backends.oracle.base',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.db.backends.oracle.introspection',
+      'importer': 'django.contrib.gis.db.backends.oracle.base',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.db.backends.oracle.operations',
+      'importer': 'django.contrib.gis.db.backends.oracle.base',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.db.backends.oracle.schema',
+      'importer': 'django.contrib.gis.db.backends.oracle.base',
+    }),
+    dict({
+      'imported': 'django.db.backends.oracle.base',
+      'importer': 'django.contrib.gis.db.backends.oracle.base',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.db.backends.base.features',
+      'importer': 'django.contrib.gis.db.backends.oracle.features',
+    }),
+    dict({
+      'imported': 'django.db.backends.oracle.features',
+      'importer': 'django.contrib.gis.db.backends.oracle.features',
+    }),
+    dict({
+      'imported': 'django.utils.functional',
+      'importer': 'django.contrib.gis.db.backends.oracle.features',
+    }),
+    dict({
+      'imported': 'django.db.backends.oracle.introspection',
+      'importer': 'django.contrib.gis.db.backends.oracle.introspection',
+    }),
+    dict({
+      'imported': 'django.utils.functional',
+      'importer': 'django.contrib.gis.db.backends.oracle.introspection',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.db.backends.base.models',
+      'importer': 'django.contrib.gis.db.backends.oracle.models',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.db.models',
+      'importer': 'django.contrib.gis.db.backends.oracle.models',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.db.backends.base.operations',
+      'importer': 'django.contrib.gis.db.backends.oracle.operations',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.db.backends.oracle.adapter',
+      'importer': 'django.contrib.gis.db.backends.oracle.operations',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.db.backends.oracle.models',
+      'importer': 'django.contrib.gis.db.backends.oracle.operations',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.db.backends.utils',
+      'importer': 'django.contrib.gis.db.backends.oracle.operations',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.db.models',
+      'importer': 'django.contrib.gis.db.backends.oracle.operations',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.geos.geometry',
+      'importer': 'django.contrib.gis.db.backends.oracle.operations',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.geos.prototypes.io',
+      'importer': 'django.contrib.gis.db.backends.oracle.operations',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.measure',
+      'importer': 'django.contrib.gis.db.backends.oracle.operations',
+    }),
+    dict({
+      'imported': 'django.db.backends.oracle.operations',
+      'importer': 'django.contrib.gis.db.backends.oracle.operations',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.db.models',
+      'importer': 'django.contrib.gis.db.backends.oracle.schema',
+    }),
+    dict({
+      'imported': 'django.db.backends.oracle.schema',
+      'importer': 'django.contrib.gis.db.backends.oracle.schema',
+    }),
+    dict({
+      'imported': 'django.db.backends.utils',
+      'importer': 'django.contrib.gis.db.backends.oracle.schema',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.db.backends.postgis.pgraster',
+      'importer': 'django.contrib.gis.db.backends.postgis.adapter',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.geos',
+      'importer': 'django.contrib.gis.db.backends.postgis.adapter',
+    }),
+    dict({
+      'imported': 'django.db.backends.postgresql.psycopg_any',
+      'importer': 'django.contrib.gis.db.backends.postgis.adapter',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.db.backends.postgis.adapter',
+      'importer': 'django.contrib.gis.db.backends.postgis.base',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.db.backends.postgis.features',
+      'importer': 'django.contrib.gis.db.backends.postgis.base',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.db.backends.postgis.introspection',
+      'importer': 'django.contrib.gis.db.backends.postgis.base',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.db.backends.postgis.operations',
+      'importer': 'django.contrib.gis.db.backends.postgis.base',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.db.backends.postgis.schema',
+      'importer': 'django.contrib.gis.db.backends.postgis.base',
+    }),
+    dict({
+      'imported': 'django.db.backends.base.base',
+      'importer': 'django.contrib.gis.db.backends.postgis.base',
+    }),
+    dict({
+      'imported': 'django.db.backends.postgresql.base',
+      'importer': 'django.contrib.gis.db.backends.postgis.base',
+    }),
+    dict({
+      'imported': 'django.db.backends.postgresql.psycopg_any',
+      'importer': 'django.contrib.gis.db.backends.postgis.base',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.db.backends.base.features',
+      'importer': 'django.contrib.gis.db.backends.postgis.features',
+    }),
+    dict({
+      'imported': 'django.db.backends.postgresql.features',
+      'importer': 'django.contrib.gis.db.backends.postgis.features',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.gdal',
+      'importer': 'django.contrib.gis.db.backends.postgis.introspection',
+    }),
+    dict({
+      'imported': 'django.db.backends.postgresql.introspection',
+      'importer': 'django.contrib.gis.db.backends.postgis.introspection',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.db.backends.base.models',
+      'importer': 'django.contrib.gis.db.backends.postgis.models',
+    }),
+    dict({
+      'imported': 'django.db.models',
+      'importer': 'django.contrib.gis.db.backends.postgis.models',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.contrib.gis.db.backends.postgis.operations',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.db.backends.base.operations',
+      'importer': 'django.contrib.gis.db.backends.postgis.operations',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.db.backends.postgis.adapter',
+      'importer': 'django.contrib.gis.db.backends.postgis.operations',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.db.backends.postgis.models',
+      'importer': 'django.contrib.gis.db.backends.postgis.operations',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.db.backends.postgis.pgraster',
+      'importer': 'django.contrib.gis.db.backends.postgis.operations',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.db.backends.utils',
+      'importer': 'django.contrib.gis.db.backends.postgis.operations',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.db.models',
+      'importer': 'django.contrib.gis.db.backends.postgis.operations',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.gdal',
+      'importer': 'django.contrib.gis.db.backends.postgis.operations',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.geos.geometry',
+      'importer': 'django.contrib.gis.db.backends.postgis.operations',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.geos.prototypes.io',
+      'importer': 'django.contrib.gis.db.backends.postgis.operations',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.measure',
+      'importer': 'django.contrib.gis.db.backends.postgis.operations',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.contrib.gis.db.backends.postgis.operations',
+    }),
+    dict({
+      'imported': 'django.db',
+      'importer': 'django.contrib.gis.db.backends.postgis.operations',
+    }),
+    dict({
+      'imported': 'django.db.backends.postgresql.operations',
+      'importer': 'django.contrib.gis.db.backends.postgis.operations',
+    }),
+    dict({
+      'imported': 'django.db.backends.postgresql.psycopg_any',
+      'importer': 'django.contrib.gis.db.backends.postgis.operations',
+    }),
+    dict({
+      'imported': 'django.db.models',
+      'importer': 'django.contrib.gis.db.backends.postgis.operations',
+    }),
+    dict({
+      'imported': 'django.utils.functional',
+      'importer': 'django.contrib.gis.db.backends.postgis.operations',
+    }),
+    dict({
+      'imported': 'django.utils.version',
+      'importer': 'django.contrib.gis.db.backends.postgis.operations',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.db.backends.postgis.const',
+      'importer': 'django.contrib.gis.db.backends.postgis.pgraster',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.contrib.gis.db.backends.postgis.pgraster',
+    }),
+    dict({
+      'imported': 'django.db.backends.postgresql.schema',
+      'importer': 'django.contrib.gis.db.backends.postgis.schema',
+    }),
+    dict({
+      'imported': 'django.db.models.expressions',
+      'importer': 'django.contrib.gis.db.backends.postgis.schema',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.db.backends.base.adapter',
+      'importer': 'django.contrib.gis.db.backends.spatialite.adapter',
+    }),
+    dict({
+      'imported': 'django.db.backends.sqlite3.base',
+      'importer': 'django.contrib.gis.db.backends.spatialite.adapter',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.contrib.gis.db.backends.spatialite.base',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.db.backends.spatialite.client',
+      'importer': 'django.contrib.gis.db.backends.spatialite.base',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.db.backends.spatialite.features',
+      'importer': 'django.contrib.gis.db.backends.spatialite.base',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.db.backends.spatialite.introspection',
+      'importer': 'django.contrib.gis.db.backends.spatialite.base',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.db.backends.spatialite.operations',
+      'importer': 'django.contrib.gis.db.backends.spatialite.base',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.db.backends.spatialite.schema',
+      'importer': 'django.contrib.gis.db.backends.spatialite.base',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.contrib.gis.db.backends.spatialite.base',
+    }),
+    dict({
+      'imported': 'django.db.backends.sqlite3.base',
+      'importer': 'django.contrib.gis.db.backends.spatialite.base',
+    }),
+    dict({
+      'imported': 'django.db.backends.sqlite3.client',
+      'importer': 'django.contrib.gis.db.backends.spatialite.client',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.db.backends.base.features',
+      'importer': 'django.contrib.gis.db.backends.spatialite.features',
+    }),
+    dict({
+      'imported': 'django.db.backends.sqlite3.features',
+      'importer': 'django.contrib.gis.db.backends.spatialite.features',
+    }),
+    dict({
+      'imported': 'django.utils.functional',
+      'importer': 'django.contrib.gis.db.backends.spatialite.features',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.gdal',
+      'importer': 'django.contrib.gis.db.backends.spatialite.introspection',
+    }),
+    dict({
+      'imported': 'django.db.backends.sqlite3.introspection',
+      'importer': 'django.contrib.gis.db.backends.spatialite.introspection',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.db.backends.base.models',
+      'importer': 'django.contrib.gis.db.backends.spatialite.models',
+    }),
+    dict({
+      'imported': 'django.db.models',
+      'importer': 'django.contrib.gis.db.backends.spatialite.models',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.db.backends.base.operations',
+      'importer': 'django.contrib.gis.db.backends.spatialite.operations',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.db.backends.spatialite.adapter',
+      'importer': 'django.contrib.gis.db.backends.spatialite.operations',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.db.backends.spatialite.models',
+      'importer': 'django.contrib.gis.db.backends.spatialite.operations',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.db.backends.utils',
+      'importer': 'django.contrib.gis.db.backends.spatialite.operations',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.db.models',
+      'importer': 'django.contrib.gis.db.backends.spatialite.operations',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.geos.geometry',
+      'importer': 'django.contrib.gis.db.backends.spatialite.operations',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.geos.prototypes.io',
+      'importer': 'django.contrib.gis.db.backends.spatialite.operations',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.measure',
+      'importer': 'django.contrib.gis.db.backends.spatialite.operations',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.contrib.gis.db.backends.spatialite.operations',
+    }),
+    dict({
+      'imported': 'django.db.backends.sqlite3.operations',
+      'importer': 'django.contrib.gis.db.backends.spatialite.operations',
+    }),
+    dict({
+      'imported': 'django.utils.functional',
+      'importer': 'django.contrib.gis.db.backends.spatialite.operations',
+    }),
+    dict({
+      'imported': 'django.utils.version',
+      'importer': 'django.contrib.gis.db.backends.spatialite.operations',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.db.models',
+      'importer': 'django.contrib.gis.db.backends.spatialite.schema',
+    }),
+    dict({
+      'imported': 'django.db',
+      'importer': 'django.contrib.gis.db.backends.spatialite.schema',
+    }),
+    dict({
+      'imported': 'django.db.backends.sqlite3.schema',
+      'importer': 'django.contrib.gis.db.backends.spatialite.schema',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.db.models.aggregates',
+      'importer': 'django.contrib.gis.db.models',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.db.models.fields',
+      'importer': 'django.contrib.gis.db.models',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.db.models.functions',
+      'importer': 'django.contrib.gis.db.models',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.db.models.lookups',
+      'importer': 'django.contrib.gis.db.models',
+    }),
+    dict({
+      'imported': 'django.db.models',
+      'importer': 'django.contrib.gis.db.models',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.db.models.fields',
+      'importer': 'django.contrib.gis.db.models.aggregates',
+    }),
+    dict({
+      'imported': 'django.db.models',
+      'importer': 'django.contrib.gis.db.models.aggregates',
+    }),
+    dict({
+      'imported': 'django.utils.functional',
+      'importer': 'django.contrib.gis.db.models.aggregates',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.db.models.lookups',
+      'importer': 'django.contrib.gis.db.models.fields',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.db.models.proxy',
+      'importer': 'django.contrib.gis.db.models.fields',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.forms',
+      'importer': 'django.contrib.gis.db.models.fields',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.gdal',
+      'importer': 'django.contrib.gis.db.models.fields',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.gdal.error',
+      'importer': 'django.contrib.gis.db.models.fields',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.geos',
+      'importer': 'django.contrib.gis.db.models.fields',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.contrib.gis.db.models.fields',
+    }),
+    dict({
+      'imported': 'django.db.models',
+      'importer': 'django.contrib.gis.db.models.fields',
+    }),
+    dict({
+      'imported': 'django.utils.translation',
+      'importer': 'django.contrib.gis.db.models.fields',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.db.models.fields',
+      'importer': 'django.contrib.gis.db.models.functions',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.db.models.sql',
+      'importer': 'django.contrib.gis.db.models.functions',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.geos',
+      'importer': 'django.contrib.gis.db.models.functions',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.contrib.gis.db.models.functions',
+    }),
+    dict({
+      'imported': 'django.db',
+      'importer': 'django.contrib.gis.db.models.functions',
+    }),
+    dict({
+      'imported': 'django.db.models',
+      'importer': 'django.contrib.gis.db.models.functions',
+    }),
+    dict({
+      'imported': 'django.db.models.functions',
+      'importer': 'django.contrib.gis.db.models.functions',
+    }),
+    dict({
+      'imported': 'django.utils.functional',
+      'importer': 'django.contrib.gis.db.models.functions',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.db.models.fields',
+      'importer': 'django.contrib.gis.db.models.lookups',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.measure',
+      'importer': 'django.contrib.gis.db.models.lookups',
+    }),
+    dict({
+      'imported': 'django.db',
+      'importer': 'django.contrib.gis.db.models.lookups',
+    }),
+    dict({
+      'imported': 'django.db.models',
+      'importer': 'django.contrib.gis.db.models.lookups',
+    }),
+    dict({
+      'imported': 'django.db.models.sql.query',
+      'importer': 'django.contrib.gis.db.models.lookups',
+    }),
+    dict({
+      'imported': 'django.utils.regex_helper',
+      'importer': 'django.contrib.gis.db.models.lookups',
+    }),
+    dict({
+      'imported': 'django.db.models.query_utils',
+      'importer': 'django.contrib.gis.db.models.proxy',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.db.models.sql.conversion',
+      'importer': 'django.contrib.gis.db.models.sql',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.measure',
+      'importer': 'django.contrib.gis.db.models.sql.conversion',
+    }),
+    dict({
+      'imported': 'django.db.models',
+      'importer': 'django.contrib.gis.db.models.sql.conversion',
+    }),
+    dict({
+      'imported': 'django.contrib.syndication.views',
+      'importer': 'django.contrib.gis.feeds',
+    }),
+    dict({
+      'imported': 'django.utils.feedgenerator',
+      'importer': 'django.contrib.gis.feeds',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.forms.fields',
+      'importer': 'django.contrib.gis.forms',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.forms.widgets',
+      'importer': 'django.contrib.gis.forms',
+    }),
+    dict({
+      'imported': 'django.forms',
+      'importer': 'django.contrib.gis.forms',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.forms.widgets',
+      'importer': 'django.contrib.gis.forms.fields',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.gdal',
+      'importer': 'django.contrib.gis.forms.fields',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.geos',
+      'importer': 'django.contrib.gis.forms.fields',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.contrib.gis.forms.fields',
+    }),
+    dict({
+      'imported': 'django.forms',
+      'importer': 'django.contrib.gis.forms.fields',
+    }),
+    dict({
+      'imported': 'django.utils.translation',
+      'importer': 'django.contrib.gis.forms.fields',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.contrib.gis.forms.widgets',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.gdal',
+      'importer': 'django.contrib.gis.forms.widgets',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.geometry',
+      'importer': 'django.contrib.gis.forms.widgets',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.geos',
+      'importer': 'django.contrib.gis.forms.widgets',
+    }),
+    dict({
+      'imported': 'django.forms.widgets',
+      'importer': 'django.contrib.gis.forms.widgets',
+    }),
+    dict({
+      'imported': 'django.utils.deprecation',
+      'importer': 'django.contrib.gis.forms.widgets',
+    }),
+    dict({
+      'imported': 'django.utils.translation',
+      'importer': 'django.contrib.gis.forms.widgets',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.gdal.datasource',
+      'importer': 'django.contrib.gis.gdal',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.gdal.driver',
+      'importer': 'django.contrib.gis.gdal',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.gdal.envelope',
+      'importer': 'django.contrib.gis.gdal',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.gdal.error',
+      'importer': 'django.contrib.gis.gdal',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.gdal.geometries',
+      'importer': 'django.contrib.gis.gdal',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.gdal.geomtype',
+      'importer': 'django.contrib.gis.gdal',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.gdal.libgdal',
+      'importer': 'django.contrib.gis.gdal',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.gdal.raster.source',
+      'importer': 'django.contrib.gis.gdal',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.gdal.srs',
+      'importer': 'django.contrib.gis.gdal',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.gdal.error',
+      'importer': 'django.contrib.gis.gdal.base',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.ptr',
+      'importer': 'django.contrib.gis.gdal.base',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.gdal.base',
+      'importer': 'django.contrib.gis.gdal.datasource',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.gdal.driver',
+      'importer': 'django.contrib.gis.gdal.datasource',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.gdal.error',
+      'importer': 'django.contrib.gis.gdal.datasource',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.gdal.layer',
+      'importer': 'django.contrib.gis.gdal.datasource',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.gdal.prototypes.ds',
+      'importer': 'django.contrib.gis.gdal.datasource',
+    }),
+    dict({
+      'imported': 'django.utils.encoding',
+      'importer': 'django.contrib.gis.gdal.datasource',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.gdal.base',
+      'importer': 'django.contrib.gis.gdal.driver',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.gdal.error',
+      'importer': 'django.contrib.gis.gdal.driver',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.gdal.prototypes.ds',
+      'importer': 'django.contrib.gis.gdal.driver',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.gdal.prototypes.raster',
+      'importer': 'django.contrib.gis.gdal.driver',
+    }),
+    dict({
+      'imported': 'django.utils.encoding',
+      'importer': 'django.contrib.gis.gdal.driver',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.gdal.error',
+      'importer': 'django.contrib.gis.gdal.envelope',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.gdal.base',
+      'importer': 'django.contrib.gis.gdal.feature',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.gdal.error',
+      'importer': 'django.contrib.gis.gdal.feature',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.gdal.field',
+      'importer': 'django.contrib.gis.gdal.feature',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.gdal.geometries',
+      'importer': 'django.contrib.gis.gdal.feature',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.gdal.prototypes.ds',
+      'importer': 'django.contrib.gis.gdal.feature',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.gdal.prototypes.geom',
+      'importer': 'django.contrib.gis.gdal.feature',
+    }),
+    dict({
+      'imported': 'django.utils.encoding',
+      'importer': 'django.contrib.gis.gdal.feature',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.gdal.base',
+      'importer': 'django.contrib.gis.gdal.field',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.gdal.error',
+      'importer': 'django.contrib.gis.gdal.field',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.gdal.prototypes.ds',
+      'importer': 'django.contrib.gis.gdal.field',
+    }),
+    dict({
+      'imported': 'django.utils.encoding',
+      'importer': 'django.contrib.gis.gdal.field',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.gdal.base',
+      'importer': 'django.contrib.gis.gdal.geometries',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.gdal.envelope',
+      'importer': 'django.contrib.gis.gdal.geometries',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.gdal.error',
+      'importer': 'django.contrib.gis.gdal.geometries',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.gdal.geomtype',
+      'importer': 'django.contrib.gis.gdal.geometries',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.gdal.prototypes.geom',
+      'importer': 'django.contrib.gis.gdal.geometries',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.gdal.prototypes.srs',
+      'importer': 'django.contrib.gis.gdal.geometries',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.gdal.srs',
+      'importer': 'django.contrib.gis.gdal.geometries',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.geometry',
+      'importer': 'django.contrib.gis.gdal.geometries',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.geos',
+      'importer': 'django.contrib.gis.gdal.geometries',
+    }),
+    dict({
+      'imported': 'django.utils.encoding',
+      'importer': 'django.contrib.gis.gdal.geometries',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.gdal.error',
+      'importer': 'django.contrib.gis.gdal.geomtype',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.gdal.base',
+      'importer': 'django.contrib.gis.gdal.layer',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.gdal.envelope',
+      'importer': 'django.contrib.gis.gdal.layer',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.gdal.error',
+      'importer': 'django.contrib.gis.gdal.layer',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.gdal.feature',
+      'importer': 'django.contrib.gis.gdal.layer',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.gdal.field',
+      'importer': 'django.contrib.gis.gdal.layer',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.gdal.geometries',
+      'importer': 'django.contrib.gis.gdal.layer',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.gdal.geomtype',
+      'importer': 'django.contrib.gis.gdal.layer',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.gdal.prototypes.ds',
+      'importer': 'django.contrib.gis.gdal.layer',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.gdal.prototypes.geom',
+      'importer': 'django.contrib.gis.gdal.layer',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.gdal.prototypes.srs',
+      'importer': 'django.contrib.gis.gdal.layer',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.gdal.srs',
+      'importer': 'django.contrib.gis.gdal.layer',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.geos',
+      'importer': 'django.contrib.gis.gdal.layer',
+    }),
+    dict({
+      'imported': 'django.utils.encoding',
+      'importer': 'django.contrib.gis.gdal.layer',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.contrib.gis.gdal.libgdal',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.gdal.error',
+      'importer': 'django.contrib.gis.gdal.libgdal',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.contrib.gis.gdal.libgdal',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.gdal.envelope',
+      'importer': 'django.contrib.gis.gdal.prototypes.ds',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.gdal.libgdal',
+      'importer': 'django.contrib.gis.gdal.prototypes.ds',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.gdal.prototypes.generation',
+      'importer': 'django.contrib.gis.gdal.prototypes.ds',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.gdal.error',
+      'importer': 'django.contrib.gis.gdal.prototypes.errcheck',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.gdal.libgdal',
+      'importer': 'django.contrib.gis.gdal.prototypes.errcheck',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.gdal.prototypes.errcheck',
+      'importer': 'django.contrib.gis.gdal.prototypes.generation',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.gdal.envelope',
+      'importer': 'django.contrib.gis.gdal.prototypes.geom',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.gdal.libgdal',
+      'importer': 'django.contrib.gis.gdal.prototypes.geom',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.gdal.prototypes.errcheck',
+      'importer': 'django.contrib.gis.gdal.prototypes.geom',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.gdal.prototypes.generation',
+      'importer': 'django.contrib.gis.gdal.prototypes.geom',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.gdal.libgdal',
+      'importer': 'django.contrib.gis.gdal.prototypes.raster',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.gdal.prototypes.generation',
+      'importer': 'django.contrib.gis.gdal.prototypes.raster',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.gdal.libgdal',
+      'importer': 'django.contrib.gis.gdal.prototypes.srs',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.gdal.prototypes.generation',
+      'importer': 'django.contrib.gis.gdal.prototypes.srs',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.gdal.error',
+      'importer': 'django.contrib.gis.gdal.raster.band',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.gdal.prototypes.raster',
+      'importer': 'django.contrib.gis.gdal.raster.band',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.gdal.raster.base',
+      'importer': 'django.contrib.gis.gdal.raster.band',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.gdal.raster.const',
+      'importer': 'django.contrib.gis.gdal.raster.band',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.shortcuts',
+      'importer': 'django.contrib.gis.gdal.raster.band',
+    }),
+    dict({
+      'imported': 'django.utils.encoding',
+      'importer': 'django.contrib.gis.gdal.raster.band',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.gdal.base',
+      'importer': 'django.contrib.gis.gdal.raster.base',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.gdal.prototypes.raster',
+      'importer': 'django.contrib.gis.gdal.raster.base',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.gdal.driver',
+      'importer': 'django.contrib.gis.gdal.raster.source',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.gdal.error',
+      'importer': 'django.contrib.gis.gdal.raster.source',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.gdal.prototypes.raster',
+      'importer': 'django.contrib.gis.gdal.raster.source',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.gdal.raster.band',
+      'importer': 'django.contrib.gis.gdal.raster.source',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.gdal.raster.base',
+      'importer': 'django.contrib.gis.gdal.raster.source',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.gdal.raster.const',
+      'importer': 'django.contrib.gis.gdal.raster.source',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.gdal.srs',
+      'importer': 'django.contrib.gis.gdal.raster.source',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.geometry',
+      'importer': 'django.contrib.gis.gdal.raster.source',
+    }),
+    dict({
+      'imported': 'django.utils.encoding',
+      'importer': 'django.contrib.gis.gdal.raster.source',
+    }),
+    dict({
+      'imported': 'django.utils.functional',
+      'importer': 'django.contrib.gis.gdal.raster.source',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.gdal.base',
+      'importer': 'django.contrib.gis.gdal.srs',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.gdal.error',
+      'importer': 'django.contrib.gis.gdal.srs',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.gdal.libgdal',
+      'importer': 'django.contrib.gis.gdal.srs',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.gdal.prototypes.srs',
+      'importer': 'django.contrib.gis.gdal.srs',
+    }),
+    dict({
+      'imported': 'django.utils.encoding',
+      'importer': 'django.contrib.gis.gdal.srs',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.geoip2.base',
+      'importer': 'django.contrib.gis.geoip2',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.contrib.gis.geoip2.base',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.geoip2.resources',
+      'importer': 'django.contrib.gis.geoip2.base',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.geos',
+      'importer': 'django.contrib.gis.geoip2.base',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.contrib.gis.geoip2.base',
+    }),
+    dict({
+      'imported': 'django.core.validators',
+      'importer': 'django.contrib.gis.geoip2.base',
+    }),
+    dict({
+      'imported': 'django.utils._os',
+      'importer': 'django.contrib.gis.geoip2.base',
+    }),
+    dict({
+      'imported': 'django.utils.regex_helper',
+      'importer': 'django.contrib.gis.geometry',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.geos.collections',
+      'importer': 'django.contrib.gis.geos',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.geos.error',
+      'importer': 'django.contrib.gis.geos',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.geos.factory',
+      'importer': 'django.contrib.gis.geos',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.geos.geometry',
+      'importer': 'django.contrib.gis.geos',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.geos.io',
+      'importer': 'django.contrib.gis.geos',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.geos.libgeos',
+      'importer': 'django.contrib.gis.geos',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.geos.linestring',
+      'importer': 'django.contrib.gis.geos',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.geos.point',
+      'importer': 'django.contrib.gis.geos',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.geos.polygon',
+      'importer': 'django.contrib.gis.geos',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.geos.error',
+      'importer': 'django.contrib.gis.geos.base',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.ptr',
+      'importer': 'django.contrib.gis.geos.base',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.geos.geometry',
+      'importer': 'django.contrib.gis.geos.collections',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.geos.libgeos',
+      'importer': 'django.contrib.gis.geos.collections',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.geos.linestring',
+      'importer': 'django.contrib.gis.geos.collections',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.geos.point',
+      'importer': 'django.contrib.gis.geos.collections',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.geos.polygon',
+      'importer': 'django.contrib.gis.geos.collections',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.geos.prototypes',
+      'importer': 'django.contrib.gis.geos.collections',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.geos.base',
+      'importer': 'django.contrib.gis.geos.coordseq',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.geos.error',
+      'importer': 'django.contrib.gis.geos.coordseq',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.geos.libgeos',
+      'importer': 'django.contrib.gis.geos.coordseq',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.geos.prototypes',
+      'importer': 'django.contrib.gis.geos.coordseq',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.shortcuts',
+      'importer': 'django.contrib.gis.geos.coordseq',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.geos.geometry',
+      'importer': 'django.contrib.gis.geos.factory',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.gdal',
+      'importer': 'django.contrib.gis.geos.geometry',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.geometry',
+      'importer': 'django.contrib.gis.geos.geometry',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.geos.base',
+      'importer': 'django.contrib.gis.geos.geometry',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.geos.collections',
+      'importer': 'django.contrib.gis.geos.geometry',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.geos.coordseq',
+      'importer': 'django.contrib.gis.geos.geometry',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.geos.error',
+      'importer': 'django.contrib.gis.geos.geometry',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.geos.libgeos',
+      'importer': 'django.contrib.gis.geos.geometry',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.geos.linestring',
+      'importer': 'django.contrib.gis.geos.geometry',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.geos.mutable_list',
+      'importer': 'django.contrib.gis.geos.geometry',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.geos.point',
+      'importer': 'django.contrib.gis.geos.geometry',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.geos.polygon',
+      'importer': 'django.contrib.gis.geos.geometry',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.geos.prepared',
+      'importer': 'django.contrib.gis.geos.geometry',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.geos.prototypes',
+      'importer': 'django.contrib.gis.geos.geometry',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.geos.prototypes.io',
+      'importer': 'django.contrib.gis.geos.geometry',
+    }),
+    dict({
+      'imported': 'django.utils.deconstruct',
+      'importer': 'django.contrib.gis.geos.geometry',
+    }),
+    dict({
+      'imported': 'django.utils.encoding',
+      'importer': 'django.contrib.gis.geos.geometry',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.geos.geometry',
+      'importer': 'django.contrib.gis.geos.io',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.geos.prototypes.io',
+      'importer': 'django.contrib.gis.geos.io',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.contrib.gis.geos.libgeos',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.geos.prototypes.threadsafe',
+      'importer': 'django.contrib.gis.geos.libgeos',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.contrib.gis.geos.libgeos',
+    }),
+    dict({
+      'imported': 'django.utils.functional',
+      'importer': 'django.contrib.gis.geos.libgeos',
+    }),
+    dict({
+      'imported': 'django.utils.version',
+      'importer': 'django.contrib.gis.geos.libgeos',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.geos.coordseq',
+      'importer': 'django.contrib.gis.geos.linestring',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.geos.error',
+      'importer': 'django.contrib.gis.geos.linestring',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.geos.geometry',
+      'importer': 'django.contrib.gis.geos.linestring',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.geos.point',
+      'importer': 'django.contrib.gis.geos.linestring',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.geos.prototypes',
+      'importer': 'django.contrib.gis.geos.linestring',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.shortcuts',
+      'importer': 'django.contrib.gis.geos.linestring',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.gdal',
+      'importer': 'django.contrib.gis.geos.point',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.geos.error',
+      'importer': 'django.contrib.gis.geos.point',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.geos.geometry',
+      'importer': 'django.contrib.gis.geos.point',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.geos.prototypes',
+      'importer': 'django.contrib.gis.geos.point',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.geos.geometry',
+      'importer': 'django.contrib.gis.geos.polygon',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.geos.libgeos',
+      'importer': 'django.contrib.gis.geos.polygon',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.geos.linestring',
+      'importer': 'django.contrib.gis.geos.polygon',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.geos.prototypes',
+      'importer': 'django.contrib.gis.geos.polygon',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.geos.base',
+      'importer': 'django.contrib.gis.geos.prepared',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.geos.geometry',
+      'importer': 'django.contrib.gis.geos.prepared',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.geos.prototypes.prepared',
+      'importer': 'django.contrib.gis.geos.prepared',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.geos.prototypes.coordseq',
+      'importer': 'django.contrib.gis.geos.prototypes',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.geos.prototypes.geom',
+      'importer': 'django.contrib.gis.geos.prototypes',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.geos.prototypes.misc',
+      'importer': 'django.contrib.gis.geos.prototypes',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.geos.prototypes.predicates',
+      'importer': 'django.contrib.gis.geos.prototypes',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.geos.prototypes.topology',
+      'importer': 'django.contrib.gis.geos.prototypes',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.geos.libgeos',
+      'importer': 'django.contrib.gis.geos.prototypes.coordseq',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.geos.prototypes.errcheck',
+      'importer': 'django.contrib.gis.geos.prototypes.coordseq',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.geos.error',
+      'importer': 'django.contrib.gis.geos.prototypes.errcheck',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.geos.libgeos',
+      'importer': 'django.contrib.gis.geos.prototypes.errcheck',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.geos.libgeos',
+      'importer': 'django.contrib.gis.geos.prototypes.geom',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.geos.prototypes.errcheck',
+      'importer': 'django.contrib.gis.geos.prototypes.geom',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.geos',
+      'importer': 'django.contrib.gis.geos.prototypes.io',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.geos.base',
+      'importer': 'django.contrib.gis.geos.prototypes.io',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.geos.libgeos',
+      'importer': 'django.contrib.gis.geos.prototypes.io',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.geos.polygon',
+      'importer': 'django.contrib.gis.geos.prototypes.io',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.geos.prototypes.errcheck',
+      'importer': 'django.contrib.gis.geos.prototypes.io',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.geos.prototypes.geom',
+      'importer': 'django.contrib.gis.geos.prototypes.io',
+    }),
+    dict({
+      'imported': 'django.utils.encoding',
+      'importer': 'django.contrib.gis.geos.prototypes.io',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.geos.libgeos',
+      'importer': 'django.contrib.gis.geos.prototypes.misc',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.geos.prototypes.errcheck',
+      'importer': 'django.contrib.gis.geos.prototypes.misc',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.geos.prototypes.geom',
+      'importer': 'django.contrib.gis.geos.prototypes.misc',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.geos.libgeos',
+      'importer': 'django.contrib.gis.geos.prototypes.predicates',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.geos.prototypes.errcheck',
+      'importer': 'django.contrib.gis.geos.prototypes.predicates',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.geos.libgeos',
+      'importer': 'django.contrib.gis.geos.prototypes.prepared',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.geos.prototypes.errcheck',
+      'importer': 'django.contrib.gis.geos.prototypes.prepared',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.geos.base',
+      'importer': 'django.contrib.gis.geos.prototypes.threadsafe',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.geos.libgeos',
+      'importer': 'django.contrib.gis.geos.prototypes.threadsafe',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.geos.libgeos',
+      'importer': 'django.contrib.gis.geos.prototypes.topology',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.geos.prototypes.errcheck',
+      'importer': 'django.contrib.gis.geos.prototypes.topology',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.geos.prototypes.geom',
+      'importer': 'django.contrib.gis.geos.prototypes.topology',
+    }),
+    dict({
+      'imported': 'django.core.management.commands.inspectdb',
+      'importer': 'django.contrib.gis.management.commands.inspectdb',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.gdal',
+      'importer': 'django.contrib.gis.management.commands.ogrinspect',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.utils.ogrinspect',
+      'importer': 'django.contrib.gis.management.commands.ogrinspect',
+    }),
+    dict({
+      'imported': 'django.core.management.base',
+      'importer': 'django.contrib.gis.management.commands.ogrinspect',
+    }),
+    dict({
+      'imported': 'django.utils.inspect',
+      'importer': 'django.contrib.gis.management.commands.ogrinspect',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.gdal',
+      'importer': 'django.contrib.gis.serializers.geojson',
+    }),
+    dict({
+      'imported': 'django.core.serializers.base',
+      'importer': 'django.contrib.gis.serializers.geojson',
+    }),
+    dict({
+      'imported': 'django.core.serializers.json',
+      'importer': 'django.contrib.gis.serializers.geojson',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.contrib.gis.shortcuts',
+    }),
+    dict({
+      'imported': 'django.http',
+      'importer': 'django.contrib.gis.shortcuts',
+    }),
+    dict({
+      'imported': 'django.template.loader',
+      'importer': 'django.contrib.gis.shortcuts',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.sitemaps.kml',
+      'importer': 'django.contrib.gis.sitemaps',
+    }),
+    dict({
+      'imported': 'django.apps',
+      'importer': 'django.contrib.gis.sitemaps.kml',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.db.models',
+      'importer': 'django.contrib.gis.sitemaps.kml',
+    }),
+    dict({
+      'imported': 'django.contrib.sitemaps',
+      'importer': 'django.contrib.gis.sitemaps.kml',
+    }),
+    dict({
+      'imported': 'django.db.models',
+      'importer': 'django.contrib.gis.sitemaps.kml',
+    }),
+    dict({
+      'imported': 'django.urls',
+      'importer': 'django.contrib.gis.sitemaps.kml',
+    }),
+    dict({
+      'imported': 'django.apps',
+      'importer': 'django.contrib.gis.sitemaps.views',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.db.models',
+      'importer': 'django.contrib.gis.sitemaps.views',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.db.models.functions',
+      'importer': 'django.contrib.gis.sitemaps.views',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.shortcuts',
+      'importer': 'django.contrib.gis.sitemaps.views',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.contrib.gis.sitemaps.views',
+    }),
+    dict({
+      'imported': 'django.db',
+      'importer': 'django.contrib.gis.sitemaps.views',
+    }),
+    dict({
+      'imported': 'django.http',
+      'importer': 'django.contrib.gis.sitemaps.views',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.utils.layermapping',
+      'importer': 'django.contrib.gis.utils',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.utils.ogrinfo',
+      'importer': 'django.contrib.gis.utils',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.utils.ogrinspect',
+      'importer': 'django.contrib.gis.utils',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.utils.srs',
+      'importer': 'django.contrib.gis.utils',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.contrib.gis.utils',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.db.models',
+      'importer': 'django.contrib.gis.utils.layermapping',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.gdal',
+      'importer': 'django.contrib.gis.utils.layermapping',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.gdal.field',
+      'importer': 'django.contrib.gis.utils.layermapping',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.contrib.gis.utils.layermapping',
+    }),
+    dict({
+      'imported': 'django.db',
+      'importer': 'django.contrib.gis.utils.layermapping',
+    }),
+    dict({
+      'imported': 'django.db.models',
+      'importer': 'django.contrib.gis.utils.layermapping',
+    }),
+    dict({
+      'imported': 'django.db.transaction',
+      'importer': 'django.contrib.gis.utils.layermapping',
+    }),
+    dict({
+      'imported': 'django.utils.encoding',
+      'importer': 'django.contrib.gis.utils.layermapping',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.gdal',
+      'importer': 'django.contrib.gis.utils.ogrinfo',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.gdal.geometries',
+      'importer': 'django.contrib.gis.utils.ogrinfo',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.gdal',
+      'importer': 'django.contrib.gis.utils.ogrinspect',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.gdal.field',
+      'importer': 'django.contrib.gis.utils.ogrinspect',
+    }),
+    dict({
+      'imported': 'django.contrib.gis.gdal',
+      'importer': 'django.contrib.gis.utils.srs',
+    }),
+    dict({
+      'imported': 'django.db',
+      'importer': 'django.contrib.gis.utils.srs',
+    }),
+    dict({
+      'imported': 'django.http',
+      'importer': 'django.contrib.gis.views',
+    }),
+    dict({
+      'imported': 'django.utils.translation',
+      'importer': 'django.contrib.gis.views',
+    }),
+    dict({
+      'imported': 'django.apps',
+      'importer': 'django.contrib.humanize.apps',
+    }),
+    dict({
+      'imported': 'django.utils.translation',
+      'importer': 'django.contrib.humanize.apps',
+    }),
+    dict({
+      'imported': 'django.template',
+      'importer': 'django.contrib.humanize.templatetags.humanize',
+    }),
+    dict({
+      'imported': 'django.template.defaultfilters',
+      'importer': 'django.contrib.humanize.templatetags.humanize',
+    }),
+    dict({
+      'imported': 'django.utils.formats',
+      'importer': 'django.contrib.humanize.templatetags.humanize',
+    }),
+    dict({
+      'imported': 'django.utils.safestring',
+      'importer': 'django.contrib.humanize.templatetags.humanize',
+    }),
+    dict({
+      'imported': 'django.utils.timezone',
+      'importer': 'django.contrib.humanize.templatetags.humanize',
+    }),
+    dict({
+      'imported': 'django.utils.translation',
+      'importer': 'django.contrib.humanize.templatetags.humanize',
+    }),
+    dict({
+      'imported': 'django.contrib.messages.api',
+      'importer': 'django.contrib.messages',
+    }),
+    dict({
+      'imported': 'django.contrib.messages.constants',
+      'importer': 'django.contrib.messages',
+    }),
+    dict({
+      'imported': 'django.contrib.messages.constants',
+      'importer': 'django.contrib.messages.api',
+    }),
+    dict({
+      'imported': 'django.contrib.messages.storage',
+      'importer': 'django.contrib.messages.api',
+    }),
+    dict({
+      'imported': 'django.apps',
+      'importer': 'django.contrib.messages.apps',
+    }),
+    dict({
+      'imported': 'django.contrib.messages.storage.base',
+      'importer': 'django.contrib.messages.apps',
+    }),
+    dict({
+      'imported': 'django.contrib.messages.utils',
+      'importer': 'django.contrib.messages.apps',
+    }),
+    dict({
+      'imported': 'django.core.signals',
+      'importer': 'django.contrib.messages.apps',
+    }),
+    dict({
+      'imported': 'django.utils.translation',
+      'importer': 'django.contrib.messages.apps',
+    }),
+    dict({
+      'imported': 'django.contrib.messages.api',
+      'importer': 'django.contrib.messages.context_processors',
+    }),
+    dict({
+      'imported': 'django.contrib.messages.constants',
+      'importer': 'django.contrib.messages.context_processors',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.contrib.messages.middleware',
+    }),
+    dict({
+      'imported': 'django.contrib.messages.storage',
+      'importer': 'django.contrib.messages.middleware',
+    }),
+    dict({
+      'imported': 'django.utils.deprecation',
+      'importer': 'django.contrib.messages.middleware',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.contrib.messages.storage',
+    }),
+    dict({
+      'imported': 'django.utils.module_loading',
+      'importer': 'django.contrib.messages.storage',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.contrib.messages.storage.base',
+    }),
+    dict({
+      'imported': 'django.contrib.messages.constants',
+      'importer': 'django.contrib.messages.storage.base',
+    }),
+    dict({
+      'imported': 'django.contrib.messages.utils',
+      'importer': 'django.contrib.messages.storage.base',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.contrib.messages.storage.cookie',
+    }),
+    dict({
+      'imported': 'django.contrib.messages.storage.base',
+      'importer': 'django.contrib.messages.storage.cookie',
+    }),
+    dict({
+      'imported': 'django.core.signing',
+      'importer': 'django.contrib.messages.storage.cookie',
+    }),
+    dict({
+      'imported': 'django.http',
+      'importer': 'django.contrib.messages.storage.cookie',
+    }),
+    dict({
+      'imported': 'django.utils.safestring',
+      'importer': 'django.contrib.messages.storage.cookie',
+    }),
+    dict({
+      'imported': 'django.contrib.messages.storage.base',
+      'importer': 'django.contrib.messages.storage.fallback',
+    }),
+    dict({
+      'imported': 'django.contrib.messages.storage.cookie',
+      'importer': 'django.contrib.messages.storage.fallback',
+    }),
+    dict({
+      'imported': 'django.contrib.messages.storage.session',
+      'importer': 'django.contrib.messages.storage.fallback',
+    }),
+    dict({
+      'imported': 'django.contrib.messages.storage.base',
+      'importer': 'django.contrib.messages.storage.session',
+    }),
+    dict({
+      'imported': 'django.contrib.messages.storage.cookie',
+      'importer': 'django.contrib.messages.storage.session',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.contrib.messages.storage.session',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.contrib.messages.utils',
+    }),
+    dict({
+      'imported': 'django.contrib.messages.constants',
+      'importer': 'django.contrib.messages.utils',
+    }),
+    dict({
+      'imported': 'django.contrib.messages',
+      'importer': 'django.contrib.messages.views',
+    }),
+    dict({
+      'imported': 'django.contrib.postgres.aggregates.general',
+      'importer': 'django.contrib.postgres.aggregates',
+    }),
+    dict({
+      'imported': 'django.contrib.postgres.aggregates.statistics',
+      'importer': 'django.contrib.postgres.aggregates',
+    }),
+    dict({
+      'imported': 'django.contrib.postgres.aggregates.mixins',
+      'importer': 'django.contrib.postgres.aggregates.general',
+    }),
+    dict({
+      'imported': 'django.contrib.postgres.fields',
+      'importer': 'django.contrib.postgres.aggregates.general',
+    }),
+    dict({
+      'imported': 'django.db.models',
+      'importer': 'django.contrib.postgres.aggregates.general',
+    }),
+    dict({
+      'imported': 'django.utils.deprecation',
+      'importer': 'django.contrib.postgres.aggregates.general',
+    }),
+    dict({
+      'imported': 'django.db.models.expressions',
+      'importer': 'django.contrib.postgres.aggregates.mixins',
+    }),
+    dict({
+      'imported': 'django.db.models',
+      'importer': 'django.contrib.postgres.aggregates.statistics',
+    }),
+    dict({
+      'imported': 'django.apps',
+      'importer': 'django.contrib.postgres.apps',
+    }),
+    dict({
+      'imported': 'django.contrib.postgres.indexes',
+      'importer': 'django.contrib.postgres.apps',
+    }),
+    dict({
+      'imported': 'django.contrib.postgres.lookups',
+      'importer': 'django.contrib.postgres.apps',
+    }),
+    dict({
+      'imported': 'django.contrib.postgres.serializers',
+      'importer': 'django.contrib.postgres.apps',
+    }),
+    dict({
+      'imported': 'django.contrib.postgres.signals',
+      'importer': 'django.contrib.postgres.apps',
+    }),
+    dict({
+      'imported': 'django.core.signals',
+      'importer': 'django.contrib.postgres.apps',
+    }),
+    dict({
+      'imported': 'django.db',
+      'importer': 'django.contrib.postgres.apps',
+    }),
+    dict({
+      'imported': 'django.db.backends.postgresql.psycopg_any',
+      'importer': 'django.contrib.postgres.apps',
+    }),
+    dict({
+      'imported': 'django.db.backends.signals',
+      'importer': 'django.contrib.postgres.apps',
+    }),
+    dict({
+      'imported': 'django.db.migrations.writer',
+      'importer': 'django.contrib.postgres.apps',
+    }),
+    dict({
+      'imported': 'django.db.models',
+      'importer': 'django.contrib.postgres.apps',
+    }),
+    dict({
+      'imported': 'django.db.models.functions',
+      'importer': 'django.contrib.postgres.apps',
+    }),
+    dict({
+      'imported': 'django.db.models.indexes',
+      'importer': 'django.contrib.postgres.apps',
+    }),
+    dict({
+      'imported': 'django.utils.translation',
+      'importer': 'django.contrib.postgres.apps',
+    }),
+    dict({
+      'imported': 'django.contrib.postgres.indexes',
+      'importer': 'django.contrib.postgres.constraints',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.contrib.postgres.constraints',
+    }),
+    dict({
+      'imported': 'django.db',
+      'importer': 'django.contrib.postgres.constraints',
+    }),
+    dict({
+      'imported': 'django.db.backends.ddl_references',
+      'importer': 'django.contrib.postgres.constraints',
+    }),
+    dict({
+      'imported': 'django.db.models',
+      'importer': 'django.contrib.postgres.constraints',
+    }),
+    dict({
+      'imported': 'django.db.models.expressions',
+      'importer': 'django.contrib.postgres.constraints',
+    }),
+    dict({
+      'imported': 'django.db.models.indexes',
+      'importer': 'django.contrib.postgres.constraints',
+    }),
+    dict({
+      'imported': 'django.db.models.lookups',
+      'importer': 'django.contrib.postgres.constraints',
+    }),
+    dict({
+      'imported': 'django.db.models.sql',
+      'importer': 'django.contrib.postgres.constraints',
+    }),
+    dict({
+      'imported': 'django.utils.deprecation',
+      'importer': 'django.contrib.postgres.constraints',
+    }),
+    dict({
+      'imported': 'django.contrib.postgres.fields',
+      'importer': 'django.contrib.postgres.expressions',
+    }),
+    dict({
+      'imported': 'django.db.models',
+      'importer': 'django.contrib.postgres.expressions',
+    }),
+    dict({
+      'imported': 'django.utils.functional',
+      'importer': 'django.contrib.postgres.expressions',
+    }),
+    dict({
+      'imported': 'django.contrib.postgres.fields.array',
+      'importer': 'django.contrib.postgres.fields',
+    }),
+    dict({
+      'imported': 'django.contrib.postgres.fields.citext',
+      'importer': 'django.contrib.postgres.fields',
+    }),
+    dict({
+      'imported': 'django.contrib.postgres.fields.hstore',
+      'importer': 'django.contrib.postgres.fields',
+    }),
+    dict({
+      'imported': 'django.contrib.postgres.fields.jsonb',
+      'importer': 'django.contrib.postgres.fields',
+    }),
+    dict({
+      'imported': 'django.contrib.postgres.fields.ranges',
+      'importer': 'django.contrib.postgres.fields',
+    }),
+    dict({
+      'imported': 'django.contrib.postgres.fields.utils',
+      'importer': 'django.contrib.postgres.fields.array',
+    }),
+    dict({
+      'imported': 'django.contrib.postgres.forms',
+      'importer': 'django.contrib.postgres.fields.array',
+    }),
+    dict({
+      'imported': 'django.contrib.postgres.lookups',
+      'importer': 'django.contrib.postgres.fields.array',
+    }),
+    dict({
+      'imported': 'django.contrib.postgres.utils',
+      'importer': 'django.contrib.postgres.fields.array',
+    }),
+    dict({
+      'imported': 'django.contrib.postgres.validators',
+      'importer': 'django.contrib.postgres.fields.array',
+    }),
+    dict({
+      'imported': 'django.core.checks',
+      'importer': 'django.contrib.postgres.fields.array',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.contrib.postgres.fields.array',
+    }),
+    dict({
+      'imported': 'django.db.models',
+      'importer': 'django.contrib.postgres.fields.array',
+    }),
+    dict({
+      'imported': 'django.db.models.fields.mixins',
+      'importer': 'django.contrib.postgres.fields.array',
+    }),
+    dict({
+      'imported': 'django.db.models.lookups',
+      'importer': 'django.contrib.postgres.fields.array',
+    }),
+    dict({
+      'imported': 'django.utils.translation',
+      'importer': 'django.contrib.postgres.fields.array',
+    }),
+    dict({
+      'imported': 'django.db.models',
+      'importer': 'django.contrib.postgres.fields.citext',
+    }),
+    dict({
+      'imported': 'django.test.utils',
+      'importer': 'django.contrib.postgres.fields.citext',
+    }),
+    dict({
+      'imported': 'django.utils.deprecation',
+      'importer': 'django.contrib.postgres.fields.citext',
+    }),
+    dict({
+      'imported': 'django.contrib.postgres.fields.array',
+      'importer': 'django.contrib.postgres.fields.hstore',
+    }),
+    dict({
+      'imported': 'django.contrib.postgres.forms',
+      'importer': 'django.contrib.postgres.fields.hstore',
+    }),
+    dict({
+      'imported': 'django.contrib.postgres.lookups',
+      'importer': 'django.contrib.postgres.fields.hstore',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.contrib.postgres.fields.hstore',
+    }),
+    dict({
+      'imported': 'django.db.models',
+      'importer': 'django.contrib.postgres.fields.hstore',
+    }),
+    dict({
+      'imported': 'django.db.models.fields.mixins',
+      'importer': 'django.contrib.postgres.fields.hstore',
+    }),
+    dict({
+      'imported': 'django.utils.translation',
+      'importer': 'django.contrib.postgres.fields.hstore',
+    }),
+    dict({
+      'imported': 'django.db.models',
+      'importer': 'django.contrib.postgres.fields.jsonb',
+    }),
+    dict({
+      'imported': 'django.contrib.postgres.fields.utils',
+      'importer': 'django.contrib.postgres.fields.ranges',
+    }),
+    dict({
+      'imported': 'django.contrib.postgres.forms',
+      'importer': 'django.contrib.postgres.fields.ranges',
+    }),
+    dict({
+      'imported': 'django.contrib.postgres.lookups',
+      'importer': 'django.contrib.postgres.fields.ranges',
+    }),
+    dict({
+      'imported': 'django.db.backends.postgresql.psycopg_any',
+      'importer': 'django.contrib.postgres.fields.ranges',
+    }),
+    dict({
+      'imported': 'django.db.models',
+      'importer': 'django.contrib.postgres.fields.ranges',
+    }),
+    dict({
+      'imported': 'django.db.models.functions',
+      'importer': 'django.contrib.postgres.fields.ranges',
+    }),
+    dict({
+      'imported': 'django.db.models.lookups',
+      'importer': 'django.contrib.postgres.fields.ranges',
+    }),
+    dict({
+      'imported': 'django.contrib.postgres.forms.array',
+      'importer': 'django.contrib.postgres.forms',
+    }),
+    dict({
+      'imported': 'django.contrib.postgres.forms.hstore',
+      'importer': 'django.contrib.postgres.forms',
+    }),
+    dict({
+      'imported': 'django.contrib.postgres.forms.ranges',
+      'importer': 'django.contrib.postgres.forms',
+    }),
+    dict({
+      'imported': 'django.contrib.postgres.utils',
+      'importer': 'django.contrib.postgres.forms.array',
+    }),
+    dict({
+      'imported': 'django.contrib.postgres.validators',
+      'importer': 'django.contrib.postgres.forms.array',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.contrib.postgres.forms.array',
+    }),
+    dict({
+      'imported': 'django.forms',
+      'importer': 'django.contrib.postgres.forms.array',
+    }),
+    dict({
+      'imported': 'django.utils.translation',
+      'importer': 'django.contrib.postgres.forms.array',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.contrib.postgres.forms.hstore',
+    }),
+    dict({
+      'imported': 'django.forms',
+      'importer': 'django.contrib.postgres.forms.hstore',
+    }),
+    dict({
+      'imported': 'django.utils.translation',
+      'importer': 'django.contrib.postgres.forms.hstore',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.contrib.postgres.forms.ranges',
+    }),
+    dict({
+      'imported': 'django.db.backends.postgresql.psycopg_any',
+      'importer': 'django.contrib.postgres.forms.ranges',
+    }),
+    dict({
+      'imported': 'django.forms',
+      'importer': 'django.contrib.postgres.forms.ranges',
+    }),
+    dict({
+      'imported': 'django.forms.widgets',
+      'importer': 'django.contrib.postgres.forms.ranges',
+    }),
+    dict({
+      'imported': 'django.utils.translation',
+      'importer': 'django.contrib.postgres.forms.ranges',
+    }),
+    dict({
+      'imported': 'django.db.models',
+      'importer': 'django.contrib.postgres.functions',
+    }),
+    dict({
+      'imported': 'django.db',
+      'importer': 'django.contrib.postgres.indexes',
+    }),
+    dict({
+      'imported': 'django.db.models',
+      'importer': 'django.contrib.postgres.indexes',
+    }),
+    dict({
+      'imported': 'django.utils.functional',
+      'importer': 'django.contrib.postgres.indexes',
+    }),
+    dict({
+      'imported': 'django.contrib.postgres.expressions',
+      'importer': 'django.contrib.postgres.lookups',
+    }),
+    dict({
+      'imported': 'django.contrib.postgres.search',
+      'importer': 'django.contrib.postgres.lookups',
+    }),
+    dict({
+      'imported': 'django.db.models',
+      'importer': 'django.contrib.postgres.lookups',
+    }),
+    dict({
+      'imported': 'django.db.models.lookups',
+      'importer': 'django.contrib.postgres.lookups',
+    }),
+    dict({
+      'imported': 'django.db.models.sql.query',
+      'importer': 'django.contrib.postgres.lookups',
+    }),
+    dict({
+      'imported': 'django.contrib.postgres.signals',
+      'importer': 'django.contrib.postgres.operations',
+    }),
+    dict({
+      'imported': 'django.db',
+      'importer': 'django.contrib.postgres.operations',
+    }),
+    dict({
+      'imported': 'django.db.migrations',
+      'importer': 'django.contrib.postgres.operations',
+    }),
+    dict({
+      'imported': 'django.db.migrations.operations.base',
+      'importer': 'django.contrib.postgres.operations',
+    }),
+    dict({
+      'imported': 'django.db.models.constraints',
+      'importer': 'django.contrib.postgres.operations',
+    }),
+    dict({
+      'imported': 'django.contrib.postgres.fields.array',
+      'importer': 'django.contrib.postgres.search',
+    }),
+    dict({
+      'imported': 'django.db.models',
+      'importer': 'django.contrib.postgres.search',
+    }),
+    dict({
+      'imported': 'django.db.models.expressions',
+      'importer': 'django.contrib.postgres.search',
+    }),
+    dict({
+      'imported': 'django.db.models.functions',
+      'importer': 'django.contrib.postgres.search',
+    }),
+    dict({
+      'imported': 'django.db.migrations.serializer',
+      'importer': 'django.contrib.postgres.serializers',
+    }),
+    dict({
+      'imported': 'django.db',
+      'importer': 'django.contrib.postgres.signals',
+    }),
+    dict({
+      'imported': 'django.db.backends.base.base',
+      'importer': 'django.contrib.postgres.signals',
+    }),
+    dict({
+      'imported': 'django.db.backends.postgresql.psycopg_any',
+      'importer': 'django.contrib.postgres.signals',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.contrib.postgres.utils',
+    }),
+    dict({
+      'imported': 'django.utils.functional',
+      'importer': 'django.contrib.postgres.utils',
+    }),
+    dict({
+      'imported': 'django.utils.text',
+      'importer': 'django.contrib.postgres.utils',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.contrib.postgres.validators',
+    }),
+    dict({
+      'imported': 'django.core.validators',
+      'importer': 'django.contrib.postgres.validators',
+    }),
+    dict({
+      'imported': 'django.utils.deconstruct',
+      'importer': 'django.contrib.postgres.validators',
+    }),
+    dict({
+      'imported': 'django.utils.translation',
+      'importer': 'django.contrib.postgres.validators',
+    }),
+    dict({
+      'imported': 'django.contrib.admin',
+      'importer': 'django.contrib.redirects.admin',
+    }),
+    dict({
+      'imported': 'django.contrib.redirects.models',
+      'importer': 'django.contrib.redirects.admin',
+    }),
+    dict({
+      'imported': 'django.apps',
+      'importer': 'django.contrib.redirects.apps',
+    }),
+    dict({
+      'imported': 'django.utils.translation',
+      'importer': 'django.contrib.redirects.apps',
+    }),
+    dict({
+      'imported': 'django.apps',
+      'importer': 'django.contrib.redirects.middleware',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.contrib.redirects.middleware',
+    }),
+    dict({
+      'imported': 'django.contrib.redirects.models',
+      'importer': 'django.contrib.redirects.middleware',
+    }),
+    dict({
+      'imported': 'django.contrib.sites.shortcuts',
+      'importer': 'django.contrib.redirects.middleware',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.contrib.redirects.middleware',
+    }),
+    dict({
+      'imported': 'django.http',
+      'importer': 'django.contrib.redirects.middleware',
+    }),
+    dict({
+      'imported': 'django.utils.deprecation',
+      'importer': 'django.contrib.redirects.middleware',
+    }),
+    dict({
+      'imported': 'django.db.migrations',
+      'importer': 'django.contrib.redirects.migrations.0001_initial',
+    }),
+    dict({
+      'imported': 'django.db.models',
+      'importer': 'django.contrib.redirects.migrations.0001_initial',
+    }),
+    dict({
+      'imported': 'django.db.migrations',
+      'importer': 'django.contrib.redirects.migrations.0002_alter_redirect_new_path_help_text',
+    }),
+    dict({
+      'imported': 'django.db.models',
+      'importer': 'django.contrib.redirects.migrations.0002_alter_redirect_new_path_help_text',
+    }),
+    dict({
+      'imported': 'django.contrib.sites.models',
+      'importer': 'django.contrib.redirects.models',
+    }),
+    dict({
+      'imported': 'django.db.models',
+      'importer': 'django.contrib.redirects.models',
+    }),
+    dict({
+      'imported': 'django.utils.translation',
+      'importer': 'django.contrib.redirects.models',
+    }),
+    dict({
+      'imported': 'django.apps',
+      'importer': 'django.contrib.sessions.apps',
+    }),
+    dict({
+      'imported': 'django.utils.translation',
+      'importer': 'django.contrib.sessions.apps',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.contrib.sessions.backends.base',
+    }),
+    dict({
+      'imported': 'django.core.signing',
+      'importer': 'django.contrib.sessions.backends.base',
+    }),
+    dict({
+      'imported': 'django.utils.crypto',
+      'importer': 'django.contrib.sessions.backends.base',
+    }),
+    dict({
+      'imported': 'django.utils.module_loading',
+      'importer': 'django.contrib.sessions.backends.base',
+    }),
+    dict({
+      'imported': 'django.utils.timezone',
+      'importer': 'django.contrib.sessions.backends.base',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.contrib.sessions.backends.cache',
+    }),
+    dict({
+      'imported': 'django.contrib.sessions.backends.base',
+      'importer': 'django.contrib.sessions.backends.cache',
+    }),
+    dict({
+      'imported': 'django.core.cache',
+      'importer': 'django.contrib.sessions.backends.cache',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.contrib.sessions.backends.cached_db',
+    }),
+    dict({
+      'imported': 'django.contrib.sessions.backends.db',
+      'importer': 'django.contrib.sessions.backends.cached_db',
+    }),
+    dict({
+      'imported': 'django.core.cache',
+      'importer': 'django.contrib.sessions.backends.cached_db',
+    }),
+    dict({
+      'imported': 'django.contrib.sessions.backends.base',
+      'importer': 'django.contrib.sessions.backends.db',
+    }),
+    dict({
+      'imported': 'django.contrib.sessions.models',
+      'importer': 'django.contrib.sessions.backends.db',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.contrib.sessions.backends.db',
+    }),
+    dict({
+      'imported': 'django.db',
+      'importer': 'django.contrib.sessions.backends.db',
+    }),
+    dict({
+      'imported': 'django.db.transaction',
+      'importer': 'django.contrib.sessions.backends.db',
+    }),
+    dict({
+      'imported': 'django.utils.functional',
+      'importer': 'django.contrib.sessions.backends.db',
+    }),
+    dict({
+      'imported': 'django.utils.timezone',
+      'importer': 'django.contrib.sessions.backends.db',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.contrib.sessions.backends.file',
+    }),
+    dict({
+      'imported': 'django.contrib.sessions.backends.base',
+      'importer': 'django.contrib.sessions.backends.file',
+    }),
+    dict({
+      'imported': 'django.contrib.sessions.exceptions',
+      'importer': 'django.contrib.sessions.backends.file',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.contrib.sessions.backends.file',
+    }),
+    dict({
+      'imported': 'django.contrib.sessions.backends.base',
+      'importer': 'django.contrib.sessions.backends.signed_cookies',
+    }),
+    dict({
+      'imported': 'django.core.signing',
+      'importer': 'django.contrib.sessions.backends.signed_cookies',
+    }),
+    dict({
+      'imported': 'django.db.models',
+      'importer': 'django.contrib.sessions.base_session',
+    }),
+    dict({
+      'imported': 'django.utils.translation',
+      'importer': 'django.contrib.sessions.base_session',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.contrib.sessions.exceptions',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.contrib.sessions.management.commands.clearsessions',
+    }),
+    dict({
+      'imported': 'django.core.management.base',
+      'importer': 'django.contrib.sessions.management.commands.clearsessions',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.contrib.sessions.middleware',
+    }),
+    dict({
+      'imported': 'django.contrib.sessions.backends.base',
+      'importer': 'django.contrib.sessions.middleware',
+    }),
+    dict({
+      'imported': 'django.contrib.sessions.exceptions',
+      'importer': 'django.contrib.sessions.middleware',
+    }),
+    dict({
+      'imported': 'django.utils.cache',
+      'importer': 'django.contrib.sessions.middleware',
+    }),
+    dict({
+      'imported': 'django.utils.deprecation',
+      'importer': 'django.contrib.sessions.middleware',
+    }),
+    dict({
+      'imported': 'django.utils.http',
+      'importer': 'django.contrib.sessions.middleware',
+    }),
+    dict({
+      'imported': 'django.contrib.sessions.models',
+      'importer': 'django.contrib.sessions.migrations.0001_initial',
+    }),
+    dict({
+      'imported': 'django.db.migrations',
+      'importer': 'django.contrib.sessions.migrations.0001_initial',
+    }),
+    dict({
+      'imported': 'django.db.models',
+      'importer': 'django.contrib.sessions.migrations.0001_initial',
+    }),
+    dict({
+      'imported': 'django.contrib.sessions.backends.db',
+      'importer': 'django.contrib.sessions.models',
+    }),
+    dict({
+      'imported': 'django.contrib.sessions.base_session',
+      'importer': 'django.contrib.sessions.models',
+    }),
+    dict({
+      'imported': 'django.core.serializers.base',
+      'importer': 'django.contrib.sessions.serializers',
+    }),
+    dict({
+      'imported': 'django.core.signing',
+      'importer': 'django.contrib.sessions.serializers',
+    }),
+    dict({
+      'imported': 'django.apps',
+      'importer': 'django.contrib.sitemaps',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.contrib.sitemaps',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.contrib.sitemaps',
+    }),
+    dict({
+      'imported': 'django.core.paginator',
+      'importer': 'django.contrib.sitemaps',
+    }),
+    dict({
+      'imported': 'django.urls',
+      'importer': 'django.contrib.sitemaps',
+    }),
+    dict({
+      'imported': 'django.utils.deprecation',
+      'importer': 'django.contrib.sitemaps',
+    }),
+    dict({
+      'imported': 'django.utils.translation',
+      'importer': 'django.contrib.sitemaps',
+    }),
+    dict({
+      'imported': 'django.apps',
+      'importer': 'django.contrib.sitemaps.apps',
+    }),
+    dict({
+      'imported': 'django.utils.translation',
+      'importer': 'django.contrib.sitemaps.apps',
+    }),
+    dict({
+      'imported': 'django.contrib.sitemaps',
+      'importer': 'django.contrib.sitemaps.management.commands.ping_google',
+    }),
+    dict({
+      'imported': 'django.core.management.base',
+      'importer': 'django.contrib.sitemaps.management.commands.ping_google',
+    }),
+    dict({
+      'imported': 'django.contrib.sites.shortcuts',
+      'importer': 'django.contrib.sitemaps.views',
+    }),
+    dict({
+      'imported': 'django.core.paginator',
+      'importer': 'django.contrib.sitemaps.views',
+    }),
+    dict({
+      'imported': 'django.http',
+      'importer': 'django.contrib.sitemaps.views',
+    }),
+    dict({
+      'imported': 'django.template.response',
+      'importer': 'django.contrib.sitemaps.views',
+    }),
+    dict({
+      'imported': 'django.urls',
+      'importer': 'django.contrib.sitemaps.views',
+    }),
+    dict({
+      'imported': 'django.utils.deprecation',
+      'importer': 'django.contrib.sitemaps.views',
+    }),
+    dict({
+      'imported': 'django.utils.http',
+      'importer': 'django.contrib.sitemaps.views',
+    }),
+    dict({
+      'imported': 'django.utils.timezone',
+      'importer': 'django.contrib.sitemaps.views',
+    }),
+    dict({
+      'imported': 'django.contrib.admin',
+      'importer': 'django.contrib.sites.admin',
+    }),
+    dict({
+      'imported': 'django.contrib.sites.models',
+      'importer': 'django.contrib.sites.admin',
+    }),
+    dict({
+      'imported': 'django.apps',
+      'importer': 'django.contrib.sites.apps',
+    }),
+    dict({
+      'imported': 'django.contrib.sites.checks',
+      'importer': 'django.contrib.sites.apps',
+    }),
+    dict({
+      'imported': 'django.contrib.sites.management',
+      'importer': 'django.contrib.sites.apps',
+    }),
+    dict({
+      'imported': 'django.core.checks',
+      'importer': 'django.contrib.sites.apps',
+    }),
+    dict({
+      'imported': 'django.db.models.signals',
+      'importer': 'django.contrib.sites.apps',
+    }),
+    dict({
+      'imported': 'django.utils.translation',
+      'importer': 'django.contrib.sites.apps',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.contrib.sites.checks',
+    }),
+    dict({
+      'imported': 'django.core.checks',
+      'importer': 'django.contrib.sites.checks',
+    }),
+    dict({
+      'imported': 'django.apps',
+      'importer': 'django.contrib.sites.management',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.contrib.sites.management',
+    }),
+    dict({
+      'imported': 'django.core.management.color',
+      'importer': 'django.contrib.sites.management',
+    }),
+    dict({
+      'imported': 'django.db',
+      'importer': 'django.contrib.sites.management',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.contrib.sites.managers',
+    }),
+    dict({
+      'imported': 'django.core.checks',
+      'importer': 'django.contrib.sites.managers',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.contrib.sites.managers',
+    }),
+    dict({
+      'imported': 'django.db.models',
+      'importer': 'django.contrib.sites.managers',
+    }),
+    dict({
+      'imported': 'django.contrib.sites.shortcuts',
+      'importer': 'django.contrib.sites.middleware',
+    }),
+    dict({
+      'imported': 'django.utils.deprecation',
+      'importer': 'django.contrib.sites.middleware',
+    }),
+    dict({
+      'imported': 'django.contrib.sites.models',
+      'importer': 'django.contrib.sites.migrations.0001_initial',
+    }),
+    dict({
+      'imported': 'django.db.migrations',
+      'importer': 'django.contrib.sites.migrations.0001_initial',
+    }),
+    dict({
+      'imported': 'django.db.models',
+      'importer': 'django.contrib.sites.migrations.0001_initial',
+    }),
+    dict({
+      'imported': 'django.contrib.sites.models',
+      'importer': 'django.contrib.sites.migrations.0002_alter_domain_unique',
+    }),
+    dict({
+      'imported': 'django.db.migrations',
+      'importer': 'django.contrib.sites.migrations.0002_alter_domain_unique',
+    }),
+    dict({
+      'imported': 'django.db.models',
+      'importer': 'django.contrib.sites.migrations.0002_alter_domain_unique',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.contrib.sites.models',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.contrib.sites.models',
+    }),
+    dict({
+      'imported': 'django.db.models',
+      'importer': 'django.contrib.sites.models',
+    }),
+    dict({
+      'imported': 'django.db.models.signals',
+      'importer': 'django.contrib.sites.models',
+    }),
+    dict({
+      'imported': 'django.http.request',
+      'importer': 'django.contrib.sites.models',
+    }),
+    dict({
+      'imported': 'django.utils.translation',
+      'importer': 'django.contrib.sites.models',
+    }),
+    dict({
+      'imported': 'django.apps',
+      'importer': 'django.contrib.sites.shortcuts',
+    }),
+    dict({
+      'imported': 'django.contrib.sites.models',
+      'importer': 'django.contrib.sites.shortcuts',
+    }),
+    dict({
+      'imported': 'django.contrib.sites.requests',
+      'importer': 'django.contrib.sites.shortcuts',
+    }),
+    dict({
+      'imported': 'django.apps',
+      'importer': 'django.contrib.staticfiles.apps',
+    }),
+    dict({
+      'imported': 'django.contrib.staticfiles.checks',
+      'importer': 'django.contrib.staticfiles.apps',
+    }),
+    dict({
+      'imported': 'django.core.checks',
+      'importer': 'django.contrib.staticfiles.apps',
+    }),
+    dict({
+      'imported': 'django.utils.translation',
+      'importer': 'django.contrib.staticfiles.apps',
+    }),
+    dict({
+      'imported': 'django.contrib.staticfiles.finders',
+      'importer': 'django.contrib.staticfiles.checks',
+    }),
+    dict({
+      'imported': 'django.apps',
+      'importer': 'django.contrib.staticfiles.finders',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.contrib.staticfiles.finders',
+    }),
+    dict({
+      'imported': 'django.contrib.staticfiles.utils',
+      'importer': 'django.contrib.staticfiles.finders',
+    }),
+    dict({
+      'imported': 'django.core.checks',
+      'importer': 'django.contrib.staticfiles.finders',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.contrib.staticfiles.finders',
+    }),
+    dict({
+      'imported': 'django.core.files.storage',
+      'importer': 'django.contrib.staticfiles.finders',
+    }),
+    dict({
+      'imported': 'django.utils._os',
+      'importer': 'django.contrib.staticfiles.finders',
+    }),
+    dict({
+      'imported': 'django.utils.functional',
+      'importer': 'django.contrib.staticfiles.finders',
+    }),
+    dict({
+      'imported': 'django.utils.module_loading',
+      'importer': 'django.contrib.staticfiles.finders',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.contrib.staticfiles.handlers',
+    }),
+    dict({
+      'imported': 'django.contrib.staticfiles.utils',
+      'importer': 'django.contrib.staticfiles.handlers',
+    }),
+    dict({
+      'imported': 'django.contrib.staticfiles.views',
+      'importer': 'django.contrib.staticfiles.handlers',
+    }),
+    dict({
+      'imported': 'django.core.handlers.asgi',
+      'importer': 'django.contrib.staticfiles.handlers',
+    }),
+    dict({
+      'imported': 'django.core.handlers.exception',
+      'importer': 'django.contrib.staticfiles.handlers',
+    }),
+    dict({
+      'imported': 'django.core.handlers.wsgi',
+      'importer': 'django.contrib.staticfiles.handlers',
+    }),
+    dict({
+      'imported': 'django.http',
+      'importer': 'django.contrib.staticfiles.handlers',
+    }),
+    dict({
+      'imported': 'django.apps',
+      'importer': 'django.contrib.staticfiles.management.commands.collectstatic',
+    }),
+    dict({
+      'imported': 'django.contrib.staticfiles.finders',
+      'importer': 'django.contrib.staticfiles.management.commands.collectstatic',
+    }),
+    dict({
+      'imported': 'django.contrib.staticfiles.storage',
+      'importer': 'django.contrib.staticfiles.management.commands.collectstatic',
+    }),
+    dict({
+      'imported': 'django.core.checks',
+      'importer': 'django.contrib.staticfiles.management.commands.collectstatic',
+    }),
+    dict({
+      'imported': 'django.core.files.storage',
+      'importer': 'django.contrib.staticfiles.management.commands.collectstatic',
+    }),
+    dict({
+      'imported': 'django.core.management.base',
+      'importer': 'django.contrib.staticfiles.management.commands.collectstatic',
+    }),
+    dict({
+      'imported': 'django.core.management.color',
+      'importer': 'django.contrib.staticfiles.management.commands.collectstatic',
+    }),
+    dict({
+      'imported': 'django.utils.functional',
+      'importer': 'django.contrib.staticfiles.management.commands.collectstatic',
+    }),
+    dict({
+      'imported': 'django.contrib.staticfiles.finders',
+      'importer': 'django.contrib.staticfiles.management.commands.findstatic',
+    }),
+    dict({
+      'imported': 'django.core.management.base',
+      'importer': 'django.contrib.staticfiles.management.commands.findstatic',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.contrib.staticfiles.management.commands.runserver',
+    }),
+    dict({
+      'imported': 'django.contrib.staticfiles.handlers',
+      'importer': 'django.contrib.staticfiles.management.commands.runserver',
+    }),
+    dict({
+      'imported': 'django.core.management.commands.runserver',
+      'importer': 'django.contrib.staticfiles.management.commands.runserver',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.contrib.staticfiles.storage',
+    }),
+    dict({
+      'imported': 'django.contrib.staticfiles.utils',
+      'importer': 'django.contrib.staticfiles.storage',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.contrib.staticfiles.storage',
+    }),
+    dict({
+      'imported': 'django.core.files.base',
+      'importer': 'django.contrib.staticfiles.storage',
+    }),
+    dict({
+      'imported': 'django.core.files.storage',
+      'importer': 'django.contrib.staticfiles.storage',
+    }),
+    dict({
+      'imported': 'django.utils.crypto',
+      'importer': 'django.contrib.staticfiles.storage',
+    }),
+    dict({
+      'imported': 'django.utils.functional',
+      'importer': 'django.contrib.staticfiles.storage',
+    }),
+    dict({
+      'imported': 'django.contrib.staticfiles.handlers',
+      'importer': 'django.contrib.staticfiles.testing',
+    }),
+    dict({
+      'imported': 'django.test',
+      'importer': 'django.contrib.staticfiles.testing',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.contrib.staticfiles.urls',
+    }),
+    dict({
+      'imported': 'django.conf.urls.static',
+      'importer': 'django.contrib.staticfiles.urls',
+    }),
+    dict({
+      'imported': 'django.contrib.staticfiles.views',
+      'importer': 'django.contrib.staticfiles.urls',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.contrib.staticfiles.utils',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.contrib.staticfiles.utils',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.contrib.staticfiles.views',
+    }),
+    dict({
+      'imported': 'django.contrib.staticfiles.finders',
+      'importer': 'django.contrib.staticfiles.views',
+    }),
+    dict({
+      'imported': 'django.http',
+      'importer': 'django.contrib.staticfiles.views',
+    }),
+    dict({
+      'imported': 'django.views.static',
+      'importer': 'django.contrib.staticfiles.views',
+    }),
+    dict({
+      'imported': 'django.apps',
+      'importer': 'django.contrib.syndication.apps',
+    }),
+    dict({
+      'imported': 'django.utils.translation',
+      'importer': 'django.contrib.syndication.apps',
+    }),
+    dict({
+      'imported': 'django.contrib.sites.shortcuts',
+      'importer': 'django.contrib.syndication.views',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.contrib.syndication.views',
+    }),
+    dict({
+      'imported': 'django.http',
+      'importer': 'django.contrib.syndication.views',
+    }),
+    dict({
+      'imported': 'django.template',
+      'importer': 'django.contrib.syndication.views',
+    }),
+    dict({
+      'imported': 'django.template.loader',
+      'importer': 'django.contrib.syndication.views',
+    }),
+    dict({
+      'imported': 'django.utils.encoding',
+      'importer': 'django.contrib.syndication.views',
+    }),
+    dict({
+      'imported': 'django.utils.feedgenerator',
+      'importer': 'django.contrib.syndication.views',
+    }),
+    dict({
+      'imported': 'django.utils.html',
+      'importer': 'django.contrib.syndication.views',
+    }),
+    dict({
+      'imported': 'django.utils.http',
+      'importer': 'django.contrib.syndication.views',
+    }),
+    dict({
+      'imported': 'django.utils.timezone',
+      'importer': 'django.contrib.syndication.views',
+    }),
+    dict({
+      'imported': 'django.utils.translation',
+      'importer': 'django.contrib.syndication.views',
+    }),
+    dict({
+      'imported': 'django',
+      'importer': 'django.core.asgi',
+    }),
+    dict({
+      'imported': 'django.core.handlers.asgi',
+      'importer': 'django.core.asgi',
+    }),
+    dict({
+      'imported': 'django.core.cache.backends.base',
+      'importer': 'django.core.cache',
+    }),
+    dict({
+      'imported': 'django.core.signals',
+      'importer': 'django.core.cache',
+    }),
+    dict({
+      'imported': 'django.utils.connection',
+      'importer': 'django.core.cache',
+    }),
+    dict({
+      'imported': 'django.utils.module_loading',
+      'importer': 'django.core.cache',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.core.cache.backends.base',
+    }),
+    dict({
+      'imported': 'django.utils.module_loading',
+      'importer': 'django.core.cache.backends.base',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.core.cache.backends.db',
+    }),
+    dict({
+      'imported': 'django.core.cache.backends.base',
+      'importer': 'django.core.cache.backends.db',
+    }),
+    dict({
+      'imported': 'django.db',
+      'importer': 'django.core.cache.backends.db',
+    }),
+    dict({
+      'imported': 'django.db.models',
+      'importer': 'django.core.cache.backends.db',
+    }),
+    dict({
+      'imported': 'django.db.transaction',
+      'importer': 'django.core.cache.backends.db',
+    }),
+    dict({
+      'imported': 'django.utils.timezone',
+      'importer': 'django.core.cache.backends.db',
+    }),
+    dict({
+      'imported': 'django.core.cache.backends.base',
+      'importer': 'django.core.cache.backends.dummy',
+    }),
+    dict({
+      'imported': 'django.core.cache.backends.base',
+      'importer': 'django.core.cache.backends.filebased',
+    }),
+    dict({
+      'imported': 'django.core.files.locks',
+      'importer': 'django.core.cache.backends.filebased',
+    }),
+    dict({
+      'imported': 'django.core.files.move',
+      'importer': 'django.core.cache.backends.filebased',
+    }),
+    dict({
+      'imported': 'django.utils.crypto',
+      'importer': 'django.core.cache.backends.filebased',
+    }),
+    dict({
+      'imported': 'django.core.cache.backends.base',
+      'importer': 'django.core.cache.backends.locmem',
+    }),
+    dict({
+      'imported': 'django.core.cache.backends.base',
+      'importer': 'django.core.cache.backends.memcached',
+    }),
+    dict({
+      'imported': 'django.utils.functional',
+      'importer': 'django.core.cache.backends.memcached',
+    }),
+    dict({
+      'imported': 'django.core.cache.backends.base',
+      'importer': 'django.core.cache.backends.redis',
+    }),
+    dict({
+      'imported': 'django.utils.functional',
+      'importer': 'django.core.cache.backends.redis',
+    }),
+    dict({
+      'imported': 'django.utils.module_loading',
+      'importer': 'django.core.cache.backends.redis',
+    }),
+    dict({
+      'imported': 'django.utils.crypto',
+      'importer': 'django.core.cache.utils',
+    }),
+    dict({
+      'imported': 'django.core.checks.async_checks',
+      'importer': 'django.core.checks',
+    }),
+    dict({
+      'imported': 'django.core.checks.caches',
+      'importer': 'django.core.checks',
+    }),
+    dict({
+      'imported': 'django.core.checks.compatibility.django_4_0',
+      'importer': 'django.core.checks',
+    }),
+    dict({
+      'imported': 'django.core.checks.database',
+      'importer': 'django.core.checks',
+    }),
+    dict({
+      'imported': 'django.core.checks.files',
+      'importer': 'django.core.checks',
+    }),
+    dict({
+      'imported': 'django.core.checks.messages',
+      'importer': 'django.core.checks',
+    }),
+    dict({
+      'imported': 'django.core.checks.model_checks',
+      'importer': 'django.core.checks',
+    }),
+    dict({
+      'imported': 'django.core.checks.registry',
+      'importer': 'django.core.checks',
+    }),
+    dict({
+      'imported': 'django.core.checks.security.base',
+      'importer': 'django.core.checks',
+    }),
+    dict({
+      'imported': 'django.core.checks.security.csrf',
+      'importer': 'django.core.checks',
+    }),
+    dict({
+      'imported': 'django.core.checks.security.sessions',
+      'importer': 'django.core.checks',
+    }),
+    dict({
+      'imported': 'django.core.checks.templates',
+      'importer': 'django.core.checks',
+    }),
+    dict({
+      'imported': 'django.core.checks.translation',
+      'importer': 'django.core.checks',
+    }),
+    dict({
+      'imported': 'django.core.checks.urls',
+      'importer': 'django.core.checks',
+    }),
+    dict({
+      'imported': 'django.core.checks',
+      'importer': 'django.core.checks.async_checks',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.core.checks.caches',
+    }),
+    dict({
+      'imported': 'django.core.cache',
+      'importer': 'django.core.checks.caches',
+    }),
+    dict({
+      'imported': 'django.core.cache.backends.filebased',
+      'importer': 'django.core.checks.caches',
+    }),
+    dict({
+      'imported': 'django.core.checks',
+      'importer': 'django.core.checks.caches',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.core.checks.compatibility.django_4_0',
+    }),
+    dict({
+      'imported': 'django.core.checks',
+      'importer': 'django.core.checks.compatibility.django_4_0',
+    }),
+    dict({
+      'imported': 'django.core.checks',
+      'importer': 'django.core.checks.database',
+    }),
+    dict({
+      'imported': 'django.db',
+      'importer': 'django.core.checks.database',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.core.checks.files',
+    }),
+    dict({
+      'imported': 'django.core.checks',
+      'importer': 'django.core.checks.files',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.core.checks.messages',
+    }),
+    dict({
+      'imported': 'django.db.models',
+      'importer': 'django.core.checks.messages',
+    }),
+    dict({
+      'imported': 'django.apps',
+      'importer': 'django.core.checks.model_checks',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.core.checks.model_checks',
+    }),
+    dict({
+      'imported': 'django.core.checks',
+      'importer': 'django.core.checks.model_checks',
+    }),
+    dict({
+      'imported': 'django.db.models.signals',
+      'importer': 'django.core.checks.model_checks',
+    }),
+    dict({
+      'imported': 'django.utils.inspect',
+      'importer': 'django.core.checks.registry',
+    }),
+    dict({
+      'imported': 'django.utils.itercompat',
+      'importer': 'django.core.checks.registry',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.core.checks.security.base',
+    }),
+    dict({
+      'imported': 'django.core.checks',
+      'importer': 'django.core.checks.security.base',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.core.checks.security.base',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.core.checks.security.csrf',
+    }),
+    dict({
+      'imported': 'django.core.checks',
+      'importer': 'django.core.checks.security.csrf',
+    }),
+    dict({
+      'imported': 'django.middleware.csrf',
+      'importer': 'django.core.checks.security.csrf',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.core.checks.security.sessions',
+    }),
+    dict({
+      'imported': 'django.core.checks',
+      'importer': 'django.core.checks.security.sessions',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.core.checks.templates',
+    }),
+    dict({
+      'imported': 'django.core.checks',
+      'importer': 'django.core.checks.templates',
+    }),
+    dict({
+      'imported': 'django.template.backends.django',
+      'importer': 'django.core.checks.templates',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.core.checks.translation',
+    }),
+    dict({
+      'imported': 'django.core.checks',
+      'importer': 'django.core.checks.translation',
+    }),
+    dict({
+      'imported': 'django.utils.translation',
+      'importer': 'django.core.checks.translation',
+    }),
+    dict({
+      'imported': 'django.utils.translation.trans_real',
+      'importer': 'django.core.checks.translation',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.core.checks.urls',
+    }),
+    dict({
+      'imported': 'django.core.checks',
+      'importer': 'django.core.checks.urls',
+    }),
+    dict({
+      'imported': 'django.urls',
+      'importer': 'django.core.checks.urls',
+    }),
+    dict({
+      'imported': 'django.utils.hashable',
+      'importer': 'django.core.exceptions',
+    }),
+    dict({
+      'imported': 'django.core.files.base',
+      'importer': 'django.core.files',
+    }),
+    dict({
+      'imported': 'django.core.files.utils',
+      'importer': 'django.core.files.base',
+    }),
+    dict({
+      'imported': 'django.utils.functional',
+      'importer': 'django.core.files.base',
+    }),
+    dict({
+      'imported': 'django.core.files',
+      'importer': 'django.core.files.images',
+    }),
+    dict({
+      'imported': 'django.core.files.locks',
+      'importer': 'django.core.files.move',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.core.files.storage',
+    }),
+    dict({
+      'imported': 'django.core.files.storage.base',
+      'importer': 'django.core.files.storage',
+    }),
+    dict({
+      'imported': 'django.core.files.storage.filesystem',
+      'importer': 'django.core.files.storage',
+    }),
+    dict({
+      'imported': 'django.core.files.storage.handler',
+      'importer': 'django.core.files.storage',
+    }),
+    dict({
+      'imported': 'django.core.files.storage.memory',
+      'importer': 'django.core.files.storage',
+    }),
+    dict({
+      'imported': 'django.utils.deprecation',
+      'importer': 'django.core.files.storage',
+    }),
+    dict({
+      'imported': 'django.utils.functional',
+      'importer': 'django.core.files.storage',
+    }),
+    dict({
+      'imported': 'django.utils.module_loading',
+      'importer': 'django.core.files.storage',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.core.files.storage.base',
+    }),
+    dict({
+      'imported': 'django.core.files',
+      'importer': 'django.core.files.storage.base',
+    }),
+    dict({
+      'imported': 'django.core.files.utils',
+      'importer': 'django.core.files.storage.base',
+    }),
+    dict({
+      'imported': 'django.utils.crypto',
+      'importer': 'django.core.files.storage.base',
+    }),
+    dict({
+      'imported': 'django.utils.text',
+      'importer': 'django.core.files.storage.base',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.core.files.storage.filesystem',
+    }),
+    dict({
+      'imported': 'django.core.files',
+      'importer': 'django.core.files.storage.filesystem',
+    }),
+    dict({
+      'imported': 'django.core.files.locks',
+      'importer': 'django.core.files.storage.filesystem',
+    }),
+    dict({
+      'imported': 'django.core.files.move',
+      'importer': 'django.core.files.storage.filesystem',
+    }),
+    dict({
+      'imported': 'django.core.files.storage.base',
+      'importer': 'django.core.files.storage.filesystem',
+    }),
+    dict({
+      'imported': 'django.core.files.storage.mixins',
+      'importer': 'django.core.files.storage.filesystem',
+    }),
+    dict({
+      'imported': 'django.core.signals',
+      'importer': 'django.core.files.storage.filesystem',
+    }),
+    dict({
+      'imported': 'django.utils._os',
+      'importer': 'django.core.files.storage.filesystem',
+    }),
+    dict({
+      'imported': 'django.utils.deconstruct',
+      'importer': 'django.core.files.storage.filesystem',
+    }),
+    dict({
+      'imported': 'django.utils.encoding',
+      'importer': 'django.core.files.storage.filesystem',
+    }),
+    dict({
+      'imported': 'django.utils.functional',
+      'importer': 'django.core.files.storage.filesystem',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.core.files.storage.handler',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.core.files.storage.handler',
+    }),
+    dict({
+      'imported': 'django.utils.functional',
+      'importer': 'django.core.files.storage.handler',
+    }),
+    dict({
+      'imported': 'django.utils.module_loading',
+      'importer': 'django.core.files.storage.handler',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.core.files.storage.memory',
+    }),
+    dict({
+      'imported': 'django.core.files.base',
+      'importer': 'django.core.files.storage.memory',
+    }),
+    dict({
+      'imported': 'django.core.files.storage.base',
+      'importer': 'django.core.files.storage.memory',
+    }),
+    dict({
+      'imported': 'django.core.files.storage.mixins',
+      'importer': 'django.core.files.storage.memory',
+    }),
+    dict({
+      'imported': 'django.core.signals',
+      'importer': 'django.core.files.storage.memory',
+    }),
+    dict({
+      'imported': 'django.utils._os',
+      'importer': 'django.core.files.storage.memory',
+    }),
+    dict({
+      'imported': 'django.utils.deconstruct',
+      'importer': 'django.core.files.storage.memory',
+    }),
+    dict({
+      'imported': 'django.utils.encoding',
+      'importer': 'django.core.files.storage.memory',
+    }),
+    dict({
+      'imported': 'django.utils.functional',
+      'importer': 'django.core.files.storage.memory',
+    }),
+    dict({
+      'imported': 'django.utils.timezone',
+      'importer': 'django.core.files.storage.memory',
+    }),
+    dict({
+      'imported': 'django.core.files.utils',
+      'importer': 'django.core.files.temp',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.core.files.uploadedfile',
+    }),
+    dict({
+      'imported': 'django.core.files.base',
+      'importer': 'django.core.files.uploadedfile',
+    }),
+    dict({
+      'imported': 'django.core.files.temp',
+      'importer': 'django.core.files.uploadedfile',
+    }),
+    dict({
+      'imported': 'django.core.files.utils',
+      'importer': 'django.core.files.uploadedfile',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.core.files.uploadhandler',
+    }),
+    dict({
+      'imported': 'django.core.files.uploadedfile',
+      'importer': 'django.core.files.uploadhandler',
+    }),
+    dict({
+      'imported': 'django.utils.module_loading',
+      'importer': 'django.core.files.uploadhandler',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.core.files.utils',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.core.handlers.asgi',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.core.handlers.asgi',
+    }),
+    dict({
+      'imported': 'django.core.handlers.base',
+      'importer': 'django.core.handlers.asgi',
+    }),
+    dict({
+      'imported': 'django.core.signals',
+      'importer': 'django.core.handlers.asgi',
+    }),
+    dict({
+      'imported': 'django.http',
+      'importer': 'django.core.handlers.asgi',
+    }),
+    dict({
+      'imported': 'django.urls',
+      'importer': 'django.core.handlers.asgi',
+    }),
+    dict({
+      'imported': 'django.utils.asyncio',
+      'importer': 'django.core.handlers.asgi',
+    }),
+    dict({
+      'imported': 'django.utils.functional',
+      'importer': 'django.core.handlers.asgi',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.core.handlers.base',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.core.handlers.base',
+    }),
+    dict({
+      'imported': 'django.core.handlers.exception',
+      'importer': 'django.core.handlers.base',
+    }),
+    dict({
+      'imported': 'django.core.signals',
+      'importer': 'django.core.handlers.base',
+    }),
+    dict({
+      'imported': 'django.db',
+      'importer': 'django.core.handlers.base',
+    }),
+    dict({
+      'imported': 'django.db.transaction',
+      'importer': 'django.core.handlers.base',
+    }),
+    dict({
+      'imported': 'django.urls',
+      'importer': 'django.core.handlers.base',
+    }),
+    dict({
+      'imported': 'django.utils.log',
+      'importer': 'django.core.handlers.base',
+    }),
+    dict({
+      'imported': 'django.utils.module_loading',
+      'importer': 'django.core.handlers.base',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.core.handlers.exception',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.core.handlers.exception',
+    }),
+    dict({
+      'imported': 'django.core.signals',
+      'importer': 'django.core.handlers.exception',
+    }),
+    dict({
+      'imported': 'django.http',
+      'importer': 'django.core.handlers.exception',
+    }),
+    dict({
+      'imported': 'django.http.multipartparser',
+      'importer': 'django.core.handlers.exception',
+    }),
+    dict({
+      'imported': 'django.urls',
+      'importer': 'django.core.handlers.exception',
+    }),
+    dict({
+      'imported': 'django.utils.log',
+      'importer': 'django.core.handlers.exception',
+    }),
+    dict({
+      'imported': 'django.views.debug',
+      'importer': 'django.core.handlers.exception',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.core.handlers.wsgi',
+    }),
+    dict({
+      'imported': 'django.core.handlers.base',
+      'importer': 'django.core.handlers.wsgi',
+    }),
+    dict({
+      'imported': 'django.core.signals',
+      'importer': 'django.core.handlers.wsgi',
+    }),
+    dict({
+      'imported': 'django.http',
+      'importer': 'django.core.handlers.wsgi',
+    }),
+    dict({
+      'imported': 'django.urls',
+      'importer': 'django.core.handlers.wsgi',
+    }),
+    dict({
+      'imported': 'django.utils.encoding',
+      'importer': 'django.core.handlers.wsgi',
+    }),
+    dict({
+      'imported': 'django.utils.functional',
+      'importer': 'django.core.handlers.wsgi',
+    }),
+    dict({
+      'imported': 'django.utils.regex_helper',
+      'importer': 'django.core.handlers.wsgi',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.core.mail',
+    }),
+    dict({
+      'imported': 'django.core.mail.message',
+      'importer': 'django.core.mail',
+    }),
+    dict({
+      'imported': 'django.core.mail.utils',
+      'importer': 'django.core.mail',
+    }),
+    dict({
+      'imported': 'django.utils.module_loading',
+      'importer': 'django.core.mail',
+    }),
+    dict({
+      'imported': 'django.core.mail.backends.base',
+      'importer': 'django.core.mail.backends.console',
+    }),
+    dict({
+      'imported': 'django.core.mail.backends.base',
+      'importer': 'django.core.mail.backends.dummy',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.core.mail.backends.filebased',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.core.mail.backends.filebased',
+    }),
+    dict({
+      'imported': 'django.core.mail.backends.console',
+      'importer': 'django.core.mail.backends.filebased',
+    }),
+    dict({
+      'imported': 'django.core.mail',
+      'importer': 'django.core.mail.backends.locmem',
+    }),
+    dict({
+      'imported': 'django.core.mail.backends.base',
+      'importer': 'django.core.mail.backends.locmem',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.core.mail.backends.smtp',
+    }),
+    dict({
+      'imported': 'django.core.mail.backends.base',
+      'importer': 'django.core.mail.backends.smtp',
+    }),
+    dict({
+      'imported': 'django.core.mail.message',
+      'importer': 'django.core.mail.backends.smtp',
+    }),
+    dict({
+      'imported': 'django.core.mail.utils',
+      'importer': 'django.core.mail.backends.smtp',
+    }),
+    dict({
+      'imported': 'django.utils.functional',
+      'importer': 'django.core.mail.backends.smtp',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.core.mail.message',
+    }),
+    dict({
+      'imported': 'django.core.mail',
+      'importer': 'django.core.mail.message',
+    }),
+    dict({
+      'imported': 'django.core.mail.utils',
+      'importer': 'django.core.mail.message',
+    }),
+    dict({
+      'imported': 'django.utils.encoding',
+      'importer': 'django.core.mail.message',
+    }),
+    dict({
+      'imported': 'django.utils.encoding',
+      'importer': 'django.core.mail.utils',
+    }),
+    dict({
+      'imported': 'django',
+      'importer': 'django.core.management',
+    }),
+    dict({
+      'imported': 'django.apps',
+      'importer': 'django.core.management',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.core.management',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.core.management',
+    }),
+    dict({
+      'imported': 'django.core.management.base',
+      'importer': 'django.core.management',
+    }),
+    dict({
+      'imported': 'django.core.management.color',
+      'importer': 'django.core.management',
+    }),
+    dict({
+      'imported': 'django.utils.autoreload',
+      'importer': 'django.core.management',
+    }),
+    dict({
+      'imported': 'django',
+      'importer': 'django.core.management.base',
+    }),
+    dict({
+      'imported': 'django.apps',
+      'importer': 'django.core.management.base',
+    }),
+    dict({
+      'imported': 'django.core.checks',
+      'importer': 'django.core.management.base',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.core.management.base',
+    }),
+    dict({
+      'imported': 'django.core.management.color',
+      'importer': 'django.core.management.base',
+    }),
+    dict({
+      'imported': 'django.db',
+      'importer': 'django.core.management.base',
+    }),
+    dict({
+      'imported': 'django.db.migrations.executor',
+      'importer': 'django.core.management.base',
+    }),
+    dict({
+      'imported': 'django.utils.translation',
+      'importer': 'django.core.management.base',
+    }),
+    dict({
+      'imported': 'django.utils.termcolors',
+      'importer': 'django.core.management.color',
+    }),
+    dict({
+      'imported': 'django.apps',
+      'importer': 'django.core.management.commands.check',
+    }),
+    dict({
+      'imported': 'django.core.checks',
+      'importer': 'django.core.management.commands.check',
+    }),
+    dict({
+      'imported': 'django.core.checks.registry',
+      'importer': 'django.core.management.commands.check',
+    }),
+    dict({
+      'imported': 'django.core.management.base',
+      'importer': 'django.core.management.commands.check',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.core.management.commands.compilemessages',
+    }),
+    dict({
+      'imported': 'django.core.management.base',
+      'importer': 'django.core.management.commands.compilemessages',
+    }),
+    dict({
+      'imported': 'django.core.management.utils',
+      'importer': 'django.core.management.commands.compilemessages',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.core.management.commands.createcachetable',
+    }),
+    dict({
+      'imported': 'django.core.cache',
+      'importer': 'django.core.management.commands.createcachetable',
+    }),
+    dict({
+      'imported': 'django.core.cache.backends.db',
+      'importer': 'django.core.management.commands.createcachetable',
+    }),
+    dict({
+      'imported': 'django.core.management.base',
+      'importer': 'django.core.management.commands.createcachetable',
+    }),
+    dict({
+      'imported': 'django.db',
+      'importer': 'django.core.management.commands.createcachetable',
+    }),
+    dict({
+      'imported': 'django.db.models',
+      'importer': 'django.core.management.commands.createcachetable',
+    }),
+    dict({
+      'imported': 'django.db.transaction',
+      'importer': 'django.core.management.commands.createcachetable',
+    }),
+    dict({
+      'imported': 'django.core.management.base',
+      'importer': 'django.core.management.commands.dbshell',
+    }),
+    dict({
+      'imported': 'django.db',
+      'importer': 'django.core.management.commands.dbshell',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.core.management.commands.diffsettings',
+    }),
+    dict({
+      'imported': 'django.conf.global_settings',
+      'importer': 'django.core.management.commands.diffsettings',
+    }),
+    dict({
+      'imported': 'django.core.management.base',
+      'importer': 'django.core.management.commands.diffsettings',
+    }),
+    dict({
+      'imported': 'django.apps',
+      'importer': 'django.core.management.commands.dumpdata',
+    }),
+    dict({
+      'imported': 'django.core.management.base',
+      'importer': 'django.core.management.commands.dumpdata',
+    }),
+    dict({
+      'imported': 'django.core.management.utils',
+      'importer': 'django.core.management.commands.dumpdata',
+    }),
+    dict({
+      'imported': 'django.core.serializers',
+      'importer': 'django.core.management.commands.dumpdata',
+    }),
+    dict({
+      'imported': 'django.db',
+      'importer': 'django.core.management.commands.dumpdata',
+    }),
+    dict({
+      'imported': 'django.apps',
+      'importer': 'django.core.management.commands.flush',
+    }),
+    dict({
+      'imported': 'django.core.management.base',
+      'importer': 'django.core.management.commands.flush',
+    }),
+    dict({
+      'imported': 'django.core.management.color',
+      'importer': 'django.core.management.commands.flush',
+    }),
+    dict({
+      'imported': 'django.core.management.sql',
+      'importer': 'django.core.management.commands.flush',
+    }),
+    dict({
+      'imported': 'django.db',
+      'importer': 'django.core.management.commands.flush',
+    }),
+    dict({
+      'imported': 'django.core.management.base',
+      'importer': 'django.core.management.commands.inspectdb',
+    }),
+    dict({
+      'imported': 'django.db',
+      'importer': 'django.core.management.commands.inspectdb',
+    }),
+    dict({
+      'imported': 'django.db.models.constants',
+      'importer': 'django.core.management.commands.inspectdb',
+    }),
+    dict({
+      'imported': 'django.apps',
+      'importer': 'django.core.management.commands.loaddata',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.core.management.commands.loaddata',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.core.management.commands.loaddata',
+    }),
+    dict({
+      'imported': 'django.core.management.base',
+      'importer': 'django.core.management.commands.loaddata',
+    }),
+    dict({
+      'imported': 'django.core.management.color',
+      'importer': 'django.core.management.commands.loaddata',
+    }),
+    dict({
+      'imported': 'django.core.management.utils',
+      'importer': 'django.core.management.commands.loaddata',
+    }),
+    dict({
+      'imported': 'django.core.serializers',
+      'importer': 'django.core.management.commands.loaddata',
+    }),
+    dict({
+      'imported': 'django.db',
+      'importer': 'django.core.management.commands.loaddata',
+    }),
+    dict({
+      'imported': 'django.db.transaction',
+      'importer': 'django.core.management.commands.loaddata',
+    }),
+    dict({
+      'imported': 'django.utils.functional',
+      'importer': 'django.core.management.commands.loaddata',
+    }),
+    dict({
+      'imported': 'django',
+      'importer': 'django.core.management.commands.makemessages',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.core.management.commands.makemessages',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.core.management.commands.makemessages',
+    }),
+    dict({
+      'imported': 'django.core.files.temp',
+      'importer': 'django.core.management.commands.makemessages',
+    }),
+    dict({
+      'imported': 'django.core.management.base',
+      'importer': 'django.core.management.commands.makemessages',
+    }),
+    dict({
+      'imported': 'django.core.management.utils',
+      'importer': 'django.core.management.commands.makemessages',
+    }),
+    dict({
+      'imported': 'django.utils.encoding',
+      'importer': 'django.core.management.commands.makemessages',
+    }),
+    dict({
+      'imported': 'django.utils.functional',
+      'importer': 'django.core.management.commands.makemessages',
+    }),
+    dict({
+      'imported': 'django.utils.jslex',
+      'importer': 'django.core.management.commands.makemessages',
+    }),
+    dict({
+      'imported': 'django.utils.regex_helper',
+      'importer': 'django.core.management.commands.makemessages',
+    }),
+    dict({
+      'imported': 'django.utils.text',
+      'importer': 'django.core.management.commands.makemessages',
+    }),
+    dict({
+      'imported': 'django.utils.translation',
+      'importer': 'django.core.management.commands.makemessages',
+    }),
+    dict({
+      'imported': 'django.apps',
+      'importer': 'django.core.management.commands.makemigrations',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.core.management.commands.makemigrations',
+    }),
+    dict({
+      'imported': 'django.core.management.base',
+      'importer': 'django.core.management.commands.makemigrations',
+    }),
+    dict({
+      'imported': 'django.core.management.utils',
+      'importer': 'django.core.management.commands.makemigrations',
+    }),
+    dict({
+      'imported': 'django.db',
+      'importer': 'django.core.management.commands.makemigrations',
+    }),
+    dict({
+      'imported': 'django.db.migrations',
+      'importer': 'django.core.management.commands.makemigrations',
+    }),
+    dict({
+      'imported': 'django.db.migrations.autodetector',
+      'importer': 'django.core.management.commands.makemigrations',
+    }),
+    dict({
+      'imported': 'django.db.migrations.loader',
+      'importer': 'django.core.management.commands.makemigrations',
+    }),
+    dict({
+      'imported': 'django.db.migrations.migration',
+      'importer': 'django.core.management.commands.makemigrations',
+    }),
+    dict({
+      'imported': 'django.db.migrations.optimizer',
+      'importer': 'django.core.management.commands.makemigrations',
+    }),
+    dict({
+      'imported': 'django.db.migrations.questioner',
+      'importer': 'django.core.management.commands.makemigrations',
+    }),
+    dict({
+      'imported': 'django.db.migrations.state',
+      'importer': 'django.core.management.commands.makemigrations',
+    }),
+    dict({
+      'imported': 'django.db.migrations.utils',
+      'importer': 'django.core.management.commands.makemigrations',
+    }),
+    dict({
+      'imported': 'django.db.migrations.writer',
+      'importer': 'django.core.management.commands.makemigrations',
+    }),
+    dict({
+      'imported': 'django.apps',
+      'importer': 'django.core.management.commands.migrate',
+    }),
+    dict({
+      'imported': 'django.core.management.base',
+      'importer': 'django.core.management.commands.migrate',
+    }),
+    dict({
+      'imported': 'django.core.management.sql',
+      'importer': 'django.core.management.commands.migrate',
+    }),
+    dict({
+      'imported': 'django.db',
+      'importer': 'django.core.management.commands.migrate',
+    }),
+    dict({
+      'imported': 'django.db.migrations.autodetector',
+      'importer': 'django.core.management.commands.migrate',
+    }),
+    dict({
+      'imported': 'django.db.migrations.executor',
+      'importer': 'django.core.management.commands.migrate',
+    }),
+    dict({
+      'imported': 'django.db.migrations.loader',
+      'importer': 'django.core.management.commands.migrate',
+    }),
+    dict({
+      'imported': 'django.db.migrations.state',
+      'importer': 'django.core.management.commands.migrate',
+    }),
+    dict({
+      'imported': 'django.utils.module_loading',
+      'importer': 'django.core.management.commands.migrate',
+    }),
+    dict({
+      'imported': 'django.utils.text',
+      'importer': 'django.core.management.commands.migrate',
+    }),
+    dict({
+      'imported': 'django.apps',
+      'importer': 'django.core.management.commands.optimizemigration',
+    }),
+    dict({
+      'imported': 'django.core.management.base',
+      'importer': 'django.core.management.commands.optimizemigration',
+    }),
+    dict({
+      'imported': 'django.core.management.utils',
+      'importer': 'django.core.management.commands.optimizemigration',
+    }),
+    dict({
+      'imported': 'django.db.migrations',
+      'importer': 'django.core.management.commands.optimizemigration',
+    }),
+    dict({
+      'imported': 'django.db.migrations.exceptions',
+      'importer': 'django.core.management.commands.optimizemigration',
+    }),
+    dict({
+      'imported': 'django.db.migrations.loader',
+      'importer': 'django.core.management.commands.optimizemigration',
+    }),
+    dict({
+      'imported': 'django.db.migrations.optimizer',
+      'importer': 'django.core.management.commands.optimizemigration',
+    }),
+    dict({
+      'imported': 'django.db.migrations.writer',
+      'importer': 'django.core.management.commands.optimizemigration',
+    }),
+    dict({
+      'imported': 'django.utils.version',
+      'importer': 'django.core.management.commands.optimizemigration',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.core.management.commands.runserver',
+    }),
+    dict({
+      'imported': 'django.core.management.base',
+      'importer': 'django.core.management.commands.runserver',
+    }),
+    dict({
+      'imported': 'django.core.servers.basehttp',
+      'importer': 'django.core.management.commands.runserver',
+    }),
+    dict({
+      'imported': 'django.utils.autoreload',
+      'importer': 'django.core.management.commands.runserver',
+    }),
+    dict({
+      'imported': 'django.utils.regex_helper',
+      'importer': 'django.core.management.commands.runserver',
+    }),
+    dict({
+      'imported': 'django.core.mail',
+      'importer': 'django.core.management.commands.sendtestemail',
+    }),
+    dict({
+      'imported': 'django.core.management.base',
+      'importer': 'django.core.management.commands.sendtestemail',
+    }),
+    dict({
+      'imported': 'django.utils.timezone',
+      'importer': 'django.core.management.commands.sendtestemail',
+    }),
+    dict({
+      'imported': 'django.core.management',
+      'importer': 'django.core.management.commands.shell',
+    }),
+    dict({
+      'imported': 'django.utils.datastructures',
+      'importer': 'django.core.management.commands.shell',
+    }),
+    dict({
+      'imported': 'django.apps',
+      'importer': 'django.core.management.commands.showmigrations',
+    }),
+    dict({
+      'imported': 'django.core.management.base',
+      'importer': 'django.core.management.commands.showmigrations',
+    }),
+    dict({
+      'imported': 'django.db',
+      'importer': 'django.core.management.commands.showmigrations',
+    }),
+    dict({
+      'imported': 'django.db.migrations.loader',
+      'importer': 'django.core.management.commands.showmigrations',
+    }),
+    dict({
+      'imported': 'django.db.migrations.recorder',
+      'importer': 'django.core.management.commands.showmigrations',
+    }),
+    dict({
+      'imported': 'django.core.management.base',
+      'importer': 'django.core.management.commands.sqlflush',
+    }),
+    dict({
+      'imported': 'django.core.management.sql',
+      'importer': 'django.core.management.commands.sqlflush',
+    }),
+    dict({
+      'imported': 'django.db',
+      'importer': 'django.core.management.commands.sqlflush',
+    }),
+    dict({
+      'imported': 'django.apps',
+      'importer': 'django.core.management.commands.sqlmigrate',
+    }),
+    dict({
+      'imported': 'django.core.management.base',
+      'importer': 'django.core.management.commands.sqlmigrate',
+    }),
+    dict({
+      'imported': 'django.db',
+      'importer': 'django.core.management.commands.sqlmigrate',
+    }),
+    dict({
+      'imported': 'django.db.migrations.loader',
+      'importer': 'django.core.management.commands.sqlmigrate',
+    }),
+    dict({
+      'imported': 'django.core.management.base',
+      'importer': 'django.core.management.commands.sqlsequencereset',
+    }),
+    dict({
+      'imported': 'django.db',
+      'importer': 'django.core.management.commands.sqlsequencereset',
+    }),
+    dict({
+      'imported': 'django.apps',
+      'importer': 'django.core.management.commands.squashmigrations',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.core.management.commands.squashmigrations',
+    }),
+    dict({
+      'imported': 'django.core.management.base',
+      'importer': 'django.core.management.commands.squashmigrations',
+    }),
+    dict({
+      'imported': 'django.core.management.utils',
+      'importer': 'django.core.management.commands.squashmigrations',
+    }),
+    dict({
+      'imported': 'django.db',
+      'importer': 'django.core.management.commands.squashmigrations',
+    }),
+    dict({
+      'imported': 'django.db.migrations',
+      'importer': 'django.core.management.commands.squashmigrations',
+    }),
+    dict({
+      'imported': 'django.db.migrations.loader',
+      'importer': 'django.core.management.commands.squashmigrations',
+    }),
+    dict({
+      'imported': 'django.db.migrations.migration',
+      'importer': 'django.core.management.commands.squashmigrations',
+    }),
+    dict({
+      'imported': 'django.db.migrations.optimizer',
+      'importer': 'django.core.management.commands.squashmigrations',
+    }),
+    dict({
+      'imported': 'django.db.migrations.writer',
+      'importer': 'django.core.management.commands.squashmigrations',
+    }),
+    dict({
+      'imported': 'django.utils.version',
+      'importer': 'django.core.management.commands.squashmigrations',
+    }),
+    dict({
+      'imported': 'django.core.management.templates',
+      'importer': 'django.core.management.commands.startapp',
+    }),
+    dict({
+      'imported': 'django.core.checks.security.base',
+      'importer': 'django.core.management.commands.startproject',
+    }),
+    dict({
+      'imported': 'django.core.management.templates',
+      'importer': 'django.core.management.commands.startproject',
+    }),
+    dict({
+      'imported': 'django.core.management.utils',
+      'importer': 'django.core.management.commands.startproject',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.core.management.commands.test',
+    }),
+    dict({
+      'imported': 'django.core.management.base',
+      'importer': 'django.core.management.commands.test',
+    }),
+    dict({
+      'imported': 'django.core.management.utils',
+      'importer': 'django.core.management.commands.test',
+    }),
+    dict({
+      'imported': 'django.test.runner',
+      'importer': 'django.core.management.commands.test',
+    }),
+    dict({
+      'imported': 'django.test.utils',
+      'importer': 'django.core.management.commands.test',
+    }),
+    dict({
+      'imported': 'django.core.management',
+      'importer': 'django.core.management.commands.testserver',
+    }),
+    dict({
+      'imported': 'django.core.management.base',
+      'importer': 'django.core.management.commands.testserver',
+    }),
+    dict({
+      'imported': 'django.db',
+      'importer': 'django.core.management.commands.testserver',
+    }),
+    dict({
+      'imported': 'django.apps',
+      'importer': 'django.core.management.sql',
+    }),
+    dict({
+      'imported': 'django.db.models',
+      'importer': 'django.core.management.sql',
+    }),
+    dict({
+      'imported': 'django',
+      'importer': 'django.core.management.templates',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.core.management.templates',
+    }),
+    dict({
+      'imported': 'django.core.management.base',
+      'importer': 'django.core.management.templates',
+    }),
+    dict({
+      'imported': 'django.core.management.utils',
+      'importer': 'django.core.management.templates',
+    }),
+    dict({
+      'imported': 'django.template',
+      'importer': 'django.core.management.templates',
+    }),
+    dict({
+      'imported': 'django.utils.archive',
+      'importer': 'django.core.management.templates',
+    }),
+    dict({
+      'imported': 'django.utils.http',
+      'importer': 'django.core.management.templates',
+    }),
+    dict({
+      'imported': 'django.utils.version',
+      'importer': 'django.core.management.templates',
+    }),
+    dict({
+      'imported': 'django.apps',
+      'importer': 'django.core.management.utils',
+    }),
+    dict({
+      'imported': 'django.core.management.base',
+      'importer': 'django.core.management.utils',
+    }),
+    dict({
+      'imported': 'django.utils.crypto',
+      'importer': 'django.core.management.utils',
+    }),
+    dict({
+      'imported': 'django.utils.encoding',
+      'importer': 'django.core.management.utils',
+    }),
+    dict({
+      'imported': 'django.utils.functional',
+      'importer': 'django.core.paginator',
+    }),
+    dict({
+      'imported': 'django.utils.inspect',
+      'importer': 'django.core.paginator',
+    }),
+    dict({
+      'imported': 'django.utils.translation',
+      'importer': 'django.core.paginator',
+    }),
+    dict({
+      'imported': 'django.apps',
+      'importer': 'django.core.serializers',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.core.serializers',
+    }),
+    dict({
+      'imported': 'django.core.serializers.base',
+      'importer': 'django.core.serializers',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.core.serializers.base',
+    }),
+    dict({
+      'imported': 'django.db.models',
+      'importer': 'django.core.serializers.base',
+    }),
+    dict({
+      'imported': 'django.utils.deprecation',
+      'importer': 'django.core.serializers.base',
+    }),
+    dict({
+      'imported': 'django.core.serializers.base',
+      'importer': 'django.core.serializers.json',
+    }),
+    dict({
+      'imported': 'django.core.serializers.python',
+      'importer': 'django.core.serializers.json',
+    }),
+    dict({
+      'imported': 'django.utils.duration',
+      'importer': 'django.core.serializers.json',
+    }),
+    dict({
+      'imported': 'django.utils.functional',
+      'importer': 'django.core.serializers.json',
+    }),
+    dict({
+      'imported': 'django.utils.timezone',
+      'importer': 'django.core.serializers.json',
+    }),
+    dict({
+      'imported': 'django.core.serializers.base',
+      'importer': 'django.core.serializers.jsonl',
+    }),
+    dict({
+      'imported': 'django.core.serializers.json',
+      'importer': 'django.core.serializers.jsonl',
+    }),
+    dict({
+      'imported': 'django.core.serializers.python',
+      'importer': 'django.core.serializers.jsonl',
+    }),
+    dict({
+      'imported': 'django.apps',
+      'importer': 'django.core.serializers.python',
+    }),
+    dict({
+      'imported': 'django.core.serializers.base',
+      'importer': 'django.core.serializers.python',
+    }),
+    dict({
+      'imported': 'django.db',
+      'importer': 'django.core.serializers.python',
+    }),
+    dict({
+      'imported': 'django.db.models',
+      'importer': 'django.core.serializers.python',
+    }),
+    dict({
+      'imported': 'django.utils.encoding',
+      'importer': 'django.core.serializers.python',
+    }),
+    dict({
+      'imported': 'django.core.serializers.base',
+      'importer': 'django.core.serializers.pyyaml',
+    }),
+    dict({
+      'imported': 'django.core.serializers.python',
+      'importer': 'django.core.serializers.pyyaml',
+    }),
+    dict({
+      'imported': 'django.db.models',
+      'importer': 'django.core.serializers.pyyaml',
+    }),
+    dict({
+      'imported': 'django.apps',
+      'importer': 'django.core.serializers.xml_serializer',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.core.serializers.xml_serializer',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.core.serializers.xml_serializer',
+    }),
+    dict({
+      'imported': 'django.core.serializers.base',
+      'importer': 'django.core.serializers.xml_serializer',
+    }),
+    dict({
+      'imported': 'django.db',
+      'importer': 'django.core.serializers.xml_serializer',
+    }),
+    dict({
+      'imported': 'django.db.models',
+      'importer': 'django.core.serializers.xml_serializer',
+    }),
+    dict({
+      'imported': 'django.utils.xmlutils',
+      'importer': 'django.core.serializers.xml_serializer',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.core.servers.basehttp',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.core.servers.basehttp',
+    }),
+    dict({
+      'imported': 'django.core.handlers.wsgi',
+      'importer': 'django.core.servers.basehttp',
+    }),
+    dict({
+      'imported': 'django.core.wsgi',
+      'importer': 'django.core.servers.basehttp',
+    }),
+    dict({
+      'imported': 'django.db',
+      'importer': 'django.core.servers.basehttp',
+    }),
+    dict({
+      'imported': 'django.utils.module_loading',
+      'importer': 'django.core.servers.basehttp',
+    }),
+    dict({
+      'imported': 'django.dispatch',
+      'importer': 'django.core.signals',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.core.signing',
+    }),
+    dict({
+      'imported': 'django.utils.crypto',
+      'importer': 'django.core.signing',
+    }),
+    dict({
+      'imported': 'django.utils.deprecation',
+      'importer': 'django.core.signing',
+    }),
+    dict({
+      'imported': 'django.utils.encoding',
+      'importer': 'django.core.signing',
+    }),
+    dict({
+      'imported': 'django.utils.module_loading',
+      'importer': 'django.core.signing',
+    }),
+    dict({
+      'imported': 'django.utils.regex_helper',
+      'importer': 'django.core.signing',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.core.validators',
+    }),
+    dict({
+      'imported': 'django.utils.deconstruct',
+      'importer': 'django.core.validators',
+    }),
+    dict({
+      'imported': 'django.utils.encoding',
+      'importer': 'django.core.validators',
+    }),
+    dict({
+      'imported': 'django.utils.ipv6',
+      'importer': 'django.core.validators',
+    }),
+    dict({
+      'imported': 'django.utils.regex_helper',
+      'importer': 'django.core.validators',
+    }),
+    dict({
+      'imported': 'django.utils.translation',
+      'importer': 'django.core.validators',
+    }),
+    dict({
+      'imported': 'django',
+      'importer': 'django.core.wsgi',
+    }),
+    dict({
+      'imported': 'django.core.handlers.wsgi',
+      'importer': 'django.core.wsgi',
+    }),
+    dict({
+      'imported': 'django.core.signals',
+      'importer': 'django.db',
+    }),
+    dict({
+      'imported': 'django.db.utils',
+      'importer': 'django.db',
+    }),
+    dict({
+      'imported': 'django.utils.connection',
+      'importer': 'django.db',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.db.backends.base.base',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.db.backends.base.base',
+    }),
+    dict({
+      'imported': 'django.db',
+      'importer': 'django.db.backends.base.base',
+    }),
+    dict({
+      'imported': 'django.db.backends.base.validation',
+      'importer': 'django.db.backends.base.base',
+    }),
+    dict({
+      'imported': 'django.db.backends.signals',
+      'importer': 'django.db.backends.base.base',
+    }),
+    dict({
+      'imported': 'django.db.backends.utils',
+      'importer': 'django.db.backends.base.base',
+    }),
+    dict({
+      'imported': 'django.db.transaction',
+      'importer': 'django.db.backends.base.base',
+    }),
+    dict({
+      'imported': 'django.db.utils',
+      'importer': 'django.db.backends.base.base',
+    }),
+    dict({
+      'imported': 'django.utils.asyncio',
+      'importer': 'django.db.backends.base.base',
+    }),
+    dict({
+      'imported': 'django.utils.functional',
+      'importer': 'django.db.backends.base.base',
+    }),
+    dict({
+      'imported': 'django.apps',
+      'importer': 'django.db.backends.base.creation',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.db.backends.base.creation',
+    }),
+    dict({
+      'imported': 'django.core.management',
+      'importer': 'django.db.backends.base.creation',
+    }),
+    dict({
+      'imported': 'django.core.serializers',
+      'importer': 'django.db.backends.base.creation',
+    }),
+    dict({
+      'imported': 'django.db',
+      'importer': 'django.db.backends.base.creation',
+    }),
+    dict({
+      'imported': 'django.db.migrations.loader',
+      'importer': 'django.db.backends.base.creation',
+    }),
+    dict({
+      'imported': 'django.db.transaction',
+      'importer': 'django.db.backends.base.creation',
+    }),
+    dict({
+      'imported': 'django.utils.module_loading',
+      'importer': 'django.db.backends.base.creation',
+    }),
+    dict({
+      'imported': 'django.db',
+      'importer': 'django.db.backends.base.features',
+    }),
+    dict({
+      'imported': 'django.utils.functional',
+      'importer': 'django.db.backends.base.features',
+    }),
+    dict({
+      'imported': 'django.apps',
+      'importer': 'django.db.backends.base.introspection',
+    }),
+    dict({
+      'imported': 'django.db',
+      'importer': 'django.db.backends.base.introspection',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.db.backends.base.operations',
+    }),
+    dict({
+      'imported': 'django.db',
+      'importer': 'django.db.backends.base.operations',
+    }),
+    dict({
+      'imported': 'django.db.backends.utils',
+      'importer': 'django.db.backends.base.operations',
+    }),
+    dict({
+      'imported': 'django.db.transaction',
+      'importer': 'django.db.backends.base.operations',
+    }),
+    dict({
+      'imported': 'django.utils.encoding',
+      'importer': 'django.db.backends.base.operations',
+    }),
+    dict({
+      'imported': 'django.utils.timezone',
+      'importer': 'django.db.backends.base.operations',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.db.backends.base.schema',
+    }),
+    dict({
+      'imported': 'django.db.backends.ddl_references',
+      'importer': 'django.db.backends.base.schema',
+    }),
+    dict({
+      'imported': 'django.db.backends.utils',
+      'importer': 'django.db.backends.base.schema',
+    }),
+    dict({
+      'imported': 'django.db.models',
+      'importer': 'django.db.backends.base.schema',
+    }),
+    dict({
+      'imported': 'django.db.models.sql',
+      'importer': 'django.db.backends.base.schema',
+    }),
+    dict({
+      'imported': 'django.db.transaction',
+      'importer': 'django.db.backends.base.schema',
+    }),
+    dict({
+      'imported': 'django.utils.timezone',
+      'importer': 'django.db.backends.base.schema',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.db.backends.dummy.base',
+    }),
+    dict({
+      'imported': 'django.db.backends.base.base',
+      'importer': 'django.db.backends.dummy.base',
+    }),
+    dict({
+      'imported': 'django.db.backends.base.client',
+      'importer': 'django.db.backends.dummy.base',
+    }),
+    dict({
+      'imported': 'django.db.backends.base.creation',
+      'importer': 'django.db.backends.dummy.base',
+    }),
+    dict({
+      'imported': 'django.db.backends.base.introspection',
+      'importer': 'django.db.backends.dummy.base',
+    }),
+    dict({
+      'imported': 'django.db.backends.base.operations',
+      'importer': 'django.db.backends.dummy.base',
+    }),
+    dict({
+      'imported': 'django.db.backends.dummy.features',
+      'importer': 'django.db.backends.dummy.base',
+    }),
+    dict({
+      'imported': 'django.db.backends.base.features',
+      'importer': 'django.db.backends.dummy.features',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.db.backends.mysql.base',
+    }),
+    dict({
+      'imported': 'django.db',
+      'importer': 'django.db.backends.mysql.base',
+    }),
+    dict({
+      'imported': 'django.db.backends.base.base',
+      'importer': 'django.db.backends.mysql.base',
+    }),
+    dict({
+      'imported': 'django.db.backends.mysql.client',
+      'importer': 'django.db.backends.mysql.base',
+    }),
+    dict({
+      'imported': 'django.db.backends.mysql.creation',
+      'importer': 'django.db.backends.mysql.base',
+    }),
+    dict({
+      'imported': 'django.db.backends.mysql.features',
+      'importer': 'django.db.backends.mysql.base',
+    }),
+    dict({
+      'imported': 'django.db.backends.mysql.introspection',
+      'importer': 'django.db.backends.mysql.base',
+    }),
+    dict({
+      'imported': 'django.db.backends.mysql.operations',
+      'importer': 'django.db.backends.mysql.base',
+    }),
+    dict({
+      'imported': 'django.db.backends.mysql.schema',
+      'importer': 'django.db.backends.mysql.base',
+    }),
+    dict({
+      'imported': 'django.db.backends.mysql.validation',
+      'importer': 'django.db.backends.mysql.base',
+    }),
+    dict({
+      'imported': 'django.db.backends.utils',
+      'importer': 'django.db.backends.mysql.base',
+    }),
+    dict({
+      'imported': 'django.utils.asyncio',
+      'importer': 'django.db.backends.mysql.base',
+    }),
+    dict({
+      'imported': 'django.utils.functional',
+      'importer': 'django.db.backends.mysql.base',
+    }),
+    dict({
+      'imported': 'django.utils.regex_helper',
+      'importer': 'django.db.backends.mysql.base',
+    }),
+    dict({
+      'imported': 'django.db.backends.base.client',
+      'importer': 'django.db.backends.mysql.client',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.db.backends.mysql.compiler',
+    }),
+    dict({
+      'imported': 'django.db.models.expressions',
+      'importer': 'django.db.backends.mysql.compiler',
+    }),
+    dict({
+      'imported': 'django.db.models.sql.compiler',
+      'importer': 'django.db.backends.mysql.compiler',
+    }),
+    dict({
+      'imported': 'django.db.backends.base.creation',
+      'importer': 'django.db.backends.mysql.creation',
+    }),
+    dict({
+      'imported': 'django.db.backends.mysql.client',
+      'importer': 'django.db.backends.mysql.creation',
+    }),
+    dict({
+      'imported': 'django.db.backends.base.features',
+      'importer': 'django.db.backends.mysql.features',
+    }),
+    dict({
+      'imported': 'django.utils.functional',
+      'importer': 'django.db.backends.mysql.features',
+    }),
+    dict({
+      'imported': 'django.db.backends.base.introspection',
+      'importer': 'django.db.backends.mysql.introspection',
+    }),
+    dict({
+      'imported': 'django.db.models',
+      'importer': 'django.db.backends.mysql.introspection',
+    }),
+    dict({
+      'imported': 'django.utils.datastructures',
+      'importer': 'django.db.backends.mysql.introspection',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.db.backends.mysql.operations',
+    }),
+    dict({
+      'imported': 'django.db.backends.base.operations',
+      'importer': 'django.db.backends.mysql.operations',
+    }),
+    dict({
+      'imported': 'django.db.backends.utils',
+      'importer': 'django.db.backends.mysql.operations',
+    }),
+    dict({
+      'imported': 'django.db.models',
+      'importer': 'django.db.backends.mysql.operations',
+    }),
+    dict({
+      'imported': 'django.db.models.constants',
+      'importer': 'django.db.backends.mysql.operations',
+    }),
+    dict({
+      'imported': 'django.utils.encoding',
+      'importer': 'django.db.backends.mysql.operations',
+    }),
+    dict({
+      'imported': 'django.utils.regex_helper',
+      'importer': 'django.db.backends.mysql.operations',
+    }),
+    dict({
+      'imported': 'django.utils.timezone',
+      'importer': 'django.db.backends.mysql.operations',
+    }),
+    dict({
+      'imported': 'django.db.backends.base.schema',
+      'importer': 'django.db.backends.mysql.schema',
+    }),
+    dict({
+      'imported': 'django.db.models',
+      'importer': 'django.db.backends.mysql.schema',
+    }),
+    dict({
+      'imported': 'django.db.models.constants',
+      'importer': 'django.db.backends.mysql.schema',
+    }),
+    dict({
+      'imported': 'django.core.checks',
+      'importer': 'django.db.backends.mysql.validation',
+    }),
+    dict({
+      'imported': 'django.db.backends.base.validation',
+      'importer': 'django.db.backends.mysql.validation',
+    }),
+    dict({
+      'imported': 'django.utils.version',
+      'importer': 'django.db.backends.mysql.validation',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.db.backends.oracle.base',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.db.backends.oracle.base',
+    }),
+    dict({
+      'imported': 'django.db',
+      'importer': 'django.db.backends.oracle.base',
+    }),
+    dict({
+      'imported': 'django.db.backends.base.base',
+      'importer': 'django.db.backends.oracle.base',
+    }),
+    dict({
+      'imported': 'django.db.backends.oracle.client',
+      'importer': 'django.db.backends.oracle.base',
+    }),
+    dict({
+      'imported': 'django.db.backends.oracle.creation',
+      'importer': 'django.db.backends.oracle.base',
+    }),
+    dict({
+      'imported': 'django.db.backends.oracle.features',
+      'importer': 'django.db.backends.oracle.base',
+    }),
+    dict({
+      'imported': 'django.db.backends.oracle.introspection',
+      'importer': 'django.db.backends.oracle.base',
+    }),
+    dict({
+      'imported': 'django.db.backends.oracle.operations',
+      'importer': 'django.db.backends.oracle.base',
+    }),
+    dict({
+      'imported': 'django.db.backends.oracle.schema',
+      'importer': 'django.db.backends.oracle.base',
+    }),
+    dict({
+      'imported': 'django.db.backends.oracle.utils',
+      'importer': 'django.db.backends.oracle.base',
+    }),
+    dict({
+      'imported': 'django.db.backends.oracle.validation',
+      'importer': 'django.db.backends.oracle.base',
+    }),
+    dict({
+      'imported': 'django.db.backends.utils',
+      'importer': 'django.db.backends.oracle.base',
+    }),
+    dict({
+      'imported': 'django.utils.asyncio',
+      'importer': 'django.db.backends.oracle.base',
+    }),
+    dict({
+      'imported': 'django.utils.encoding',
+      'importer': 'django.db.backends.oracle.base',
+    }),
+    dict({
+      'imported': 'django.utils.functional',
+      'importer': 'django.db.backends.oracle.base',
+    }),
+    dict({
+      'imported': 'django.db.backends.base.client',
+      'importer': 'django.db.backends.oracle.client',
+    }),
+    dict({
+      'imported': 'django.db.backends.oracle.utils',
+      'importer': 'django.db.backends.oracle.client',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.db.backends.oracle.creation',
+    }),
+    dict({
+      'imported': 'django.db',
+      'importer': 'django.db.backends.oracle.creation',
+    }),
+    dict({
+      'imported': 'django.db.backends.base.creation',
+      'importer': 'django.db.backends.oracle.creation',
+    }),
+    dict({
+      'imported': 'django.utils.crypto',
+      'importer': 'django.db.backends.oracle.creation',
+    }),
+    dict({
+      'imported': 'django.utils.functional',
+      'importer': 'django.db.backends.oracle.creation',
+    }),
+    dict({
+      'imported': 'django.db',
+      'importer': 'django.db.backends.oracle.features',
+    }),
+    dict({
+      'imported': 'django.db.backends.base.features',
+      'importer': 'django.db.backends.oracle.features',
+    }),
+    dict({
+      'imported': 'django.utils.functional',
+      'importer': 'django.db.backends.oracle.features',
+    }),
+    dict({
+      'imported': 'django.db.models',
+      'importer': 'django.db.backends.oracle.functions',
+    }),
+    dict({
+      'imported': 'django.db.backends.base.introspection',
+      'importer': 'django.db.backends.oracle.introspection',
+    }),
+    dict({
+      'imported': 'django.db.models',
+      'importer': 'django.db.backends.oracle.introspection',
+    }),
+    dict({
+      'imported': 'django.utils.functional',
+      'importer': 'django.db.backends.oracle.introspection',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.db.backends.oracle.operations',
+    }),
+    dict({
+      'imported': 'django.db',
+      'importer': 'django.db.backends.oracle.operations',
+    }),
+    dict({
+      'imported': 'django.db.backends.base.operations',
+      'importer': 'django.db.backends.oracle.operations',
+    }),
+    dict({
+      'imported': 'django.db.backends.oracle.base',
+      'importer': 'django.db.backends.oracle.operations',
+    }),
+    dict({
+      'imported': 'django.db.backends.oracle.utils',
+      'importer': 'django.db.backends.oracle.operations',
+    }),
+    dict({
+      'imported': 'django.db.backends.utils',
+      'importer': 'django.db.backends.oracle.operations',
+    }),
+    dict({
+      'imported': 'django.db.models',
+      'importer': 'django.db.backends.oracle.operations',
+    }),
+    dict({
+      'imported': 'django.db.models.expressions',
+      'importer': 'django.db.backends.oracle.operations',
+    }),
+    dict({
+      'imported': 'django.db.models.sql.where',
+      'importer': 'django.db.backends.oracle.operations',
+    }),
+    dict({
+      'imported': 'django.utils.encoding',
+      'importer': 'django.db.backends.oracle.operations',
+    }),
+    dict({
+      'imported': 'django.utils.functional',
+      'importer': 'django.db.backends.oracle.operations',
+    }),
+    dict({
+      'imported': 'django.utils.regex_helper',
+      'importer': 'django.db.backends.oracle.operations',
+    }),
+    dict({
+      'imported': 'django.utils.timezone',
+      'importer': 'django.db.backends.oracle.operations',
+    }),
+    dict({
+      'imported': 'django.db',
+      'importer': 'django.db.backends.oracle.schema',
+    }),
+    dict({
+      'imported': 'django.db.backends.base.schema',
+      'importer': 'django.db.backends.oracle.schema',
+    }),
+    dict({
+      'imported': 'django.utils.duration',
+      'importer': 'django.db.backends.oracle.schema',
+    }),
+    dict({
+      'imported': 'django.db.backends.oracle.base',
+      'importer': 'django.db.backends.oracle.utils',
+    }),
+    dict({
+      'imported': 'django.core.checks',
+      'importer': 'django.db.backends.oracle.validation',
+    }),
+    dict({
+      'imported': 'django.db.backends.base.validation',
+      'importer': 'django.db.backends.oracle.validation',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.db.backends.postgresql.base',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.db.backends.postgresql.base',
+    }),
+    dict({
+      'imported': 'django.db',
+      'importer': 'django.db.backends.postgresql.base',
+    }),
+    dict({
+      'imported': 'django.db.backends.base.base',
+      'importer': 'django.db.backends.postgresql.base',
+    }),
+    dict({
+      'imported': 'django.db.backends.postgresql.client',
+      'importer': 'django.db.backends.postgresql.base',
+    }),
+    dict({
+      'imported': 'django.db.backends.postgresql.creation',
+      'importer': 'django.db.backends.postgresql.base',
+    }),
+    dict({
+      'imported': 'django.db.backends.postgresql.features',
+      'importer': 'django.db.backends.postgresql.base',
+    }),
+    dict({
+      'imported': 'django.db.backends.postgresql.introspection',
+      'importer': 'django.db.backends.postgresql.base',
+    }),
+    dict({
+      'imported': 'django.db.backends.postgresql.operations',
+      'importer': 'django.db.backends.postgresql.base',
+    }),
+    dict({
+      'imported': 'django.db.backends.postgresql.psycopg_any',
+      'importer': 'django.db.backends.postgresql.base',
+    }),
+    dict({
+      'imported': 'django.db.backends.postgresql.schema',
+      'importer': 'django.db.backends.postgresql.base',
+    }),
+    dict({
+      'imported': 'django.db.backends.utils',
+      'importer': 'django.db.backends.postgresql.base',
+    }),
+    dict({
+      'imported': 'django.utils.asyncio',
+      'importer': 'django.db.backends.postgresql.base',
+    }),
+    dict({
+      'imported': 'django.utils.functional',
+      'importer': 'django.db.backends.postgresql.base',
+    }),
+    dict({
+      'imported': 'django.utils.safestring',
+      'importer': 'django.db.backends.postgresql.base',
+    }),
+    dict({
+      'imported': 'django.utils.version',
+      'importer': 'django.db.backends.postgresql.base',
+    }),
+    dict({
+      'imported': 'django.db.backends.base.client',
+      'importer': 'django.db.backends.postgresql.client',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.db.backends.postgresql.creation',
+    }),
+    dict({
+      'imported': 'django.db.backends.base.creation',
+      'importer': 'django.db.backends.postgresql.creation',
+    }),
+    dict({
+      'imported': 'django.db.backends.postgresql.psycopg_any',
+      'importer': 'django.db.backends.postgresql.creation',
+    }),
+    dict({
+      'imported': 'django.db.backends.utils',
+      'importer': 'django.db.backends.postgresql.creation',
+    }),
+    dict({
+      'imported': 'django.db',
+      'importer': 'django.db.backends.postgresql.features',
+    }),
+    dict({
+      'imported': 'django.db.backends.base.features',
+      'importer': 'django.db.backends.postgresql.features',
+    }),
+    dict({
+      'imported': 'django.db.backends.postgresql.psycopg_any',
+      'importer': 'django.db.backends.postgresql.features',
+    }),
+    dict({
+      'imported': 'django.utils.functional',
+      'importer': 'django.db.backends.postgresql.features',
+    }),
+    dict({
+      'imported': 'django.db.backends.base.introspection',
+      'importer': 'django.db.backends.postgresql.introspection',
+    }),
+    dict({
+      'imported': 'django.db.models',
+      'importer': 'django.db.backends.postgresql.introspection',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.db.backends.postgresql.operations',
+    }),
+    dict({
+      'imported': 'django.db.backends.base.operations',
+      'importer': 'django.db.backends.postgresql.operations',
+    }),
+    dict({
+      'imported': 'django.db.backends.postgresql.psycopg_any',
+      'importer': 'django.db.backends.postgresql.operations',
+    }),
+    dict({
+      'imported': 'django.db.backends.utils',
+      'importer': 'django.db.backends.postgresql.operations',
+    }),
+    dict({
+      'imported': 'django.db.models',
+      'importer': 'django.db.backends.postgresql.operations',
+    }),
+    dict({
+      'imported': 'django.db.models.constants',
+      'importer': 'django.db.backends.postgresql.operations',
+    }),
+    dict({
+      'imported': 'django.utils.regex_helper',
+      'importer': 'django.db.backends.postgresql.operations',
+    }),
+    dict({
+      'imported': 'django.db.backends.base.schema',
+      'importer': 'django.db.backends.postgresql.schema',
+    }),
+    dict({
+      'imported': 'django.db.backends.ddl_references',
+      'importer': 'django.db.backends.postgresql.schema',
+    }),
+    dict({
+      'imported': 'django.db.backends.postgresql.psycopg_any',
+      'importer': 'django.db.backends.postgresql.schema',
+    }),
+    dict({
+      'imported': 'django.db.backends.utils',
+      'importer': 'django.db.backends.postgresql.schema',
+    }),
+    dict({
+      'imported': 'django.dispatch',
+      'importer': 'django.db.backends.signals',
+    }),
+    dict({
+      'imported': 'django.db.backends.base.base',
+      'importer': 'django.db.backends.sqlite3._functions',
+    }),
+    dict({
+      'imported': 'django.db.backends.utils',
+      'importer': 'django.db.backends.sqlite3._functions',
+    }),
+    dict({
+      'imported': 'django.utils.crypto',
+      'importer': 'django.db.backends.sqlite3._functions',
+    }),
+    dict({
+      'imported': 'django.utils.duration',
+      'importer': 'django.db.backends.sqlite3._functions',
+    }),
+    dict({
+      'imported': 'django.utils.timezone',
+      'importer': 'django.db.backends.sqlite3._functions',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.db.backends.sqlite3.base',
+    }),
+    dict({
+      'imported': 'django.db',
+      'importer': 'django.db.backends.sqlite3.base',
+    }),
+    dict({
+      'imported': 'django.db.backends.base.base',
+      'importer': 'django.db.backends.sqlite3.base',
+    }),
+    dict({
+      'imported': 'django.db.backends.sqlite3._functions',
+      'importer': 'django.db.backends.sqlite3.base',
+    }),
+    dict({
+      'imported': 'django.db.backends.sqlite3.client',
+      'importer': 'django.db.backends.sqlite3.base',
+    }),
+    dict({
+      'imported': 'django.db.backends.sqlite3.creation',
+      'importer': 'django.db.backends.sqlite3.base',
+    }),
+    dict({
+      'imported': 'django.db.backends.sqlite3.features',
+      'importer': 'django.db.backends.sqlite3.base',
+    }),
+    dict({
+      'imported': 'django.db.backends.sqlite3.introspection',
+      'importer': 'django.db.backends.sqlite3.base',
+    }),
+    dict({
+      'imported': 'django.db.backends.sqlite3.operations',
+      'importer': 'django.db.backends.sqlite3.base',
+    }),
+    dict({
+      'imported': 'django.db.backends.sqlite3.schema',
+      'importer': 'django.db.backends.sqlite3.base',
+    }),
+    dict({
+      'imported': 'django.utils.asyncio',
+      'importer': 'django.db.backends.sqlite3.base',
+    }),
+    dict({
+      'imported': 'django.utils.dateparse',
+      'importer': 'django.db.backends.sqlite3.base',
+    }),
+    dict({
+      'imported': 'django.utils.regex_helper',
+      'importer': 'django.db.backends.sqlite3.base',
+    }),
+    dict({
+      'imported': 'django.db.backends.base.client',
+      'importer': 'django.db.backends.sqlite3.client',
+    }),
+    dict({
+      'imported': 'django.db',
+      'importer': 'django.db.backends.sqlite3.creation',
+    }),
+    dict({
+      'imported': 'django.db.backends.base.creation',
+      'importer': 'django.db.backends.sqlite3.creation',
+    }),
+    dict({
+      'imported': 'django.db.backends.base.features',
+      'importer': 'django.db.backends.sqlite3.features',
+    }),
+    dict({
+      'imported': 'django.db.backends.sqlite3.base',
+      'importer': 'django.db.backends.sqlite3.features',
+    }),
+    dict({
+      'imported': 'django.db.transaction',
+      'importer': 'django.db.backends.sqlite3.features',
+    }),
+    dict({
+      'imported': 'django.db.utils',
+      'importer': 'django.db.backends.sqlite3.features',
+    }),
+    dict({
+      'imported': 'django.utils.functional',
+      'importer': 'django.db.backends.sqlite3.features',
+    }),
+    dict({
+      'imported': 'django.db',
+      'importer': 'django.db.backends.sqlite3.introspection',
+    }),
+    dict({
+      'imported': 'django.db.backends.base.introspection',
+      'importer': 'django.db.backends.sqlite3.introspection',
+    }),
+    dict({
+      'imported': 'django.db.models',
+      'importer': 'django.db.backends.sqlite3.introspection',
+    }),
+    dict({
+      'imported': 'django.utils.regex_helper',
+      'importer': 'django.db.backends.sqlite3.introspection',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.db.backends.sqlite3.operations',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.db.backends.sqlite3.operations',
+    }),
+    dict({
+      'imported': 'django.db',
+      'importer': 'django.db.backends.sqlite3.operations',
+    }),
+    dict({
+      'imported': 'django.db.backends.base.operations',
+      'importer': 'django.db.backends.sqlite3.operations',
+    }),
+    dict({
+      'imported': 'django.db.models',
+      'importer': 'django.db.backends.sqlite3.operations',
+    }),
+    dict({
+      'imported': 'django.db.models.constants',
+      'importer': 'django.db.backends.sqlite3.operations',
+    }),
+    dict({
+      'imported': 'django.db.models.expressions',
+      'importer': 'django.db.backends.sqlite3.operations',
+    }),
+    dict({
+      'imported': 'django.utils.dateparse',
+      'importer': 'django.db.backends.sqlite3.operations',
+    }),
+    dict({
+      'imported': 'django.utils.functional',
+      'importer': 'django.db.backends.sqlite3.operations',
+    }),
+    dict({
+      'imported': 'django.utils.timezone',
+      'importer': 'django.db.backends.sqlite3.operations',
+    }),
+    dict({
+      'imported': 'django.apps.registry',
+      'importer': 'django.db.backends.sqlite3.schema',
+    }),
+    dict({
+      'imported': 'django.db',
+      'importer': 'django.db.backends.sqlite3.schema',
+    }),
+    dict({
+      'imported': 'django.db.backends.base.schema',
+      'importer': 'django.db.backends.sqlite3.schema',
+    }),
+    dict({
+      'imported': 'django.db.backends.ddl_references',
+      'importer': 'django.db.backends.sqlite3.schema',
+    }),
+    dict({
+      'imported': 'django.db.backends.utils',
+      'importer': 'django.db.backends.sqlite3.schema',
+    }),
+    dict({
+      'imported': 'django.db.models',
+      'importer': 'django.db.backends.sqlite3.schema',
+    }),
+    dict({
+      'imported': 'django.db.transaction',
+      'importer': 'django.db.backends.sqlite3.schema',
+    }),
+    dict({
+      'imported': 'django.db',
+      'importer': 'django.db.backends.utils',
+    }),
+    dict({
+      'imported': 'django.utils.crypto',
+      'importer': 'django.db.backends.utils',
+    }),
+    dict({
+      'imported': 'django.utils.dateparse',
+      'importer': 'django.db.backends.utils',
+    }),
+    dict({
+      'imported': 'django.db.migrations.migration',
+      'importer': 'django.db.migrations',
+    }),
+    dict({
+      'imported': 'django.db.migrations.operations',
+      'importer': 'django.db.migrations',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.db.migrations.autodetector',
+    }),
+    dict({
+      'imported': 'django.db.migrations.migration',
+      'importer': 'django.db.migrations.autodetector',
+    }),
+    dict({
+      'imported': 'django.db.migrations.operations',
+      'importer': 'django.db.migrations.autodetector',
+    }),
+    dict({
+      'imported': 'django.db.migrations.operations.models',
+      'importer': 'django.db.migrations.autodetector',
+    }),
+    dict({
+      'imported': 'django.db.migrations.optimizer',
+      'importer': 'django.db.migrations.autodetector',
+    }),
+    dict({
+      'imported': 'django.db.migrations.questioner',
+      'importer': 'django.db.migrations.autodetector',
+    }),
+    dict({
+      'imported': 'django.db.migrations.utils',
+      'importer': 'django.db.migrations.autodetector',
+    }),
+    dict({
+      'imported': 'django.db.models',
+      'importer': 'django.db.migrations.autodetector',
+    }),
+    dict({
+      'imported': 'django.utils.topological_sort',
+      'importer': 'django.db.migrations.autodetector',
+    }),
+    dict({
+      'imported': 'django.db',
+      'importer': 'django.db.migrations.exceptions',
+    }),
+    dict({
+      'imported': 'django.apps.registry',
+      'importer': 'django.db.migrations.executor',
+    }),
+    dict({
+      'imported': 'django.db',
+      'importer': 'django.db.migrations.executor',
+    }),
+    dict({
+      'imported': 'django.db.migrations',
+      'importer': 'django.db.migrations.executor',
+    }),
+    dict({
+      'imported': 'django.db.migrations.exceptions',
+      'importer': 'django.db.migrations.executor',
+    }),
+    dict({
+      'imported': 'django.db.migrations.loader',
+      'importer': 'django.db.migrations.executor',
+    }),
+    dict({
+      'imported': 'django.db.migrations.recorder',
+      'importer': 'django.db.migrations.executor',
+    }),
+    dict({
+      'imported': 'django.db.migrations.state',
+      'importer': 'django.db.migrations.executor',
+    }),
+    dict({
+      'imported': 'django.db.migrations.exceptions',
+      'importer': 'django.db.migrations.graph',
+    }),
+    dict({
+      'imported': 'django.db.migrations.state',
+      'importer': 'django.db.migrations.graph',
+    }),
+    dict({
+      'imported': 'django.apps',
+      'importer': 'django.db.migrations.loader',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.db.migrations.loader',
+    }),
+    dict({
+      'imported': 'django.db.migrations.exceptions',
+      'importer': 'django.db.migrations.loader',
+    }),
+    dict({
+      'imported': 'django.db.migrations.graph',
+      'importer': 'django.db.migrations.loader',
+    }),
+    dict({
+      'imported': 'django.db.migrations.recorder',
+      'importer': 'django.db.migrations.loader',
+    }),
+    dict({
+      'imported': 'django.db.migrations.exceptions',
+      'importer': 'django.db.migrations.migration',
+    }),
+    dict({
+      'imported': 'django.db.migrations.utils',
+      'importer': 'django.db.migrations.migration',
+    }),
+    dict({
+      'imported': 'django.db.transaction',
+      'importer': 'django.db.migrations.migration',
+    }),
+    dict({
+      'imported': 'django.db.migrations.operations.fields',
+      'importer': 'django.db.migrations.operations',
+    }),
+    dict({
+      'imported': 'django.db.migrations.operations.models',
+      'importer': 'django.db.migrations.operations',
+    }),
+    dict({
+      'imported': 'django.db.migrations.operations.special',
+      'importer': 'django.db.migrations.operations',
+    }),
+    dict({
+      'imported': 'django.db',
+      'importer': 'django.db.migrations.operations.base',
+    }),
+    dict({
+      'imported': 'django.db.migrations.operations.base',
+      'importer': 'django.db.migrations.operations.fields',
+    }),
+    dict({
+      'imported': 'django.db.migrations.operations.models',
+      'importer': 'django.db.migrations.operations.fields',
+    }),
+    dict({
+      'imported': 'django.db.migrations.utils',
+      'importer': 'django.db.migrations.operations.fields',
+    }),
+    dict({
+      'imported': 'django.db.models',
+      'importer': 'django.db.migrations.operations.fields',
+    }),
+    dict({
+      'imported': 'django.utils.functional',
+      'importer': 'django.db.migrations.operations.fields',
+    }),
+    dict({
+      'imported': 'django.db.migrations.operations.base',
+      'importer': 'django.db.migrations.operations.models',
+    }),
+    dict({
+      'imported': 'django.db.migrations.operations.fields',
+      'importer': 'django.db.migrations.operations.models',
+    }),
+    dict({
+      'imported': 'django.db.migrations.state',
+      'importer': 'django.db.migrations.operations.models',
+    }),
+    dict({
+      'imported': 'django.db.migrations.utils',
+      'importer': 'django.db.migrations.operations.models',
+    }),
+    dict({
+      'imported': 'django.db.models',
+      'importer': 'django.db.migrations.operations.models',
+    }),
+    dict({
+      'imported': 'django.db.models.options',
+      'importer': 'django.db.migrations.operations.models',
+    }),
+    dict({
+      'imported': 'django.utils.functional',
+      'importer': 'django.db.migrations.operations.models',
+    }),
+    dict({
+      'imported': 'django.db',
+      'importer': 'django.db.migrations.operations.special',
+    }),
+    dict({
+      'imported': 'django.db.migrations.operations.base',
+      'importer': 'django.db.migrations.operations.special',
+    }),
+    dict({
+      'imported': 'django.apps',
+      'importer': 'django.db.migrations.questioner',
+    }),
+    dict({
+      'imported': 'django.core.management.base',
+      'importer': 'django.db.migrations.questioner',
+    }),
+    dict({
+      'imported': 'django.db.migrations.loader',
+      'importer': 'django.db.migrations.questioner',
+    }),
+    dict({
+      'imported': 'django.db.models',
+      'importer': 'django.db.migrations.questioner',
+    }),
+    dict({
+      'imported': 'django.utils.timezone',
+      'importer': 'django.db.migrations.questioner',
+    }),
+    dict({
+      'imported': 'django.utils.version',
+      'importer': 'django.db.migrations.questioner',
+    }),
+    dict({
+      'imported': 'django.apps.registry',
+      'importer': 'django.db.migrations.recorder',
+    }),
+    dict({
+      'imported': 'django.db',
+      'importer': 'django.db.migrations.recorder',
+    }),
+    dict({
+      'imported': 'django.db.migrations.exceptions',
+      'importer': 'django.db.migrations.recorder',
+    }),
+    dict({
+      'imported': 'django.db.models',
+      'importer': 'django.db.migrations.recorder',
+    }),
+    dict({
+      'imported': 'django.utils.functional',
+      'importer': 'django.db.migrations.recorder',
+    }),
+    dict({
+      'imported': 'django.utils.timezone',
+      'importer': 'django.db.migrations.recorder',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.db.migrations.serializer',
+    }),
+    dict({
+      'imported': 'django.db.migrations.operations.base',
+      'importer': 'django.db.migrations.serializer',
+    }),
+    dict({
+      'imported': 'django.db.migrations.utils',
+      'importer': 'django.db.migrations.serializer',
+    }),
+    dict({
+      'imported': 'django.db.migrations.writer',
+      'importer': 'django.db.migrations.serializer',
+    }),
+    dict({
+      'imported': 'django.db.models',
+      'importer': 'django.db.migrations.serializer',
+    }),
+    dict({
+      'imported': 'django.utils.functional',
+      'importer': 'django.db.migrations.serializer',
+    }),
+    dict({
+      'imported': 'django.utils.version',
+      'importer': 'django.db.migrations.serializer',
+    }),
+    dict({
+      'imported': 'django.apps',
+      'importer': 'django.db.migrations.state',
+    }),
+    dict({
+      'imported': 'django.apps.registry',
+      'importer': 'django.db.migrations.state',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.db.migrations.state',
+    }),
+    dict({
+      'imported': 'django.core.checks.model_checks',
+      'importer': 'django.db.migrations.state',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.db.migrations.state',
+    }),
+    dict({
+      'imported': 'django.db.migrations.exceptions',
+      'importer': 'django.db.migrations.state',
+    }),
+    dict({
+      'imported': 'django.db.migrations.utils',
+      'importer': 'django.db.migrations.state',
+    }),
+    dict({
+      'imported': 'django.db.models',
+      'importer': 'django.db.migrations.state',
+    }),
+    dict({
+      'imported': 'django.db.models.fields.related',
+      'importer': 'django.db.migrations.state',
+    }),
+    dict({
+      'imported': 'django.db.models.options',
+      'importer': 'django.db.migrations.state',
+    }),
+    dict({
+      'imported': 'django.db.models.utils',
+      'importer': 'django.db.migrations.state',
+    }),
+    dict({
+      'imported': 'django.utils.functional',
+      'importer': 'django.db.migrations.state',
+    }),
+    dict({
+      'imported': 'django.utils.module_loading',
+      'importer': 'django.db.migrations.state',
+    }),
+    dict({
+      'imported': 'django.utils.version',
+      'importer': 'django.db.migrations.state',
+    }),
+    dict({
+      'imported': 'django.db.models.fields.related',
+      'importer': 'django.db.migrations.utils',
+    }),
+    dict({
+      'imported': 'django',
+      'importer': 'django.db.migrations.writer',
+    }),
+    dict({
+      'imported': 'django.apps',
+      'importer': 'django.db.migrations.writer',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.db.migrations.writer',
+    }),
+    dict({
+      'imported': 'django.db.migrations',
+      'importer': 'django.db.migrations.writer',
+    }),
+    dict({
+      'imported': 'django.db.migrations.loader',
+      'importer': 'django.db.migrations.writer',
+    }),
+    dict({
+      'imported': 'django.db.migrations.serializer',
+      'importer': 'django.db.migrations.writer',
+    }),
+    dict({
+      'imported': 'django.utils.inspect',
+      'importer': 'django.db.migrations.writer',
+    }),
+    dict({
+      'imported': 'django.utils.module_loading',
+      'importer': 'django.db.migrations.writer',
+    }),
+    dict({
+      'imported': 'django.utils.timezone',
+      'importer': 'django.db.migrations.writer',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.db.models',
+    }),
+    dict({
+      'imported': 'django.db.models.aggregates',
+      'importer': 'django.db.models',
+    }),
+    dict({
+      'imported': 'django.db.models.base',
+      'importer': 'django.db.models',
+    }),
+    dict({
+      'imported': 'django.db.models.constraints',
+      'importer': 'django.db.models',
+    }),
+    dict({
+      'imported': 'django.db.models.deletion',
+      'importer': 'django.db.models',
+    }),
+    dict({
+      'imported': 'django.db.models.enums',
+      'importer': 'django.db.models',
+    }),
+    dict({
+      'imported': 'django.db.models.expressions',
+      'importer': 'django.db.models',
+    }),
+    dict({
+      'imported': 'django.db.models.fields',
+      'importer': 'django.db.models',
+    }),
+    dict({
+      'imported': 'django.db.models.fields.files',
+      'importer': 'django.db.models',
+    }),
+    dict({
+      'imported': 'django.db.models.fields.json',
+      'importer': 'django.db.models',
+    }),
+    dict({
+      'imported': 'django.db.models.fields.proxy',
+      'importer': 'django.db.models',
+    }),
+    dict({
+      'imported': 'django.db.models.fields.related',
+      'importer': 'django.db.models',
+    }),
+    dict({
+      'imported': 'django.db.models.indexes',
+      'importer': 'django.db.models',
+    }),
+    dict({
+      'imported': 'django.db.models.lookups',
+      'importer': 'django.db.models',
+    }),
+    dict({
+      'imported': 'django.db.models.manager',
+      'importer': 'django.db.models',
+    }),
+    dict({
+      'imported': 'django.db.models.query',
+      'importer': 'django.db.models',
+    }),
+    dict({
+      'imported': 'django.db.models.query_utils',
+      'importer': 'django.db.models',
+    }),
+    dict({
+      'imported': 'django.db.models.signals',
+      'importer': 'django.db.models',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.db.models.aggregates',
+    }),
+    dict({
+      'imported': 'django.db.models.expressions',
+      'importer': 'django.db.models.aggregates',
+    }),
+    dict({
+      'imported': 'django.db.models.fields',
+      'importer': 'django.db.models.aggregates',
+    }),
+    dict({
+      'imported': 'django.db.models.functions.comparison',
+      'importer': 'django.db.models.aggregates',
+    }),
+    dict({
+      'imported': 'django.db.models.functions.mixins',
+      'importer': 'django.db.models.aggregates',
+    }),
+    dict({
+      'imported': 'django',
+      'importer': 'django.db.models.base',
+    }),
+    dict({
+      'imported': 'django.apps',
+      'importer': 'django.db.models.base',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.db.models.base',
+    }),
+    dict({
+      'imported': 'django.core.checks',
+      'importer': 'django.db.models.base',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.db.models.base',
+    }),
+    dict({
+      'imported': 'django.db',
+      'importer': 'django.db.models.base',
+    }),
+    dict({
+      'imported': 'django.db.models',
+      'importer': 'django.db.models.base',
+    }),
+    dict({
+      'imported': 'django.db.models.constants',
+      'importer': 'django.db.models.base',
+    }),
+    dict({
+      'imported': 'django.db.models.constraints',
+      'importer': 'django.db.models.base',
+    }),
+    dict({
+      'imported': 'django.db.models.deletion',
+      'importer': 'django.db.models.base',
+    }),
+    dict({
+      'imported': 'django.db.models.expressions',
+      'importer': 'django.db.models.base',
+    }),
+    dict({
+      'imported': 'django.db.models.fields.related',
+      'importer': 'django.db.models.base',
+    }),
+    dict({
+      'imported': 'django.db.models.functions',
+      'importer': 'django.db.models.base',
+    }),
+    dict({
+      'imported': 'django.db.models.manager',
+      'importer': 'django.db.models.base',
+    }),
+    dict({
+      'imported': 'django.db.models.options',
+      'importer': 'django.db.models.base',
+    }),
+    dict({
+      'imported': 'django.db.models.query',
+      'importer': 'django.db.models.base',
+    }),
+    dict({
+      'imported': 'django.db.models.signals',
+      'importer': 'django.db.models.base',
+    }),
+    dict({
+      'imported': 'django.db.models.utils',
+      'importer': 'django.db.models.base',
+    }),
+    dict({
+      'imported': 'django.db.transaction',
+      'importer': 'django.db.models.base',
+    }),
+    dict({
+      'imported': 'django.utils.encoding',
+      'importer': 'django.db.models.base',
+    }),
+    dict({
+      'imported': 'django.utils.hashable',
+      'importer': 'django.db.models.base',
+    }),
+    dict({
+      'imported': 'django.utils.text',
+      'importer': 'django.db.models.base',
+    }),
+    dict({
+      'imported': 'django.utils.translation',
+      'importer': 'django.db.models.base',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.db.models.constraints',
+    }),
+    dict({
+      'imported': 'django.db',
+      'importer': 'django.db.models.constraints',
+    }),
+    dict({
+      'imported': 'django.db.models.expressions',
+      'importer': 'django.db.models.constraints',
+    }),
+    dict({
+      'imported': 'django.db.models.indexes',
+      'importer': 'django.db.models.constraints',
+    }),
+    dict({
+      'imported': 'django.db.models.lookups',
+      'importer': 'django.db.models.constraints',
+    }),
+    dict({
+      'imported': 'django.db.models.query_utils',
+      'importer': 'django.db.models.constraints',
+    }),
+    dict({
+      'imported': 'django.db.models.sql.query',
+      'importer': 'django.db.models.constraints',
+    }),
+    dict({
+      'imported': 'django.db.utils',
+      'importer': 'django.db.models.constraints',
+    }),
+    dict({
+      'imported': 'django.utils.translation',
+      'importer': 'django.db.models.constraints',
+    }),
+    dict({
+      'imported': 'django.db',
+      'importer': 'django.db.models.deletion',
+    }),
+    dict({
+      'imported': 'django.db.models',
+      'importer': 'django.db.models.deletion',
+    }),
+    dict({
+      'imported': 'django.db.models.query_utils',
+      'importer': 'django.db.models.deletion',
+    }),
+    dict({
+      'imported': 'django.db.models.signals',
+      'importer': 'django.db.models.deletion',
+    }),
+    dict({
+      'imported': 'django.db.models.sql',
+      'importer': 'django.db.models.deletion',
+    }),
+    dict({
+      'imported': 'django.db.transaction',
+      'importer': 'django.db.models.deletion',
+    }),
+    dict({
+      'imported': 'django.utils.functional',
+      'importer': 'django.db.models.enums',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.db.models.expressions',
+    }),
+    dict({
+      'imported': 'django.db',
+      'importer': 'django.db.models.expressions',
+    }),
+    dict({
+      'imported': 'django.db.models.constants',
+      'importer': 'django.db.models.expressions',
+    }),
+    dict({
+      'imported': 'django.db.models.fields',
+      'importer': 'django.db.models.expressions',
+    }),
+    dict({
+      'imported': 'django.db.models.query_utils',
+      'importer': 'django.db.models.expressions',
+    }),
+    dict({
+      'imported': 'django.utils.deconstruct',
+      'importer': 'django.db.models.expressions',
+    }),
+    dict({
+      'imported': 'django.utils.deprecation',
+      'importer': 'django.db.models.expressions',
+    }),
+    dict({
+      'imported': 'django.utils.functional',
+      'importer': 'django.db.models.expressions',
+    }),
+    dict({
+      'imported': 'django.utils.hashable',
+      'importer': 'django.db.models.expressions',
+    }),
+    dict({
+      'imported': 'django.apps',
+      'importer': 'django.db.models.fields',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.db.models.fields',
+    }),
+    dict({
+      'imported': 'django.core.checks',
+      'importer': 'django.db.models.fields',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.db.models.fields',
+    }),
+    dict({
+      'imported': 'django.core.validators',
+      'importer': 'django.db.models.fields',
+    }),
+    dict({
+      'imported': 'django.db',
+      'importer': 'django.db.models.fields',
+    }),
+    dict({
+      'imported': 'django.db.models.constants',
+      'importer': 'django.db.models.fields',
+    }),
+    dict({
+      'imported': 'django.db.models.expressions',
+      'importer': 'django.db.models.fields',
+    }),
+    dict({
+      'imported': 'django.db.models.query_utils',
+      'importer': 'django.db.models.fields',
+    }),
+    dict({
+      'imported': 'django.forms',
+      'importer': 'django.db.models.fields',
+    }),
+    dict({
+      'imported': 'django.utils.datastructures',
+      'importer': 'django.db.models.fields',
+    }),
+    dict({
+      'imported': 'django.utils.dateparse',
+      'importer': 'django.db.models.fields',
+    }),
+    dict({
+      'imported': 'django.utils.duration',
+      'importer': 'django.db.models.fields',
+    }),
+    dict({
+      'imported': 'django.utils.functional',
+      'importer': 'django.db.models.fields',
+    }),
+    dict({
+      'imported': 'django.utils.ipv6',
+      'importer': 'django.db.models.fields',
+    }),
+    dict({
+      'imported': 'django.utils.itercompat',
+      'importer': 'django.db.models.fields',
+    }),
+    dict({
+      'imported': 'django.utils.text',
+      'importer': 'django.db.models.fields',
+    }),
+    dict({
+      'imported': 'django.utils.timezone',
+      'importer': 'django.db.models.fields',
+    }),
+    dict({
+      'imported': 'django.utils.translation',
+      'importer': 'django.db.models.fields',
+    }),
+    dict({
+      'imported': 'django.core.checks',
+      'importer': 'django.db.models.fields.files',
+    }),
+    dict({
+      'imported': 'django.core.files.base',
+      'importer': 'django.db.models.fields.files',
+    }),
+    dict({
+      'imported': 'django.core.files.images',
+      'importer': 'django.db.models.fields.files',
+    }),
+    dict({
+      'imported': 'django.core.files.storage',
+      'importer': 'django.db.models.fields.files',
+    }),
+    dict({
+      'imported': 'django.core.files.utils',
+      'importer': 'django.db.models.fields.files',
+    }),
+    dict({
+      'imported': 'django.db.models.fields',
+      'importer': 'django.db.models.fields.files',
+    }),
+    dict({
+      'imported': 'django.db.models.query_utils',
+      'importer': 'django.db.models.fields.files',
+    }),
+    dict({
+      'imported': 'django.db.models.signals',
+      'importer': 'django.db.models.fields.files',
+    }),
+    dict({
+      'imported': 'django.db.models.utils',
+      'importer': 'django.db.models.fields.files',
+    }),
+    dict({
+      'imported': 'django.forms',
+      'importer': 'django.db.models.fields.files',
+    }),
+    dict({
+      'imported': 'django.utils.translation',
+      'importer': 'django.db.models.fields.files',
+    }),
+    dict({
+      'imported': 'django.core.checks',
+      'importer': 'django.db.models.fields.json',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.db.models.fields.json',
+    }),
+    dict({
+      'imported': 'django.db',
+      'importer': 'django.db.models.fields.json',
+    }),
+    dict({
+      'imported': 'django.db.models.constants',
+      'importer': 'django.db.models.fields.json',
+    }),
+    dict({
+      'imported': 'django.db.models.expressions',
+      'importer': 'django.db.models.fields.json',
+    }),
+    dict({
+      'imported': 'django.db.models.fields',
+      'importer': 'django.db.models.fields.json',
+    }),
+    dict({
+      'imported': 'django.db.models.fields.mixins',
+      'importer': 'django.db.models.fields.json',
+    }),
+    dict({
+      'imported': 'django.db.models.lookups',
+      'importer': 'django.db.models.fields.json',
+    }),
+    dict({
+      'imported': 'django.forms',
+      'importer': 'django.db.models.fields.json',
+    }),
+    dict({
+      'imported': 'django.utils.deprecation',
+      'importer': 'django.db.models.fields.json',
+    }),
+    dict({
+      'imported': 'django.utils.translation',
+      'importer': 'django.db.models.fields.json',
+    }),
+    dict({
+      'imported': 'django.core.checks',
+      'importer': 'django.db.models.fields.mixins',
+    }),
+    dict({
+      'imported': 'django.db.models.fields',
+      'importer': 'django.db.models.fields.proxy',
+    }),
+    dict({
+      'imported': 'django.apps',
+      'importer': 'django.db.models.fields.related',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.db.models.fields.related',
+    }),
+    dict({
+      'imported': 'django.core.checks',
+      'importer': 'django.db.models.fields.related',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.db.models.fields.related',
+    }),
+    dict({
+      'imported': 'django.db',
+      'importer': 'django.db.models.fields.related',
+    }),
+    dict({
+      'imported': 'django.db.backends.utils',
+      'importer': 'django.db.models.fields.related',
+    }),
+    dict({
+      'imported': 'django.db.models',
+      'importer': 'django.db.models.fields.related',
+    }),
+    dict({
+      'imported': 'django.db.models.base',
+      'importer': 'django.db.models.fields.related',
+    }),
+    dict({
+      'imported': 'django.db.models.constants',
+      'importer': 'django.db.models.fields.related',
+    }),
+    dict({
+      'imported': 'django.db.models.deletion',
+      'importer': 'django.db.models.fields.related',
+    }),
+    dict({
+      'imported': 'django.db.models.fields',
+      'importer': 'django.db.models.fields.related',
+    }),
+    dict({
+      'imported': 'django.db.models.fields.mixins',
+      'importer': 'django.db.models.fields.related',
+    }),
+    dict({
+      'imported': 'django.db.models.fields.related_descriptors',
+      'importer': 'django.db.models.fields.related',
+    }),
+    dict({
+      'imported': 'django.db.models.fields.related_lookups',
+      'importer': 'django.db.models.fields.related',
+    }),
+    dict({
+      'imported': 'django.db.models.fields.reverse_related',
+      'importer': 'django.db.models.fields.related',
+    }),
+    dict({
+      'imported': 'django.db.models.query_utils',
+      'importer': 'django.db.models.fields.related',
+    }),
+    dict({
+      'imported': 'django.db.models.utils',
+      'importer': 'django.db.models.fields.related',
+    }),
+    dict({
+      'imported': 'django.forms',
+      'importer': 'django.db.models.fields.related',
+    }),
+    dict({
+      'imported': 'django.utils.functional',
+      'importer': 'django.db.models.fields.related',
+    }),
+    dict({
+      'imported': 'django.utils.translation',
+      'importer': 'django.db.models.fields.related',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.db.models.fields.related_descriptors',
+    }),
+    dict({
+      'imported': 'django.db',
+      'importer': 'django.db.models.fields.related_descriptors',
+    }),
+    dict({
+      'imported': 'django.db.models',
+      'importer': 'django.db.models.fields.related_descriptors',
+    }),
+    dict({
+      'imported': 'django.db.models.functions',
+      'importer': 'django.db.models.fields.related_descriptors',
+    }),
+    dict({
+      'imported': 'django.db.models.lookups',
+      'importer': 'django.db.models.fields.related_descriptors',
+    }),
+    dict({
+      'imported': 'django.db.models.query',
+      'importer': 'django.db.models.fields.related_descriptors',
+    }),
+    dict({
+      'imported': 'django.db.models.query_utils',
+      'importer': 'django.db.models.fields.related_descriptors',
+    }),
+    dict({
+      'imported': 'django.db.models.signals',
+      'importer': 'django.db.models.fields.related_descriptors',
+    }),
+    dict({
+      'imported': 'django.db.models.utils',
+      'importer': 'django.db.models.fields.related_descriptors',
+    }),
+    dict({
+      'imported': 'django.db.transaction',
+      'importer': 'django.db.models.fields.related_descriptors',
+    }),
+    dict({
+      'imported': 'django.utils.functional',
+      'importer': 'django.db.models.fields.related_descriptors',
+    }),
+    dict({
+      'imported': 'django.db.models',
+      'importer': 'django.db.models.fields.related_lookups',
+    }),
+    dict({
+      'imported': 'django.db.models.lookups',
+      'importer': 'django.db.models.fields.related_lookups',
+    }),
+    dict({
+      'imported': 'django.db.models.sql.where',
+      'importer': 'django.db.models.fields.related_lookups',
+    }),
+    dict({
+      'imported': 'django.utils.deprecation',
+      'importer': 'django.db.models.fields.related_lookups',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.db.models.fields.reverse_related',
+    }),
+    dict({
+      'imported': 'django.db.models.fields',
+      'importer': 'django.db.models.fields.reverse_related',
+    }),
+    dict({
+      'imported': 'django.db.models.fields.mixins',
+      'importer': 'django.db.models.fields.reverse_related',
+    }),
+    dict({
+      'imported': 'django.utils.functional',
+      'importer': 'django.db.models.fields.reverse_related',
+    }),
+    dict({
+      'imported': 'django.utils.hashable',
+      'importer': 'django.db.models.fields.reverse_related',
+    }),
+    dict({
+      'imported': 'django.db.models.functions.comparison',
+      'importer': 'django.db.models.functions',
+    }),
+    dict({
+      'imported': 'django.db.models.functions.datetime',
+      'importer': 'django.db.models.functions',
+    }),
+    dict({
+      'imported': 'django.db.models.functions.math',
+      'importer': 'django.db.models.functions',
+    }),
+    dict({
+      'imported': 'django.db.models.functions.text',
+      'importer': 'django.db.models.functions',
+    }),
+    dict({
+      'imported': 'django.db.models.functions.window',
+      'importer': 'django.db.models.functions',
+    }),
+    dict({
+      'imported': 'django.db',
+      'importer': 'django.db.models.functions.comparison',
+    }),
+    dict({
+      'imported': 'django.db.models.expressions',
+      'importer': 'django.db.models.functions.comparison',
+    }),
+    dict({
+      'imported': 'django.db.models.fields',
+      'importer': 'django.db.models.functions.comparison',
+    }),
+    dict({
+      'imported': 'django.db.models.fields.json',
+      'importer': 'django.db.models.functions.comparison',
+    }),
+    dict({
+      'imported': 'django.utils.regex_helper',
+      'importer': 'django.db.models.functions.comparison',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.db.models.functions.datetime',
+    }),
+    dict({
+      'imported': 'django.db.models.expressions',
+      'importer': 'django.db.models.functions.datetime',
+    }),
+    dict({
+      'imported': 'django.db.models.fields',
+      'importer': 'django.db.models.functions.datetime',
+    }),
+    dict({
+      'imported': 'django.db.models.lookups',
+      'importer': 'django.db.models.functions.datetime',
+    }),
+    dict({
+      'imported': 'django.utils.timezone',
+      'importer': 'django.db.models.functions.datetime',
+    }),
+    dict({
+      'imported': 'django.db.models.expressions',
+      'importer': 'django.db.models.functions.math',
+    }),
+    dict({
+      'imported': 'django.db.models.fields',
+      'importer': 'django.db.models.functions.math',
+    }),
+    dict({
+      'imported': 'django.db.models.functions',
+      'importer': 'django.db.models.functions.math',
+    }),
+    dict({
+      'imported': 'django.db.models.functions.mixins',
+      'importer': 'django.db.models.functions.math',
+    }),
+    dict({
+      'imported': 'django.db.models.lookups',
+      'importer': 'django.db.models.functions.math',
+    }),
+    dict({
+      'imported': 'django.db.backends.oracle.functions',
+      'importer': 'django.db.models.functions.mixins',
+    }),
+    dict({
+      'imported': 'django.db.models.fields',
+      'importer': 'django.db.models.functions.mixins',
+    }),
+    dict({
+      'imported': 'django.db.models.functions',
+      'importer': 'django.db.models.functions.mixins',
+    }),
+    dict({
+      'imported': 'django.db',
+      'importer': 'django.db.models.functions.text',
+    }),
+    dict({
+      'imported': 'django.db.models.expressions',
+      'importer': 'django.db.models.functions.text',
+    }),
+    dict({
+      'imported': 'django.db.models.fields',
+      'importer': 'django.db.models.functions.text',
+    }),
+    dict({
+      'imported': 'django.db.models.functions',
+      'importer': 'django.db.models.functions.text',
+    }),
+    dict({
+      'imported': 'django.db.models.lookups',
+      'importer': 'django.db.models.functions.text',
+    }),
+    dict({
+      'imported': 'django.db.models.expressions',
+      'importer': 'django.db.models.functions.window',
+    }),
+    dict({
+      'imported': 'django.db.models.fields',
+      'importer': 'django.db.models.functions.window',
+    }),
+    dict({
+      'imported': 'django.db.backends.utils',
+      'importer': 'django.db.models.indexes',
+    }),
+    dict({
+      'imported': 'django.db.models.expressions',
+      'importer': 'django.db.models.indexes',
+    }),
+    dict({
+      'imported': 'django.db.models.functions',
+      'importer': 'django.db.models.indexes',
+    }),
+    dict({
+      'imported': 'django.db.models.query_utils',
+      'importer': 'django.db.models.indexes',
+    }),
+    dict({
+      'imported': 'django.db.models.sql',
+      'importer': 'django.db.models.indexes',
+    }),
+    dict({
+      'imported': 'django.utils.functional',
+      'importer': 'django.db.models.indexes',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.db.models.lookups',
+    }),
+    dict({
+      'imported': 'django.db.models.expressions',
+      'importer': 'django.db.models.lookups',
+    }),
+    dict({
+      'imported': 'django.db.models.fields',
+      'importer': 'django.db.models.lookups',
+    }),
+    dict({
+      'imported': 'django.db.models.functions',
+      'importer': 'django.db.models.lookups',
+    }),
+    dict({
+      'imported': 'django.db.models.query_utils',
+      'importer': 'django.db.models.lookups',
+    }),
+    dict({
+      'imported': 'django.db.models.sql.query',
+      'importer': 'django.db.models.lookups',
+    }),
+    dict({
+      'imported': 'django.utils.datastructures',
+      'importer': 'django.db.models.lookups',
+    }),
+    dict({
+      'imported': 'django.utils.functional',
+      'importer': 'django.db.models.lookups',
+    }),
+    dict({
+      'imported': 'django.utils.hashable',
+      'importer': 'django.db.models.lookups',
+    }),
+    dict({
+      'imported': 'django.db',
+      'importer': 'django.db.models.manager',
+    }),
+    dict({
+      'imported': 'django.db.models.query',
+      'importer': 'django.db.models.manager',
+    }),
+    dict({
+      'imported': 'django.apps',
+      'importer': 'django.db.models.options',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.db.models.options',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.db.models.options',
+    }),
+    dict({
+      'imported': 'django.db',
+      'importer': 'django.db.models.options',
+    }),
+    dict({
+      'imported': 'django.db.backends.utils',
+      'importer': 'django.db.models.options',
+    }),
+    dict({
+      'imported': 'django.db.models',
+      'importer': 'django.db.models.options',
+    }),
+    dict({
+      'imported': 'django.db.models.query_utils',
+      'importer': 'django.db.models.options',
+    }),
+    dict({
+      'imported': 'django.utils.datastructures',
+      'importer': 'django.db.models.options',
+    }),
+    dict({
+      'imported': 'django.utils.deprecation',
+      'importer': 'django.db.models.options',
+    }),
+    dict({
+      'imported': 'django.utils.functional',
+      'importer': 'django.db.models.options',
+    }),
+    dict({
+      'imported': 'django.utils.module_loading',
+      'importer': 'django.db.models.options',
+    }),
+    dict({
+      'imported': 'django.utils.text',
+      'importer': 'django.db.models.options',
+    }),
+    dict({
+      'imported': 'django.utils.translation',
+      'importer': 'django.db.models.options',
+    }),
+    dict({
+      'imported': 'django',
+      'importer': 'django.db.models.query',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.db.models.query',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.db.models.query',
+    }),
+    dict({
+      'imported': 'django.db',
+      'importer': 'django.db.models.query',
+    }),
+    dict({
+      'imported': 'django.db.models',
+      'importer': 'django.db.models.query',
+    }),
+    dict({
+      'imported': 'django.db.models.constants',
+      'importer': 'django.db.models.query',
+    }),
+    dict({
+      'imported': 'django.db.models.deletion',
+      'importer': 'django.db.models.query',
+    }),
+    dict({
+      'imported': 'django.db.models.expressions',
+      'importer': 'django.db.models.query',
+    }),
+    dict({
+      'imported': 'django.db.models.functions',
+      'importer': 'django.db.models.query',
+    }),
+    dict({
+      'imported': 'django.db.models.manager',
+      'importer': 'django.db.models.query',
+    }),
+    dict({
+      'imported': 'django.db.models.query_utils',
+      'importer': 'django.db.models.query',
+    }),
+    dict({
+      'imported': 'django.db.models.sql',
+      'importer': 'django.db.models.query',
+    }),
+    dict({
+      'imported': 'django.db.models.sql.constants',
+      'importer': 'django.db.models.query',
+    }),
+    dict({
+      'imported': 'django.db.models.utils',
+      'importer': 'django.db.models.query',
+    }),
+    dict({
+      'imported': 'django.db.transaction',
+      'importer': 'django.db.models.query',
+    }),
+    dict({
+      'imported': 'django.utils.deprecation',
+      'importer': 'django.db.models.query',
+    }),
+    dict({
+      'imported': 'django.utils.functional',
+      'importer': 'django.db.models.query',
+    }),
+    dict({
+      'imported': 'django.utils.timezone',
+      'importer': 'django.db.models.query',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.db.models.query_utils',
+    }),
+    dict({
+      'imported': 'django.db',
+      'importer': 'django.db.models.query_utils',
+    }),
+    dict({
+      'imported': 'django.db.models',
+      'importer': 'django.db.models.query_utils',
+    }),
+    dict({
+      'imported': 'django.db.models.constants',
+      'importer': 'django.db.models.query_utils',
+    }),
+    dict({
+      'imported': 'django.db.models.functions',
+      'importer': 'django.db.models.query_utils',
+    }),
+    dict({
+      'imported': 'django.db.models.lookups',
+      'importer': 'django.db.models.query_utils',
+    }),
+    dict({
+      'imported': 'django.db.models.sql',
+      'importer': 'django.db.models.query_utils',
+    }),
+    dict({
+      'imported': 'django.db.models.sql.constants',
+      'importer': 'django.db.models.query_utils',
+    }),
+    dict({
+      'imported': 'django.utils.tree',
+      'importer': 'django.db.models.query_utils',
+    }),
+    dict({
+      'imported': 'django.db.models.options',
+      'importer': 'django.db.models.signals',
+    }),
+    dict({
+      'imported': 'django.db.models.utils',
+      'importer': 'django.db.models.signals',
+    }),
+    dict({
+      'imported': 'django.dispatch',
+      'importer': 'django.db.models.signals',
+    }),
+    dict({
+      'imported': 'django.db.models.sql.query',
+      'importer': 'django.db.models.sql',
+    }),
+    dict({
+      'imported': 'django.db.models.sql.subqueries',
+      'importer': 'django.db.models.sql',
+    }),
+    dict({
+      'imported': 'django.db.models.sql.where',
+      'importer': 'django.db.models.sql',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.db.models.sql.compiler',
+    }),
+    dict({
+      'imported': 'django.db',
+      'importer': 'django.db.models.sql.compiler',
+    }),
+    dict({
+      'imported': 'django.db.models.constants',
+      'importer': 'django.db.models.sql.compiler',
+    }),
+    dict({
+      'imported': 'django.db.models.expressions',
+      'importer': 'django.db.models.sql.compiler',
+    }),
+    dict({
+      'imported': 'django.db.models.functions',
+      'importer': 'django.db.models.sql.compiler',
+    }),
+    dict({
+      'imported': 'django.db.models.lookups',
+      'importer': 'django.db.models.sql.compiler',
+    }),
+    dict({
+      'imported': 'django.db.models.query_utils',
+      'importer': 'django.db.models.sql.compiler',
+    }),
+    dict({
+      'imported': 'django.db.models.sql.constants',
+      'importer': 'django.db.models.sql.compiler',
+    }),
+    dict({
+      'imported': 'django.db.models.sql.query',
+      'importer': 'django.db.models.sql.compiler',
+    }),
+    dict({
+      'imported': 'django.db.models.sql.where',
+      'importer': 'django.db.models.sql.compiler',
+    }),
+    dict({
+      'imported': 'django.db.transaction',
+      'importer': 'django.db.models.sql.compiler',
+    }),
+    dict({
+      'imported': 'django.utils.functional',
+      'importer': 'django.db.models.sql.compiler',
+    }),
+    dict({
+      'imported': 'django.utils.hashable',
+      'importer': 'django.db.models.sql.compiler',
+    }),
+    dict({
+      'imported': 'django.utils.regex_helper',
+      'importer': 'django.db.models.sql.compiler',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.db.models.sql.datastructures',
+    }),
+    dict({
+      'imported': 'django.db.models.sql.constants',
+      'importer': 'django.db.models.sql.datastructures',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.db.models.sql.query',
+    }),
+    dict({
+      'imported': 'django.db',
+      'importer': 'django.db.models.sql.query',
+    }),
+    dict({
+      'imported': 'django.db.models.aggregates',
+      'importer': 'django.db.models.sql.query',
+    }),
+    dict({
+      'imported': 'django.db.models.constants',
+      'importer': 'django.db.models.sql.query',
+    }),
+    dict({
+      'imported': 'django.db.models.expressions',
+      'importer': 'django.db.models.sql.query',
+    }),
+    dict({
+      'imported': 'django.db.models.fields',
+      'importer': 'django.db.models.sql.query',
+    }),
+    dict({
+      'imported': 'django.db.models.fields.related_lookups',
+      'importer': 'django.db.models.sql.query',
+    }),
+    dict({
+      'imported': 'django.db.models.lookups',
+      'importer': 'django.db.models.sql.query',
+    }),
+    dict({
+      'imported': 'django.db.models.query_utils',
+      'importer': 'django.db.models.sql.query',
+    }),
+    dict({
+      'imported': 'django.db.models.sql.constants',
+      'importer': 'django.db.models.sql.query',
+    }),
+    dict({
+      'imported': 'django.db.models.sql.datastructures',
+      'importer': 'django.db.models.sql.query',
+    }),
+    dict({
+      'imported': 'django.db.models.sql.subqueries',
+      'importer': 'django.db.models.sql.query',
+    }),
+    dict({
+      'imported': 'django.db.models.sql.where',
+      'importer': 'django.db.models.sql.query',
+    }),
+    dict({
+      'imported': 'django.utils.functional',
+      'importer': 'django.db.models.sql.query',
+    }),
+    dict({
+      'imported': 'django.utils.regex_helper',
+      'importer': 'django.db.models.sql.query',
+    }),
+    dict({
+      'imported': 'django.utils.tree',
+      'importer': 'django.db.models.sql.query',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.db.models.sql.subqueries',
+    }),
+    dict({
+      'imported': 'django.db.models.sql.constants',
+      'importer': 'django.db.models.sql.subqueries',
+    }),
+    dict({
+      'imported': 'django.db.models.sql.query',
+      'importer': 'django.db.models.sql.subqueries',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.db.models.sql.where',
+    }),
+    dict({
+      'imported': 'django.db.models',
+      'importer': 'django.db.models.sql.where',
+    }),
+    dict({
+      'imported': 'django.db.models.expressions',
+      'importer': 'django.db.models.sql.where',
+    }),
+    dict({
+      'imported': 'django.db.models.lookups',
+      'importer': 'django.db.models.sql.where',
+    }),
+    dict({
+      'imported': 'django.utils.functional',
+      'importer': 'django.db.models.sql.where',
+    }),
+    dict({
+      'imported': 'django.utils.tree',
+      'importer': 'django.db.models.sql.where',
+    }),
+    dict({
+      'imported': 'django.db',
+      'importer': 'django.db.transaction',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.db.utils',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.db.utils',
+    }),
+    dict({
+      'imported': 'django.db.backends',
+      'importer': 'django.db.utils',
+    }),
+    dict({
+      'imported': 'django.utils.connection',
+      'importer': 'django.db.utils',
+    }),
+    dict({
+      'imported': 'django.utils.functional',
+      'importer': 'django.db.utils',
+    }),
+    dict({
+      'imported': 'django.utils.module_loading',
+      'importer': 'django.db.utils',
+    }),
+    dict({
+      'imported': 'django.dispatch.dispatcher',
+      'importer': 'django.dispatch',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.dispatch.dispatcher',
+    }),
+    dict({
+      'imported': 'django.utils.inspect',
+      'importer': 'django.dispatch.dispatcher',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.forms',
+    }),
+    dict({
+      'imported': 'django.forms.boundfield',
+      'importer': 'django.forms',
+    }),
+    dict({
+      'imported': 'django.forms.fields',
+      'importer': 'django.forms',
+    }),
+    dict({
+      'imported': 'django.forms.forms',
+      'importer': 'django.forms',
+    }),
+    dict({
+      'imported': 'django.forms.formsets',
+      'importer': 'django.forms',
+    }),
+    dict({
+      'imported': 'django.forms.models',
+      'importer': 'django.forms',
+    }),
+    dict({
+      'imported': 'django.forms.widgets',
+      'importer': 'django.forms',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.forms.boundfield',
+    }),
+    dict({
+      'imported': 'django.forms.utils',
+      'importer': 'django.forms.boundfield',
+    }),
+    dict({
+      'imported': 'django.forms.widgets',
+      'importer': 'django.forms.boundfield',
+    }),
+    dict({
+      'imported': 'django.utils.functional',
+      'importer': 'django.forms.boundfield',
+    }),
+    dict({
+      'imported': 'django.utils.html',
+      'importer': 'django.forms.boundfield',
+    }),
+    dict({
+      'imported': 'django.utils.translation',
+      'importer': 'django.forms.boundfield',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.forms.fields',
+    }),
+    dict({
+      'imported': 'django.core.validators',
+      'importer': 'django.forms.fields',
+    }),
+    dict({
+      'imported': 'django.forms.boundfield',
+      'importer': 'django.forms.fields',
+    }),
+    dict({
+      'imported': 'django.forms.utils',
+      'importer': 'django.forms.fields',
+    }),
+    dict({
+      'imported': 'django.forms.widgets',
+      'importer': 'django.forms.fields',
+    }),
+    dict({
+      'imported': 'django.utils.dateparse',
+      'importer': 'django.forms.fields',
+    }),
+    dict({
+      'imported': 'django.utils.duration',
+      'importer': 'django.forms.fields',
+    }),
+    dict({
+      'imported': 'django.utils.formats',
+      'importer': 'django.forms.fields',
+    }),
+    dict({
+      'imported': 'django.utils.ipv6',
+      'importer': 'django.forms.fields',
+    }),
+    dict({
+      'imported': 'django.utils.regex_helper',
+      'importer': 'django.forms.fields',
+    }),
+    dict({
+      'imported': 'django.utils.translation',
+      'importer': 'django.forms.fields',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.forms.forms',
+    }),
+    dict({
+      'imported': 'django.forms.fields',
+      'importer': 'django.forms.forms',
+    }),
+    dict({
+      'imported': 'django.forms.renderers',
+      'importer': 'django.forms.forms',
+    }),
+    dict({
+      'imported': 'django.forms.utils',
+      'importer': 'django.forms.forms',
+    }),
+    dict({
+      'imported': 'django.forms.widgets',
+      'importer': 'django.forms.forms',
+    }),
+    dict({
+      'imported': 'django.utils.datastructures',
+      'importer': 'django.forms.forms',
+    }),
+    dict({
+      'imported': 'django.utils.deprecation',
+      'importer': 'django.forms.forms',
+    }),
+    dict({
+      'imported': 'django.utils.functional',
+      'importer': 'django.forms.forms',
+    }),
+    dict({
+      'imported': 'django.utils.html',
+      'importer': 'django.forms.forms',
+    }),
+    dict({
+      'imported': 'django.utils.safestring',
+      'importer': 'django.forms.forms',
+    }),
+    dict({
+      'imported': 'django.utils.translation',
+      'importer': 'django.forms.forms',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.forms.formsets',
+    }),
+    dict({
+      'imported': 'django.forms',
+      'importer': 'django.forms.formsets',
+    }),
+    dict({
+      'imported': 'django.forms.fields',
+      'importer': 'django.forms.formsets',
+    }),
+    dict({
+      'imported': 'django.forms.renderers',
+      'importer': 'django.forms.formsets',
+    }),
+    dict({
+      'imported': 'django.forms.utils',
+      'importer': 'django.forms.formsets',
+    }),
+    dict({
+      'imported': 'django.forms.widgets',
+      'importer': 'django.forms.formsets',
+    }),
+    dict({
+      'imported': 'django.utils.functional',
+      'importer': 'django.forms.formsets',
+    }),
+    dict({
+      'imported': 'django.utils.translation',
+      'importer': 'django.forms.formsets',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.forms.models',
+    }),
+    dict({
+      'imported': 'django.db.models',
+      'importer': 'django.forms.models',
+    }),
+    dict({
+      'imported': 'django.db.models.utils',
+      'importer': 'django.forms.models',
+    }),
+    dict({
+      'imported': 'django.forms.fields',
+      'importer': 'django.forms.models',
+    }),
+    dict({
+      'imported': 'django.forms.forms',
+      'importer': 'django.forms.models',
+    }),
+    dict({
+      'imported': 'django.forms.formsets',
+      'importer': 'django.forms.models',
+    }),
+    dict({
+      'imported': 'django.forms.utils',
+      'importer': 'django.forms.models',
+    }),
+    dict({
+      'imported': 'django.forms.widgets',
+      'importer': 'django.forms.models',
+    }),
+    dict({
+      'imported': 'django.utils.text',
+      'importer': 'django.forms.models',
+    }),
+    dict({
+      'imported': 'django.utils.translation',
+      'importer': 'django.forms.models',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.forms.renderers',
+    }),
+    dict({
+      'imported': 'django.template.backends.django',
+      'importer': 'django.forms.renderers',
+    }),
+    dict({
+      'imported': 'django.template.backends.jinja2',
+      'importer': 'django.forms.renderers',
+    }),
+    dict({
+      'imported': 'django.template.loader',
+      'importer': 'django.forms.renderers',
+    }),
+    dict({
+      'imported': 'django.utils.functional',
+      'importer': 'django.forms.renderers',
+    }),
+    dict({
+      'imported': 'django.utils.module_loading',
+      'importer': 'django.forms.renderers',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.forms.utils',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.forms.utils',
+    }),
+    dict({
+      'imported': 'django.forms.renderers',
+      'importer': 'django.forms.utils',
+    }),
+    dict({
+      'imported': 'django.utils.deprecation',
+      'importer': 'django.forms.utils',
+    }),
+    dict({
+      'imported': 'django.utils.html',
+      'importer': 'django.forms.utils',
+    }),
+    dict({
+      'imported': 'django.utils.safestring',
+      'importer': 'django.forms.utils',
+    }),
+    dict({
+      'imported': 'django.utils.timezone',
+      'importer': 'django.forms.utils',
+    }),
+    dict({
+      'imported': 'django.utils.translation',
+      'importer': 'django.forms.utils',
+    }),
+    dict({
+      'imported': 'django.utils.version',
+      'importer': 'django.forms.utils',
+    }),
+    dict({
+      'imported': 'django.forms.renderers',
+      'importer': 'django.forms.widgets',
+    }),
+    dict({
+      'imported': 'django.forms.utils',
+      'importer': 'django.forms.widgets',
+    }),
+    dict({
+      'imported': 'django.templatetags.static',
+      'importer': 'django.forms.widgets',
+    }),
+    dict({
+      'imported': 'django.utils.datastructures',
+      'importer': 'django.forms.widgets',
+    }),
+    dict({
+      'imported': 'django.utils.dates',
+      'importer': 'django.forms.widgets',
+    }),
+    dict({
+      'imported': 'django.utils.formats',
+      'importer': 'django.forms.widgets',
+    }),
+    dict({
+      'imported': 'django.utils.html',
+      'importer': 'django.forms.widgets',
+    }),
+    dict({
+      'imported': 'django.utils.regex_helper',
+      'importer': 'django.forms.widgets',
+    }),
+    dict({
+      'imported': 'django.utils.safestring',
+      'importer': 'django.forms.widgets',
+    }),
+    dict({
+      'imported': 'django.utils.topological_sort',
+      'importer': 'django.forms.widgets',
+    }),
+    dict({
+      'imported': 'django.utils.translation',
+      'importer': 'django.forms.widgets',
+    }),
+    dict({
+      'imported': 'django.http.cookie',
+      'importer': 'django.http',
+    }),
+    dict({
+      'imported': 'django.http.request',
+      'importer': 'django.http',
+    }),
+    dict({
+      'imported': 'django.http.response',
+      'importer': 'django.http',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.http.multipartparser',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.http.multipartparser',
+    }),
+    dict({
+      'imported': 'django.core.files.uploadhandler',
+      'importer': 'django.http.multipartparser',
+    }),
+    dict({
+      'imported': 'django.http',
+      'importer': 'django.http.multipartparser',
+    }),
+    dict({
+      'imported': 'django.utils.datastructures',
+      'importer': 'django.http.multipartparser',
+    }),
+    dict({
+      'imported': 'django.utils.encoding',
+      'importer': 'django.http.multipartparser',
+    }),
+    dict({
+      'imported': 'django.utils.http',
+      'importer': 'django.http.multipartparser',
+    }),
+    dict({
+      'imported': 'django.utils.regex_helper',
+      'importer': 'django.http.multipartparser',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.http.request',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.http.request',
+    }),
+    dict({
+      'imported': 'django.core.files.uploadhandler',
+      'importer': 'django.http.request',
+    }),
+    dict({
+      'imported': 'django.core.signing',
+      'importer': 'django.http.request',
+    }),
+    dict({
+      'imported': 'django.http.multipartparser',
+      'importer': 'django.http.request',
+    }),
+    dict({
+      'imported': 'django.utils.datastructures',
+      'importer': 'django.http.request',
+    }),
+    dict({
+      'imported': 'django.utils.encoding',
+      'importer': 'django.http.request',
+    }),
+    dict({
+      'imported': 'django.utils.functional',
+      'importer': 'django.http.request',
+    }),
+    dict({
+      'imported': 'django.utils.http',
+      'importer': 'django.http.request',
+    }),
+    dict({
+      'imported': 'django.utils.regex_helper',
+      'importer': 'django.http.request',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.http.response',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.http.response',
+    }),
+    dict({
+      'imported': 'django.core.serializers.json',
+      'importer': 'django.http.response',
+    }),
+    dict({
+      'imported': 'django.core.signals',
+      'importer': 'django.http.response',
+    }),
+    dict({
+      'imported': 'django.core.signing',
+      'importer': 'django.http.response',
+    }),
+    dict({
+      'imported': 'django.http.cookie',
+      'importer': 'django.http.response',
+    }),
+    dict({
+      'imported': 'django.utils.datastructures',
+      'importer': 'django.http.response',
+    }),
+    dict({
+      'imported': 'django.utils.encoding',
+      'importer': 'django.http.response',
+    }),
+    dict({
+      'imported': 'django.utils.http',
+      'importer': 'django.http.response',
+    }),
+    dict({
+      'imported': 'django.utils.regex_helper',
+      'importer': 'django.http.response',
+    }),
+    dict({
+      'imported': 'django.utils.timezone',
+      'importer': 'django.http.response',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.middleware.cache',
+    }),
+    dict({
+      'imported': 'django.core.cache',
+      'importer': 'django.middleware.cache',
+    }),
+    dict({
+      'imported': 'django.utils.cache',
+      'importer': 'django.middleware.cache',
+    }),
+    dict({
+      'imported': 'django.utils.deprecation',
+      'importer': 'django.middleware.cache',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.middleware.clickjacking',
+    }),
+    dict({
+      'imported': 'django.utils.deprecation',
+      'importer': 'django.middleware.clickjacking',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.middleware.common',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.middleware.common',
+    }),
+    dict({
+      'imported': 'django.core.mail',
+      'importer': 'django.middleware.common',
+    }),
+    dict({
+      'imported': 'django.http',
+      'importer': 'django.middleware.common',
+    }),
+    dict({
+      'imported': 'django.urls',
+      'importer': 'django.middleware.common',
+    }),
+    dict({
+      'imported': 'django.utils.deprecation',
+      'importer': 'django.middleware.common',
+    }),
+    dict({
+      'imported': 'django.utils.http',
+      'importer': 'django.middleware.common',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.middleware.csrf',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.middleware.csrf',
+    }),
+    dict({
+      'imported': 'django.http',
+      'importer': 'django.middleware.csrf',
+    }),
+    dict({
+      'imported': 'django.urls',
+      'importer': 'django.middleware.csrf',
+    }),
+    dict({
+      'imported': 'django.utils.cache',
+      'importer': 'django.middleware.csrf',
+    }),
+    dict({
+      'imported': 'django.utils.crypto',
+      'importer': 'django.middleware.csrf',
+    }),
+    dict({
+      'imported': 'django.utils.deprecation',
+      'importer': 'django.middleware.csrf',
+    }),
+    dict({
+      'imported': 'django.utils.functional',
+      'importer': 'django.middleware.csrf',
+    }),
+    dict({
+      'imported': 'django.utils.http',
+      'importer': 'django.middleware.csrf',
+    }),
+    dict({
+      'imported': 'django.utils.log',
+      'importer': 'django.middleware.csrf',
+    }),
+    dict({
+      'imported': 'django.utils.regex_helper',
+      'importer': 'django.middleware.csrf',
+    }),
+    dict({
+      'imported': 'django.utils.cache',
+      'importer': 'django.middleware.gzip',
+    }),
+    dict({
+      'imported': 'django.utils.deprecation',
+      'importer': 'django.middleware.gzip',
+    }),
+    dict({
+      'imported': 'django.utils.regex_helper',
+      'importer': 'django.middleware.gzip',
+    }),
+    dict({
+      'imported': 'django.utils.text',
+      'importer': 'django.middleware.gzip',
+    }),
+    dict({
+      'imported': 'django.utils.cache',
+      'importer': 'django.middleware.http',
+    }),
+    dict({
+      'imported': 'django.utils.deprecation',
+      'importer': 'django.middleware.http',
+    }),
+    dict({
+      'imported': 'django.utils.http',
+      'importer': 'django.middleware.http',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.middleware.locale',
+    }),
+    dict({
+      'imported': 'django.conf.urls.i18n',
+      'importer': 'django.middleware.locale',
+    }),
+    dict({
+      'imported': 'django.http',
+      'importer': 'django.middleware.locale',
+    }),
+    dict({
+      'imported': 'django.urls',
+      'importer': 'django.middleware.locale',
+    }),
+    dict({
+      'imported': 'django.utils.cache',
+      'importer': 'django.middleware.locale',
+    }),
+    dict({
+      'imported': 'django.utils.deprecation',
+      'importer': 'django.middleware.locale',
+    }),
+    dict({
+      'imported': 'django.utils.translation',
+      'importer': 'django.middleware.locale',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.middleware.security',
+    }),
+    dict({
+      'imported': 'django.http',
+      'importer': 'django.middleware.security',
+    }),
+    dict({
+      'imported': 'django.utils.deprecation',
+      'importer': 'django.middleware.security',
+    }),
+    dict({
+      'imported': 'django.http',
+      'importer': 'django.shortcuts',
+    }),
+    dict({
+      'imported': 'django.template.loader',
+      'importer': 'django.shortcuts',
+    }),
+    dict({
+      'imported': 'django.urls',
+      'importer': 'django.shortcuts',
+    }),
+    dict({
+      'imported': 'django.utils.functional',
+      'importer': 'django.shortcuts',
+    }),
+    dict({
+      'imported': 'django.template.autoreload',
+      'importer': 'django.template',
+    }),
+    dict({
+      'imported': 'django.template.base',
+      'importer': 'django.template',
+    }),
+    dict({
+      'imported': 'django.template.context',
+      'importer': 'django.template',
+    }),
+    dict({
+      'imported': 'django.template.engine',
+      'importer': 'django.template',
+    }),
+    dict({
+      'imported': 'django.template.exceptions',
+      'importer': 'django.template',
+    }),
+    dict({
+      'imported': 'django.template.library',
+      'importer': 'django.template',
+    }),
+    dict({
+      'imported': 'django.template.utils',
+      'importer': 'django.template',
+    }),
+    dict({
+      'imported': 'django.dispatch',
+      'importer': 'django.template.autoreload',
+    }),
+    dict({
+      'imported': 'django.template',
+      'importer': 'django.template.autoreload',
+    }),
+    dict({
+      'imported': 'django.template.backends.django',
+      'importer': 'django.template.autoreload',
+    }),
+    dict({
+      'imported': 'django.utils._os',
+      'importer': 'django.template.autoreload',
+    }),
+    dict({
+      'imported': 'django.utils.autoreload',
+      'importer': 'django.template.autoreload',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.template.backends.base',
+    }),
+    dict({
+      'imported': 'django.template.utils',
+      'importer': 'django.template.backends.base',
+    }),
+    dict({
+      'imported': 'django.utils._os',
+      'importer': 'django.template.backends.base',
+    }),
+    dict({
+      'imported': 'django.utils.functional',
+      'importer': 'django.template.backends.base',
+    }),
+    dict({
+      'imported': 'django.apps',
+      'importer': 'django.template.backends.django',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.template.backends.django',
+    }),
+    dict({
+      'imported': 'django.template',
+      'importer': 'django.template.backends.django',
+    }),
+    dict({
+      'imported': 'django.template.backends.base',
+      'importer': 'django.template.backends.django',
+    }),
+    dict({
+      'imported': 'django.template.context',
+      'importer': 'django.template.backends.django',
+    }),
+    dict({
+      'imported': 'django.template.engine',
+      'importer': 'django.template.backends.django',
+    }),
+    dict({
+      'imported': 'django.template.library',
+      'importer': 'django.template.backends.django',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.template.backends.dummy',
+    }),
+    dict({
+      'imported': 'django.template',
+      'importer': 'django.template.backends.dummy',
+    }),
+    dict({
+      'imported': 'django.template.backends.base',
+      'importer': 'django.template.backends.dummy',
+    }),
+    dict({
+      'imported': 'django.template.backends.utils',
+      'importer': 'django.template.backends.dummy',
+    }),
+    dict({
+      'imported': 'django.utils.html',
+      'importer': 'django.template.backends.dummy',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.template.backends.jinja2',
+    }),
+    dict({
+      'imported': 'django.template',
+      'importer': 'django.template.backends.jinja2',
+    }),
+    dict({
+      'imported': 'django.template.backends.base',
+      'importer': 'django.template.backends.jinja2',
+    }),
+    dict({
+      'imported': 'django.template.backends.utils',
+      'importer': 'django.template.backends.jinja2',
+    }),
+    dict({
+      'imported': 'django.utils.functional',
+      'importer': 'django.template.backends.jinja2',
+    }),
+    dict({
+      'imported': 'django.utils.module_loading',
+      'importer': 'django.template.backends.jinja2',
+    }),
+    dict({
+      'imported': 'django.middleware.csrf',
+      'importer': 'django.template.backends.utils',
+    }),
+    dict({
+      'imported': 'django.utils.functional',
+      'importer': 'django.template.backends.utils',
+    }),
+    dict({
+      'imported': 'django.utils.html',
+      'importer': 'django.template.backends.utils',
+    }),
+    dict({
+      'imported': 'django.utils.safestring',
+      'importer': 'django.template.backends.utils',
+    }),
+    dict({
+      'imported': 'django.template.context',
+      'importer': 'django.template.base',
+    }),
+    dict({
+      'imported': 'django.template.engine',
+      'importer': 'django.template.base',
+    }),
+    dict({
+      'imported': 'django.template.exceptions',
+      'importer': 'django.template.base',
+    }),
+    dict({
+      'imported': 'django.utils.formats',
+      'importer': 'django.template.base',
+    }),
+    dict({
+      'imported': 'django.utils.html',
+      'importer': 'django.template.base',
+    }),
+    dict({
+      'imported': 'django.utils.regex_helper',
+      'importer': 'django.template.base',
+    }),
+    dict({
+      'imported': 'django.utils.safestring',
+      'importer': 'django.template.base',
+    }),
+    dict({
+      'imported': 'django.utils.text',
+      'importer': 'django.template.base',
+    }),
+    dict({
+      'imported': 'django.utils.timezone',
+      'importer': 'django.template.base',
+    }),
+    dict({
+      'imported': 'django.utils.translation',
+      'importer': 'django.template.base',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.template.context_processors',
+    }),
+    dict({
+      'imported': 'django.db',
+      'importer': 'django.template.context_processors',
+    }),
+    dict({
+      'imported': 'django.middleware.csrf',
+      'importer': 'django.template.context_processors',
+    }),
+    dict({
+      'imported': 'django.utils.functional',
+      'importer': 'django.template.context_processors',
+    }),
+    dict({
+      'imported': 'django.utils.timezone',
+      'importer': 'django.template.context_processors',
+    }),
+    dict({
+      'imported': 'django.utils.translation',
+      'importer': 'django.template.context_processors',
+    }),
+    dict({
+      'imported': 'django.template.base',
+      'importer': 'django.template.defaultfilters',
+    }),
+    dict({
+      'imported': 'django.template.library',
+      'importer': 'django.template.defaultfilters',
+    }),
+    dict({
+      'imported': 'django.utils.dateformat',
+      'importer': 'django.template.defaultfilters',
+    }),
+    dict({
+      'imported': 'django.utils.deprecation',
+      'importer': 'django.template.defaultfilters',
+    }),
+    dict({
+      'imported': 'django.utils.encoding',
+      'importer': 'django.template.defaultfilters',
+    }),
+    dict({
+      'imported': 'django.utils.formats',
+      'importer': 'django.template.defaultfilters',
+    }),
+    dict({
+      'imported': 'django.utils.html',
+      'importer': 'django.template.defaultfilters',
+    }),
+    dict({
+      'imported': 'django.utils.safestring',
+      'importer': 'django.template.defaultfilters',
+    }),
+    dict({
+      'imported': 'django.utils.text',
+      'importer': 'django.template.defaultfilters',
+    }),
+    dict({
+      'imported': 'django.utils.timesince',
+      'importer': 'django.template.defaultfilters',
+    }),
+    dict({
+      'imported': 'django.utils.translation',
+      'importer': 'django.template.defaultfilters',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.template.defaulttags',
+    }),
+    dict({
+      'imported': 'django.template.base',
+      'importer': 'django.template.defaulttags',
+    }),
+    dict({
+      'imported': 'django.template.context',
+      'importer': 'django.template.defaulttags',
+    }),
+    dict({
+      'imported': 'django.template.defaultfilters',
+      'importer': 'django.template.defaulttags',
+    }),
+    dict({
+      'imported': 'django.template.library',
+      'importer': 'django.template.defaulttags',
+    }),
+    dict({
+      'imported': 'django.template.smartif',
+      'importer': 'django.template.defaulttags',
+    }),
+    dict({
+      'imported': 'django.urls',
+      'importer': 'django.template.defaulttags',
+    }),
+    dict({
+      'imported': 'django.utils.html',
+      'importer': 'django.template.defaulttags',
+    }),
+    dict({
+      'imported': 'django.utils.lorem_ipsum',
+      'importer': 'django.template.defaulttags',
+    }),
+    dict({
+      'imported': 'django.utils.safestring',
+      'importer': 'django.template.defaulttags',
+    }),
+    dict({
+      'imported': 'django.utils.timezone',
+      'importer': 'django.template.defaulttags',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.template.engine',
+    }),
+    dict({
+      'imported': 'django.template',
+      'importer': 'django.template.engine',
+    }),
+    dict({
+      'imported': 'django.template.backends.django',
+      'importer': 'django.template.engine',
+    }),
+    dict({
+      'imported': 'django.template.base',
+      'importer': 'django.template.engine',
+    }),
+    dict({
+      'imported': 'django.template.context',
+      'importer': 'django.template.engine',
+    }),
+    dict({
+      'imported': 'django.template.exceptions',
+      'importer': 'django.template.engine',
+    }),
+    dict({
+      'imported': 'django.template.library',
+      'importer': 'django.template.engine',
+    }),
+    dict({
+      'imported': 'django.utils.functional',
+      'importer': 'django.template.engine',
+    }),
+    dict({
+      'imported': 'django.utils.module_loading',
+      'importer': 'django.template.engine',
+    }),
+    dict({
+      'imported': 'django.template.base',
+      'importer': 'django.template.library',
+    }),
+    dict({
+      'imported': 'django.template.exceptions',
+      'importer': 'django.template.library',
+    }),
+    dict({
+      'imported': 'django.utils.html',
+      'importer': 'django.template.library',
+    }),
+    dict({
+      'imported': 'django.utils.itercompat',
+      'importer': 'django.template.library',
+    }),
+    dict({
+      'imported': 'django.template',
+      'importer': 'django.template.loader',
+    }),
+    dict({
+      'imported': 'django.template.exceptions',
+      'importer': 'django.template.loader',
+    }),
+    dict({
+      'imported': 'django.template.base',
+      'importer': 'django.template.loader_tags',
+    }),
+    dict({
+      'imported': 'django.template.library',
+      'importer': 'django.template.loader_tags',
+    }),
+    dict({
+      'imported': 'django.utils.safestring',
+      'importer': 'django.template.loader_tags',
+    }),
+    dict({
+      'imported': 'django.template.loaders.filesystem',
+      'importer': 'django.template.loaders.app_directories',
+    }),
+    dict({
+      'imported': 'django.template.utils',
+      'importer': 'django.template.loaders.app_directories',
+    }),
+    dict({
+      'imported': 'django.template',
+      'importer': 'django.template.loaders.base',
+    }),
+    dict({
+      'imported': 'django.template',
+      'importer': 'django.template.loaders.cached',
+    }),
+    dict({
+      'imported': 'django.template.backends.django',
+      'importer': 'django.template.loaders.cached',
+    }),
+    dict({
+      'imported': 'django.template.loaders.base',
+      'importer': 'django.template.loaders.cached',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.template.loaders.filesystem',
+    }),
+    dict({
+      'imported': 'django.template',
+      'importer': 'django.template.loaders.filesystem',
+    }),
+    dict({
+      'imported': 'django.template.loaders.base',
+      'importer': 'django.template.loaders.filesystem',
+    }),
+    dict({
+      'imported': 'django.utils._os',
+      'importer': 'django.template.loaders.filesystem',
+    }),
+    dict({
+      'imported': 'django.template',
+      'importer': 'django.template.loaders.locmem',
+    }),
+    dict({
+      'imported': 'django.template.loaders.base',
+      'importer': 'django.template.loaders.locmem',
+    }),
+    dict({
+      'imported': 'django.http',
+      'importer': 'django.template.response',
+    }),
+    dict({
+      'imported': 'django.template.loader',
+      'importer': 'django.template.response',
+    }),
+    dict({
+      'imported': 'django.apps',
+      'importer': 'django.template.utils',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.template.utils',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.template.utils',
+    }),
+    dict({
+      'imported': 'django.utils.functional',
+      'importer': 'django.template.utils',
+    }),
+    dict({
+      'imported': 'django.utils.module_loading',
+      'importer': 'django.template.utils',
+    }),
+    dict({
+      'imported': 'django.core.cache',
+      'importer': 'django.templatetags.cache',
+    }),
+    dict({
+      'imported': 'django.core.cache.utils',
+      'importer': 'django.templatetags.cache',
+    }),
+    dict({
+      'imported': 'django.template',
+      'importer': 'django.templatetags.cache',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.templatetags.i18n',
+    }),
+    dict({
+      'imported': 'django.template',
+      'importer': 'django.templatetags.i18n',
+    }),
+    dict({
+      'imported': 'django.template.base',
+      'importer': 'django.templatetags.i18n',
+    }),
+    dict({
+      'imported': 'django.template.defaulttags',
+      'importer': 'django.templatetags.i18n',
+    }),
+    dict({
+      'imported': 'django.utils.safestring',
+      'importer': 'django.templatetags.i18n',
+    }),
+    dict({
+      'imported': 'django.utils.translation',
+      'importer': 'django.templatetags.i18n',
+    }),
+    dict({
+      'imported': 'django.template',
+      'importer': 'django.templatetags.l10n',
+    }),
+    dict({
+      'imported': 'django.utils.formats',
+      'importer': 'django.templatetags.l10n',
+    }),
+    dict({
+      'imported': 'django.apps',
+      'importer': 'django.templatetags.static',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.templatetags.static',
+    }),
+    dict({
+      'imported': 'django.contrib.staticfiles.storage',
+      'importer': 'django.templatetags.static',
+    }),
+    dict({
+      'imported': 'django.template',
+      'importer': 'django.templatetags.static',
+    }),
+    dict({
+      'imported': 'django.utils.encoding',
+      'importer': 'django.templatetags.static',
+    }),
+    dict({
+      'imported': 'django.utils.html',
+      'importer': 'django.templatetags.static',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.templatetags.tz',
+    }),
+    dict({
+      'imported': 'django.template',
+      'importer': 'django.templatetags.tz',
+    }),
+    dict({
+      'imported': 'django.utils.timezone',
+      'importer': 'django.templatetags.tz',
+    }),
+    dict({
+      'imported': 'django.test.client',
+      'importer': 'django.test',
+    }),
+    dict({
+      'imported': 'django.test.testcases',
+      'importer': 'django.test',
+    }),
+    dict({
+      'imported': 'django.test.utils',
+      'importer': 'django.test',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.test.client',
+    }),
+    dict({
+      'imported': 'django.contrib.auth',
+      'importer': 'django.test.client',
+    }),
+    dict({
+      'imported': 'django.core.handlers.asgi',
+      'importer': 'django.test.client',
+    }),
+    dict({
+      'imported': 'django.core.handlers.base',
+      'importer': 'django.test.client',
+    }),
+    dict({
+      'imported': 'django.core.handlers.wsgi',
+      'importer': 'django.test.client',
+    }),
+    dict({
+      'imported': 'django.core.serializers.json',
+      'importer': 'django.test.client',
+    }),
+    dict({
+      'imported': 'django.core.signals',
+      'importer': 'django.test.client',
+    }),
+    dict({
+      'imported': 'django.db',
+      'importer': 'django.test.client',
+    }),
+    dict({
+      'imported': 'django.http',
+      'importer': 'django.test.client',
+    }),
+    dict({
+      'imported': 'django.test.signals',
+      'importer': 'django.test.client',
+    }),
+    dict({
+      'imported': 'django.test.utils',
+      'importer': 'django.test.client',
+    }),
+    dict({
+      'imported': 'django.urls',
+      'importer': 'django.test.client',
+    }),
+    dict({
+      'imported': 'django.utils.encoding',
+      'importer': 'django.test.client',
+    }),
+    dict({
+      'imported': 'django.utils.functional',
+      'importer': 'django.test.client',
+    }),
+    dict({
+      'imported': 'django.utils.http',
+      'importer': 'django.test.client',
+    }),
+    dict({
+      'imported': 'django.utils.itercompat',
+      'importer': 'django.test.client',
+    }),
+    dict({
+      'imported': 'django.utils.regex_helper',
+      'importer': 'django.test.client',
+    }),
+    dict({
+      'imported': 'django.utils.regex_helper',
+      'importer': 'django.test.html',
+    }),
+    dict({
+      'imported': 'django',
+      'importer': 'django.test.runner',
+    }),
+    dict({
+      'imported': 'django.core.management',
+      'importer': 'django.test.runner',
+    }),
+    dict({
+      'imported': 'django.db',
+      'importer': 'django.test.runner',
+    }),
+    dict({
+      'imported': 'django.test',
+      'importer': 'django.test.runner',
+    }),
+    dict({
+      'imported': 'django.test.utils',
+      'importer': 'django.test.runner',
+    }),
+    dict({
+      'imported': 'django.utils.crypto',
+      'importer': 'django.test.runner',
+    }),
+    dict({
+      'imported': 'django.utils.datastructures',
+      'importer': 'django.test.runner',
+    }),
+    dict({
+      'imported': 'django.utils.deprecation',
+      'importer': 'django.test.runner',
+    }),
+    dict({
+      'imported': 'django.test',
+      'importer': 'django.test.selenium',
+    }),
+    dict({
+      'imported': 'django.utils.functional',
+      'importer': 'django.test.selenium',
+    }),
+    dict({
+      'imported': 'django.utils.module_loading',
+      'importer': 'django.test.selenium',
+    }),
+    dict({
+      'imported': 'django.utils.text',
+      'importer': 'django.test.selenium',
+    }),
+    dict({
+      'imported': 'django.apps',
+      'importer': 'django.test.signals',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.test.signals',
+    }),
+    dict({
+      'imported': 'django.contrib.auth',
+      'importer': 'django.test.signals',
+    }),
+    dict({
+      'imported': 'django.contrib.auth.backends',
+      'importer': 'django.test.signals',
+    }),
+    dict({
+      'imported': 'django.contrib.auth.forms',
+      'importer': 'django.test.signals',
+    }),
+    dict({
+      'imported': 'django.contrib.auth.handlers.modwsgi',
+      'importer': 'django.test.signals',
+    }),
+    dict({
+      'imported': 'django.contrib.auth.management.commands.changepassword',
+      'importer': 'django.test.signals',
+    }),
+    dict({
+      'imported': 'django.contrib.auth.password_validation',
+      'importer': 'django.test.signals',
+    }),
+    dict({
+      'imported': 'django.contrib.auth.views',
+      'importer': 'django.test.signals',
+    }),
+    dict({
+      'imported': 'django.contrib.staticfiles.finders',
+      'importer': 'django.test.signals',
+    }),
+    dict({
+      'imported': 'django.contrib.staticfiles.storage',
+      'importer': 'django.test.signals',
+    }),
+    dict({
+      'imported': 'django.core.cache',
+      'importer': 'django.test.signals',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.test.signals',
+    }),
+    dict({
+      'imported': 'django.core.files.storage',
+      'importer': 'django.test.signals',
+    }),
+    dict({
+      'imported': 'django.core.management',
+      'importer': 'django.test.signals',
+    }),
+    dict({
+      'imported': 'django.core.serializers',
+      'importer': 'django.test.signals',
+    }),
+    dict({
+      'imported': 'django.core.signals',
+      'importer': 'django.test.signals',
+    }),
+    dict({
+      'imported': 'django.db',
+      'importer': 'django.test.signals',
+    }),
+    dict({
+      'imported': 'django.db.utils',
+      'importer': 'django.test.signals',
+    }),
+    dict({
+      'imported': 'django.dispatch',
+      'importer': 'django.test.signals',
+    }),
+    dict({
+      'imported': 'django.forms.renderers',
+      'importer': 'django.test.signals',
+    }),
+    dict({
+      'imported': 'django.template',
+      'importer': 'django.test.signals',
+    }),
+    dict({
+      'imported': 'django.template.engine',
+      'importer': 'django.test.signals',
+    }),
+    dict({
+      'imported': 'django.template.utils',
+      'importer': 'django.test.signals',
+    }),
+    dict({
+      'imported': 'django.urls',
+      'importer': 'django.test.signals',
+    }),
+    dict({
+      'imported': 'django.utils.formats',
+      'importer': 'django.test.signals',
+    }),
+    dict({
+      'imported': 'django.utils.functional',
+      'importer': 'django.test.signals',
+    }),
+    dict({
+      'imported': 'django.utils.module_loading',
+      'importer': 'django.test.signals',
+    }),
+    dict({
+      'imported': 'django.utils.timezone',
+      'importer': 'django.test.signals',
+    }),
+    dict({
+      'imported': 'django.utils.translation.trans_real',
+      'importer': 'django.test.signals',
+    }),
+    dict({
+      'imported': 'django.utils.version',
+      'importer': 'django.test.signals',
+    }),
+    dict({
+      'imported': 'django.apps',
+      'importer': 'django.test.testcases',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.test.testcases',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.test.testcases',
+    }),
+    dict({
+      'imported': 'django.core.files.locks',
+      'importer': 'django.test.testcases',
+    }),
+    dict({
+      'imported': 'django.core.handlers.wsgi',
+      'importer': 'django.test.testcases',
+    }),
+    dict({
+      'imported': 'django.core.mail',
+      'importer': 'django.test.testcases',
+    }),
+    dict({
+      'imported': 'django.core.management',
+      'importer': 'django.test.testcases',
+    }),
+    dict({
+      'imported': 'django.core.management.color',
+      'importer': 'django.test.testcases',
+    }),
+    dict({
+      'imported': 'django.core.management.sql',
+      'importer': 'django.test.testcases',
+    }),
+    dict({
+      'imported': 'django.core.servers.basehttp',
+      'importer': 'django.test.testcases',
+    }),
+    dict({
+      'imported': 'django.core.signals',
+      'importer': 'django.test.testcases',
+    }),
+    dict({
+      'imported': 'django.db',
+      'importer': 'django.test.testcases',
+    }),
+    dict({
+      'imported': 'django.db.transaction',
+      'importer': 'django.test.testcases',
+    }),
+    dict({
+      'imported': 'django.forms.fields',
+      'importer': 'django.test.testcases',
+    }),
+    dict({
+      'imported': 'django.http',
+      'importer': 'django.test.testcases',
+    }),
+    dict({
+      'imported': 'django.http.request',
+      'importer': 'django.test.testcases',
+    }),
+    dict({
+      'imported': 'django.http.response',
+      'importer': 'django.test.testcases',
+    }),
+    dict({
+      'imported': 'django.test.client',
+      'importer': 'django.test.testcases',
+    }),
+    dict({
+      'imported': 'django.test.html',
+      'importer': 'django.test.testcases',
+    }),
+    dict({
+      'imported': 'django.test.signals',
+      'importer': 'django.test.testcases',
+    }),
+    dict({
+      'imported': 'django.test.utils',
+      'importer': 'django.test.testcases',
+    }),
+    dict({
+      'imported': 'django.utils.deprecation',
+      'importer': 'django.test.testcases',
+    }),
+    dict({
+      'imported': 'django.utils.functional',
+      'importer': 'django.test.testcases',
+    }),
+    dict({
+      'imported': 'django.utils.version',
+      'importer': 'django.test.testcases',
+    }),
+    dict({
+      'imported': 'django.views.static',
+      'importer': 'django.test.testcases',
+    }),
+    dict({
+      'imported': 'django.apps',
+      'importer': 'django.test.utils',
+    }),
+    dict({
+      'imported': 'django.apps.registry',
+      'importer': 'django.test.utils',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.test.utils',
+    }),
+    dict({
+      'imported': 'django.core.checks.registry',
+      'importer': 'django.test.utils',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.test.utils',
+    }),
+    dict({
+      'imported': 'django.core.mail',
+      'importer': 'django.test.utils',
+    }),
+    dict({
+      'imported': 'django.core.signals',
+      'importer': 'django.test.utils',
+    }),
+    dict({
+      'imported': 'django.db',
+      'importer': 'django.test.utils',
+    }),
+    dict({
+      'imported': 'django.db.models.options',
+      'importer': 'django.test.utils',
+    }),
+    dict({
+      'imported': 'django.template',
+      'importer': 'django.test.utils',
+    }),
+    dict({
+      'imported': 'django.test',
+      'importer': 'django.test.utils',
+    }),
+    dict({
+      'imported': 'django.test.signals',
+      'importer': 'django.test.utils',
+    }),
+    dict({
+      'imported': 'django.urls',
+      'importer': 'django.test.utils',
+    }),
+    dict({
+      'imported': 'django.utils.deprecation',
+      'importer': 'django.test.utils',
+    }),
+    dict({
+      'imported': 'django.utils.translation',
+      'importer': 'django.test.utils',
+    }),
+    dict({
+      'imported': 'django.urls.base',
+      'importer': 'django.urls',
+    }),
+    dict({
+      'imported': 'django.urls.conf',
+      'importer': 'django.urls',
+    }),
+    dict({
+      'imported': 'django.urls.converters',
+      'importer': 'django.urls',
+    }),
+    dict({
+      'imported': 'django.urls.exceptions',
+      'importer': 'django.urls',
+    }),
+    dict({
+      'imported': 'django.urls.resolvers',
+      'importer': 'django.urls',
+    }),
+    dict({
+      'imported': 'django.urls.utils',
+      'importer': 'django.urls',
+    }),
+    dict({
+      'imported': 'django.urls.exceptions',
+      'importer': 'django.urls.base',
+    }),
+    dict({
+      'imported': 'django.urls.resolvers',
+      'importer': 'django.urls.base',
+    }),
+    dict({
+      'imported': 'django.urls.utils',
+      'importer': 'django.urls.base',
+    }),
+    dict({
+      'imported': 'django.utils.functional',
+      'importer': 'django.urls.base',
+    }),
+    dict({
+      'imported': 'django.utils.translation',
+      'importer': 'django.urls.base',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.urls.conf',
+    }),
+    dict({
+      'imported': 'django.urls.resolvers',
+      'importer': 'django.urls.conf',
+    }),
+    dict({
+      'imported': 'django.views',
+      'importer': 'django.urls.conf',
+    }),
+    dict({
+      'imported': 'django.http',
+      'importer': 'django.urls.exceptions',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.urls.resolvers',
+    }),
+    dict({
+      'imported': 'django.conf.urls',
+      'importer': 'django.urls.resolvers',
+    }),
+    dict({
+      'imported': 'django.core.checks',
+      'importer': 'django.urls.resolvers',
+    }),
+    dict({
+      'imported': 'django.core.checks.urls',
+      'importer': 'django.urls.resolvers',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.urls.resolvers',
+    }),
+    dict({
+      'imported': 'django.urls.converters',
+      'importer': 'django.urls.resolvers',
+    }),
+    dict({
+      'imported': 'django.urls.exceptions',
+      'importer': 'django.urls.resolvers',
+    }),
+    dict({
+      'imported': 'django.urls.utils',
+      'importer': 'django.urls.resolvers',
+    }),
+    dict({
+      'imported': 'django.utils.datastructures',
+      'importer': 'django.urls.resolvers',
+    }),
+    dict({
+      'imported': 'django.utils.functional',
+      'importer': 'django.urls.resolvers',
+    }),
+    dict({
+      'imported': 'django.utils.http',
+      'importer': 'django.urls.resolvers',
+    }),
+    dict({
+      'imported': 'django.utils.regex_helper',
+      'importer': 'django.urls.resolvers',
+    }),
+    dict({
+      'imported': 'django.utils.translation',
+      'importer': 'django.urls.resolvers',
+    }),
+    dict({
+      'imported': 'django.views',
+      'importer': 'django.urls.resolvers',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.urls.utils',
+    }),
+    dict({
+      'imported': 'django.utils.module_loading',
+      'importer': 'django.urls.utils',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.utils._os',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.utils.archive',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.utils.asyncio',
+    }),
+    dict({
+      'imported': 'django',
+      'importer': 'django.utils.autoreload',
+    }),
+    dict({
+      'imported': 'django.apps',
+      'importer': 'django.utils.autoreload',
+    }),
+    dict({
+      'imported': 'django.core.signals',
+      'importer': 'django.utils.autoreload',
+    }),
+    dict({
+      'imported': 'django.dispatch',
+      'importer': 'django.utils.autoreload',
+    }),
+    dict({
+      'imported': 'django.urls',
+      'importer': 'django.utils.autoreload',
+    }),
+    dict({
+      'imported': 'django.utils.functional',
+      'importer': 'django.utils.autoreload',
+    }),
+    dict({
+      'imported': 'django.utils.version',
+      'importer': 'django.utils.autoreload',
+    }),
+    dict({
+      'imported': 'django.utils.deprecation',
+      'importer': 'django.utils.baseconv',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.utils.cache',
+    }),
+    dict({
+      'imported': 'django.core.cache',
+      'importer': 'django.utils.cache',
+    }),
+    dict({
+      'imported': 'django.http',
+      'importer': 'django.utils.cache',
+    }),
+    dict({
+      'imported': 'django.utils.crypto',
+      'importer': 'django.utils.cache',
+    }),
+    dict({
+      'imported': 'django.utils.http',
+      'importer': 'django.utils.cache',
+    }),
+    dict({
+      'imported': 'django.utils.log',
+      'importer': 'django.utils.cache',
+    }),
+    dict({
+      'imported': 'django.utils.regex_helper',
+      'importer': 'django.utils.cache',
+    }),
+    dict({
+      'imported': 'django.utils.timezone',
+      'importer': 'django.utils.cache',
+    }),
+    dict({
+      'imported': 'django.utils.translation',
+      'importer': 'django.utils.cache',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.utils.connection',
+    }),
+    dict({
+      'imported': 'django.utils.functional',
+      'importer': 'django.utils.connection',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.utils.crypto',
+    }),
+    dict({
+      'imported': 'django.utils.encoding',
+      'importer': 'django.utils.crypto',
+    }),
+    dict({
+      'imported': 'django.utils.inspect',
+      'importer': 'django.utils.crypto',
+    }),
+    dict({
+      'imported': 'django.utils.dates',
+      'importer': 'django.utils.dateformat',
+    }),
+    dict({
+      'imported': 'django.utils.regex_helper',
+      'importer': 'django.utils.dateformat',
+    }),
+    dict({
+      'imported': 'django.utils.timezone',
+      'importer': 'django.utils.dateformat',
+    }),
+    dict({
+      'imported': 'django.utils.translation',
+      'importer': 'django.utils.dateformat',
+    }),
+    dict({
+      'imported': 'django.utils.regex_helper',
+      'importer': 'django.utils.dateparse',
+    }),
+    dict({
+      'imported': 'django.utils.timezone',
+      'importer': 'django.utils.dateparse',
+    }),
+    dict({
+      'imported': 'django.utils.translation',
+      'importer': 'django.utils.dates',
+    }),
+    dict({
+      'imported': 'django.utils.deprecation',
+      'importer': 'django.utils.datetime_safe',
+    }),
+    dict({
+      'imported': 'django.utils.regex_helper',
+      'importer': 'django.utils.datetime_safe',
+    }),
+    dict({
+      'imported': 'django.utils.version',
+      'importer': 'django.utils.deconstruct',
+    }),
+    dict({
+      'imported': 'django.utils.functional',
+      'importer': 'django.utils.encoding',
+    }),
+    dict({
+      'imported': 'django.utils.encoding',
+      'importer': 'django.utils.feedgenerator',
+    }),
+    dict({
+      'imported': 'django.utils.xmlutils',
+      'importer': 'django.utils.feedgenerator',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.utils.formats',
+    }),
+    dict({
+      'imported': 'django.utils.dateformat',
+      'importer': 'django.utils.formats',
+    }),
+    dict({
+      'imported': 'django.utils.functional',
+      'importer': 'django.utils.formats',
+    }),
+    dict({
+      'imported': 'django.utils.numberformat',
+      'importer': 'django.utils.formats',
+    }),
+    dict({
+      'imported': 'django.utils.translation',
+      'importer': 'django.utils.formats',
+    }),
+    dict({
+      'imported': 'django.utils.deprecation',
+      'importer': 'django.utils.functional',
+    }),
+    dict({
+      'imported': 'django.utils.itercompat',
+      'importer': 'django.utils.hashable',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.utils.html',
+    }),
+    dict({
+      'imported': 'django.core.serializers.json',
+      'importer': 'django.utils.html',
+    }),
+    dict({
+      'imported': 'django.utils.encoding',
+      'importer': 'django.utils.html',
+    }),
+    dict({
+      'imported': 'django.utils.functional',
+      'importer': 'django.utils.html',
+    }),
+    dict({
+      'imported': 'django.utils.http',
+      'importer': 'django.utils.html',
+    }),
+    dict({
+      'imported': 'django.utils.regex_helper',
+      'importer': 'django.utils.html',
+    }),
+    dict({
+      'imported': 'django.utils.safestring',
+      'importer': 'django.utils.html',
+    }),
+    dict({
+      'imported': 'django.utils.text',
+      'importer': 'django.utils.html',
+    }),
+    dict({
+      'imported': 'django.utils.datastructures',
+      'importer': 'django.utils.http',
+    }),
+    dict({
+      'imported': 'django.utils.regex_helper',
+      'importer': 'django.utils.http',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.utils.ipv6',
+    }),
+    dict({
+      'imported': 'django.utils.translation',
+      'importer': 'django.utils.ipv6',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.utils.log',
+    }),
+    dict({
+      'imported': 'django.core.mail',
+      'importer': 'django.utils.log',
+    }),
+    dict({
+      'imported': 'django.core.management.color',
+      'importer': 'django.utils.log',
+    }),
+    dict({
+      'imported': 'django.utils.module_loading',
+      'importer': 'django.utils.log',
+    }),
+    dict({
+      'imported': 'django.apps',
+      'importer': 'django.utils.module_loading',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.utils.numberformat',
+    }),
+    dict({
+      'imported': 'django.utils.safestring',
+      'importer': 'django.utils.numberformat',
+    }),
+    dict({
+      'imported': 'django.utils.functional',
+      'importer': 'django.utils.regex_helper',
+    }),
+    dict({
+      'imported': 'django.utils.functional',
+      'importer': 'django.utils.safestring',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.utils.text',
+    }),
+    dict({
+      'imported': 'django.utils.functional',
+      'importer': 'django.utils.text',
+    }),
+    dict({
+      'imported': 'django.utils.regex_helper',
+      'importer': 'django.utils.text',
+    }),
+    dict({
+      'imported': 'django.utils.translation',
+      'importer': 'django.utils.text',
+    }),
+    dict({
+      'imported': 'django.utils.html',
+      'importer': 'django.utils.timesince',
+    }),
+    dict({
+      'imported': 'django.utils.timezone',
+      'importer': 'django.utils.timesince',
+    }),
+    dict({
+      'imported': 'django.utils.translation',
+      'importer': 'django.utils.timesince',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.utils.timezone',
+    }),
+    dict({
+      'imported': 'django.utils.deprecation',
+      'importer': 'django.utils.timezone',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.utils.translation',
+    }),
+    dict({
+      'imported': 'django.conf.locale',
+      'importer': 'django.utils.translation',
+    }),
+    dict({
+      'imported': 'django.utils.autoreload',
+      'importer': 'django.utils.translation',
+    }),
+    dict({
+      'imported': 'django.utils.functional',
+      'importer': 'django.utils.translation',
+    }),
+    dict({
+      'imported': 'django.utils.regex_helper',
+      'importer': 'django.utils.translation',
+    }),
+    dict({
+      'imported': 'django.utils.translation.reloader',
+      'importer': 'django.utils.translation',
+    }),
+    dict({
+      'imported': 'django.utils.translation.template',
+      'importer': 'django.utils.translation',
+    }),
+    dict({
+      'imported': 'django.utils.translation.trans_null',
+      'importer': 'django.utils.translation',
+    }),
+    dict({
+      'imported': 'django.utils.translation.trans_real',
+      'importer': 'django.utils.translation',
+    }),
+    dict({
+      'imported': 'django.apps',
+      'importer': 'django.utils.translation.reloader',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.utils.translation.reloader',
+    }),
+    dict({
+      'imported': 'django.utils.autoreload',
+      'importer': 'django.utils.translation.reloader',
+    }),
+    dict({
+      'imported': 'django.utils.translation.trans_real',
+      'importer': 'django.utils.translation.reloader',
+    }),
+    dict({
+      'imported': 'django.template.base',
+      'importer': 'django.utils.translation.template',
+    }),
+    dict({
+      'imported': 'django.utils.regex_helper',
+      'importer': 'django.utils.translation.template',
+    }),
+    dict({
+      'imported': 'django.utils.translation',
+      'importer': 'django.utils.translation.template',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.utils.translation.trans_null',
+    }),
+    dict({
+      'imported': 'django.apps',
+      'importer': 'django.utils.translation.trans_real',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.utils.translation.trans_real',
+    }),
+    dict({
+      'imported': 'django.conf.locale',
+      'importer': 'django.utils.translation.trans_real',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.utils.translation.trans_real',
+    }),
+    dict({
+      'imported': 'django.core.signals',
+      'importer': 'django.utils.translation.trans_real',
+    }),
+    dict({
+      'imported': 'django.dispatch',
+      'importer': 'django.utils.translation.trans_real',
+    }),
+    dict({
+      'imported': 'django.utils.regex_helper',
+      'importer': 'django.utils.translation.trans_real',
+    }),
+    dict({
+      'imported': 'django.utils.safestring',
+      'importer': 'django.utils.translation.trans_real',
+    }),
+    dict({
+      'imported': 'django.utils.translation',
+      'importer': 'django.utils.translation.trans_real',
+    }),
+    dict({
+      'imported': 'django.utils.hashable',
+      'importer': 'django.utils.tree',
+    }),
+    dict({
+      'imported': 'django',
+      'importer': 'django.utils.version',
+    }),
+    dict({
+      'imported': 'django.utils.regex_helper',
+      'importer': 'django.utils.version',
+    }),
+    dict({
+      'imported': 'django.views.generic.base',
+      'importer': 'django.views',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.views.csrf',
+    }),
+    dict({
+      'imported': 'django.http',
+      'importer': 'django.views.csrf',
+    }),
+    dict({
+      'imported': 'django.middleware.csrf',
+      'importer': 'django.views.csrf',
+    }),
+    dict({
+      'imported': 'django.template',
+      'importer': 'django.views.csrf',
+    }),
+    dict({
+      'imported': 'django.template.loader',
+      'importer': 'django.views.csrf',
+    }),
+    dict({
+      'imported': 'django.utils.translation',
+      'importer': 'django.views.csrf',
+    }),
+    dict({
+      'imported': 'django.utils.version',
+      'importer': 'django.views.csrf',
+    }),
+    dict({
+      'imported': 'django',
+      'importer': 'django.views.debug',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.views.debug',
+    }),
+    dict({
+      'imported': 'django.http',
+      'importer': 'django.views.debug',
+    }),
+    dict({
+      'imported': 'django.template',
+      'importer': 'django.views.debug',
+    }),
+    dict({
+      'imported': 'django.template.defaultfilters',
+      'importer': 'django.views.debug',
+    }),
+    dict({
+      'imported': 'django.urls',
+      'importer': 'django.views.debug',
+    }),
+    dict({
+      'imported': 'django.utils.datastructures',
+      'importer': 'django.views.debug',
+    }),
+    dict({
+      'imported': 'django.utils.encoding',
+      'importer': 'django.views.debug',
+    }),
+    dict({
+      'imported': 'django.utils.module_loading',
+      'importer': 'django.views.debug',
+    }),
+    dict({
+      'imported': 'django.utils.regex_helper',
+      'importer': 'django.views.debug',
+    }),
+    dict({
+      'imported': 'django.utils.timezone',
+      'importer': 'django.views.debug',
+    }),
+    dict({
+      'imported': 'django.utils.version',
+      'importer': 'django.views.debug',
+    }),
+    dict({
+      'imported': 'django.middleware.cache',
+      'importer': 'django.views.decorators.cache',
+    }),
+    dict({
+      'imported': 'django.utils.cache',
+      'importer': 'django.views.decorators.cache',
+    }),
+    dict({
+      'imported': 'django.utils.decorators',
+      'importer': 'django.views.decorators.cache',
+    }),
+    dict({
+      'imported': 'django.middleware.csrf',
+      'importer': 'django.views.decorators.csrf',
+    }),
+    dict({
+      'imported': 'django.utils.decorators',
+      'importer': 'django.views.decorators.csrf',
+    }),
+    dict({
+      'imported': 'django.http',
+      'importer': 'django.views.decorators.debug',
+    }),
+    dict({
+      'imported': 'django.middleware.gzip',
+      'importer': 'django.views.decorators.gzip',
+    }),
+    dict({
+      'imported': 'django.utils.decorators',
+      'importer': 'django.views.decorators.gzip',
+    }),
+    dict({
+      'imported': 'django.http',
+      'importer': 'django.views.decorators.http',
+    }),
+    dict({
+      'imported': 'django.middleware.http',
+      'importer': 'django.views.decorators.http',
+    }),
+    dict({
+      'imported': 'django.utils.cache',
+      'importer': 'django.views.decorators.http',
+    }),
+    dict({
+      'imported': 'django.utils.decorators',
+      'importer': 'django.views.decorators.http',
+    }),
+    dict({
+      'imported': 'django.utils.http',
+      'importer': 'django.views.decorators.http',
+    }),
+    dict({
+      'imported': 'django.utils.log',
+      'importer': 'django.views.decorators.http',
+    }),
+    dict({
+      'imported': 'django.utils.timezone',
+      'importer': 'django.views.decorators.http',
+    }),
+    dict({
+      'imported': 'django.utils.cache',
+      'importer': 'django.views.decorators.vary',
+    }),
+    dict({
+      'imported': 'django.http',
+      'importer': 'django.views.defaults',
+    }),
+    dict({
+      'imported': 'django.template',
+      'importer': 'django.views.defaults',
+    }),
+    dict({
+      'imported': 'django.template.loader',
+      'importer': 'django.views.defaults',
+    }),
+    dict({
+      'imported': 'django.views.decorators.csrf',
+      'importer': 'django.views.defaults',
+    }),
+    dict({
+      'imported': 'django.views.generic.base',
+      'importer': 'django.views.generic',
+    }),
+    dict({
+      'imported': 'django.views.generic.dates',
+      'importer': 'django.views.generic',
+    }),
+    dict({
+      'imported': 'django.views.generic.detail',
+      'importer': 'django.views.generic',
+    }),
+    dict({
+      'imported': 'django.views.generic.edit',
+      'importer': 'django.views.generic',
+    }),
+    dict({
+      'imported': 'django.views.generic.list',
+      'importer': 'django.views.generic',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.views.generic.base',
+    }),
+    dict({
+      'imported': 'django.http',
+      'importer': 'django.views.generic.base',
+    }),
+    dict({
+      'imported': 'django.template.response',
+      'importer': 'django.views.generic.base',
+    }),
+    dict({
+      'imported': 'django.urls',
+      'importer': 'django.views.generic.base',
+    }),
+    dict({
+      'imported': 'django.utils.decorators',
+      'importer': 'django.views.generic.base',
+    }),
+    dict({
+      'imported': 'django.utils.functional',
+      'importer': 'django.views.generic.base',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.views.generic.dates',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.views.generic.dates',
+    }),
+    dict({
+      'imported': 'django.db.models',
+      'importer': 'django.views.generic.dates',
+    }),
+    dict({
+      'imported': 'django.http',
+      'importer': 'django.views.generic.dates',
+    }),
+    dict({
+      'imported': 'django.utils.functional',
+      'importer': 'django.views.generic.dates',
+    }),
+    dict({
+      'imported': 'django.utils.timezone',
+      'importer': 'django.views.generic.dates',
+    }),
+    dict({
+      'imported': 'django.utils.translation',
+      'importer': 'django.views.generic.dates',
+    }),
+    dict({
+      'imported': 'django.views.generic.base',
+      'importer': 'django.views.generic.dates',
+    }),
+    dict({
+      'imported': 'django.views.generic.detail',
+      'importer': 'django.views.generic.dates',
+    }),
+    dict({
+      'imported': 'django.views.generic.list',
+      'importer': 'django.views.generic.dates',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.views.generic.detail',
+    }),
+    dict({
+      'imported': 'django.db.models',
+      'importer': 'django.views.generic.detail',
+    }),
+    dict({
+      'imported': 'django.http',
+      'importer': 'django.views.generic.detail',
+    }),
+    dict({
+      'imported': 'django.utils.translation',
+      'importer': 'django.views.generic.detail',
+    }),
+    dict({
+      'imported': 'django.views.generic.base',
+      'importer': 'django.views.generic.detail',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.views.generic.edit',
+    }),
+    dict({
+      'imported': 'django.forms',
+      'importer': 'django.views.generic.edit',
+    }),
+    dict({
+      'imported': 'django.forms.models',
+      'importer': 'django.views.generic.edit',
+    }),
+    dict({
+      'imported': 'django.http',
+      'importer': 'django.views.generic.edit',
+    }),
+    dict({
+      'imported': 'django.views.generic.base',
+      'importer': 'django.views.generic.edit',
+    }),
+    dict({
+      'imported': 'django.views.generic.detail',
+      'importer': 'django.views.generic.edit',
+    }),
+    dict({
+      'imported': 'django.core.exceptions',
+      'importer': 'django.views.generic.list',
+    }),
+    dict({
+      'imported': 'django.core.paginator',
+      'importer': 'django.views.generic.list',
+    }),
+    dict({
+      'imported': 'django.db.models',
+      'importer': 'django.views.generic.list',
+    }),
+    dict({
+      'imported': 'django.http',
+      'importer': 'django.views.generic.list',
+    }),
+    dict({
+      'imported': 'django.utils.translation',
+      'importer': 'django.views.generic.list',
+    }),
+    dict({
+      'imported': 'django.views.generic.base',
+      'importer': 'django.views.generic.list',
+    }),
+    dict({
+      'imported': 'django.apps',
+      'importer': 'django.views.i18n',
+    }),
+    dict({
+      'imported': 'django.conf',
+      'importer': 'django.views.i18n',
+    }),
+    dict({
+      'imported': 'django.http',
+      'importer': 'django.views.i18n',
+    }),
+    dict({
+      'imported': 'django.template',
+      'importer': 'django.views.i18n',
+    }),
+    dict({
+      'imported': 'django.urls',
+      'importer': 'django.views.i18n',
+    }),
+    dict({
+      'imported': 'django.utils.formats',
+      'importer': 'django.views.i18n',
+    }),
+    dict({
+      'imported': 'django.utils.http',
+      'importer': 'django.views.i18n',
+    }),
+    dict({
+      'imported': 'django.utils.translation',
+      'importer': 'django.views.i18n',
+    }),
+    dict({
+      'imported': 'django.utils.translation.trans_real',
+      'importer': 'django.views.i18n',
+    }),
+    dict({
+      'imported': 'django.views.generic',
+      'importer': 'django.views.i18n',
+    }),
+    dict({
+      'imported': 'django.http',
+      'importer': 'django.views.static',
+    }),
+    dict({
+      'imported': 'django.template',
+      'importer': 'django.views.static',
+    }),
+    dict({
+      'imported': 'django.template.loader',
+      'importer': 'django.views.static',
+    }),
+    dict({
+      'imported': 'django.utils._os',
+      'importer': 'django.views.static',
+    }),
+    dict({
+      'imported': 'django.utils.http',
+      'importer': 'django.views.static',
+    }),
+    dict({
+      'imported': 'django.utils.translation',
+      'importer': 'django.views.static',
+    }),
+  ])
+# ---
+# name: test_build_graph_on_real_package[flask]
+  list([
+    dict({
+      'imported': 'flask.app',
+      'importer': 'flask',
+    }),
+    dict({
+      'imported': 'flask.blueprints',
+      'importer': 'flask',
+    }),
+    dict({
+      'imported': 'flask.config',
+      'importer': 'flask',
+    }),
+    dict({
+      'imported': 'flask.ctx',
+      'importer': 'flask',
+    }),
+    dict({
+      'imported': 'flask.globals',
+      'importer': 'flask',
+    }),
+    dict({
+      'imported': 'flask.helpers',
+      'importer': 'flask',
+    }),
+    dict({
+      'imported': 'flask.json',
+      'importer': 'flask',
+    }),
+    dict({
+      'imported': 'flask.signals',
+      'importer': 'flask',
+    }),
+    dict({
+      'imported': 'flask.templating',
+      'importer': 'flask',
+    }),
+    dict({
+      'imported': 'flask.wrappers',
+      'importer': 'flask',
+    }),
+    dict({
+      'imported': 'flask.cli',
+      'importer': 'flask.__main__',
+    }),
+    dict({
+      'imported': 'flask.cli',
+      'importer': 'flask.app',
+    }),
+    dict({
+      'imported': 'flask.ctx',
+      'importer': 'flask.app',
+    }),
+    dict({
+      'imported': 'flask.debughelpers',
+      'importer': 'flask.app',
+    }),
+    dict({
+      'imported': 'flask.globals',
+      'importer': 'flask.app',
+    }),
+    dict({
+      'imported': 'flask.helpers',
+      'importer': 'flask.app',
+    }),
+    dict({
+      'imported': 'flask.sessions',
+      'importer': 'flask.app',
+    }),
+    dict({
+      'imported': 'flask.signals',
+      'importer': 'flask.app',
+    }),
+    dict({
+      'imported': 'flask.templating',
+      'importer': 'flask.app',
+    }),
+    dict({
+      'imported': 'flask.testing',
+      'importer': 'flask.app',
+    }),
+    dict({
+      'imported': 'flask.typing',
+      'importer': 'flask.app',
+    }),
+    dict({
+      'imported': 'flask.wrappers',
+      'importer': 'flask.app',
+    }),
+    dict({
+      'imported': 'flask.cli',
+      'importer': 'flask.blueprints',
+    }),
+    dict({
+      'imported': 'flask.globals',
+      'importer': 'flask.blueprints',
+    }),
+    dict({
+      'imported': 'flask.helpers',
+      'importer': 'flask.blueprints',
+    }),
+    dict({
+      'imported': 'flask.wrappers',
+      'importer': 'flask.blueprints',
+    }),
+    dict({
+      'imported': 'flask',
+      'importer': 'flask.cli',
+    }),
+    dict({
+      'imported': 'flask.app',
+      'importer': 'flask.cli',
+    }),
+    dict({
+      'imported': 'flask.globals',
+      'importer': 'flask.cli',
+    }),
+    dict({
+      'imported': 'flask.helpers',
+      'importer': 'flask.cli',
+    }),
+    dict({
+      'imported': 'flask.app',
+      'importer': 'flask.ctx',
+    }),
+    dict({
+      'imported': 'flask.globals',
+      'importer': 'flask.ctx',
+    }),
+    dict({
+      'imported': 'flask.sessions',
+      'importer': 'flask.ctx',
+    }),
+    dict({
+      'imported': 'flask.signals',
+      'importer': 'flask.ctx',
+    }),
+    dict({
+      'imported': 'flask.typing',
+      'importer': 'flask.ctx',
+    }),
+    dict({
+      'imported': 'flask.wrappers',
+      'importer': 'flask.ctx',
+    }),
+    dict({
+      'imported': 'flask.blueprints',
+      'importer': 'flask.debughelpers',
+    }),
+    dict({
+      'imported': 'flask.globals',
+      'importer': 'flask.debughelpers',
+    }),
+    dict({
+      'imported': 'flask.wrappers',
+      'importer': 'flask.debughelpers',
+    }),
+    dict({
+      'imported': 'flask.app',
+      'importer': 'flask.globals',
+    }),
+    dict({
+      'imported': 'flask.ctx',
+      'importer': 'flask.globals',
+    }),
+    dict({
+      'imported': 'flask.sessions',
+      'importer': 'flask.globals',
+    }),
+    dict({
+      'imported': 'flask.wrappers',
+      'importer': 'flask.globals',
+    }),
+    dict({
+      'imported': 'flask.globals',
+      'importer': 'flask.helpers',
+    }),
+    dict({
+      'imported': 'flask.signals',
+      'importer': 'flask.helpers',
+    }),
+    dict({
+      'imported': 'flask.wrappers',
+      'importer': 'flask.helpers',
+    }),
+    dict({
+      'imported': 'flask.globals',
+      'importer': 'flask.json',
+    }),
+    dict({
+      'imported': 'flask.json.provider',
+      'importer': 'flask.json',
+    }),
+    dict({
+      'imported': 'flask.wrappers',
+      'importer': 'flask.json',
+    }),
+    dict({
+      'imported': 'flask.json',
+      'importer': 'flask.json.tag',
+    }),
+    dict({
+      'imported': 'flask.globals',
+      'importer': 'flask.logging',
+    }),
+    dict({
+      'imported': 'flask.app',
+      'importer': 'flask.sessions',
+    }),
+    dict({
+      'imported': 'flask.json.tag',
+      'importer': 'flask.sessions',
+    }),
+    dict({
+      'imported': 'flask.wrappers',
+      'importer': 'flask.sessions',
+    }),
+    dict({
+      'imported': 'flask.app',
+      'importer': 'flask.templating',
+    }),
+    dict({
+      'imported': 'flask.debughelpers',
+      'importer': 'flask.templating',
+    }),
+    dict({
+      'imported': 'flask.globals',
+      'importer': 'flask.templating',
+    }),
+    dict({
+      'imported': 'flask.helpers',
+      'importer': 'flask.templating',
+    }),
+    dict({
+      'imported': 'flask.signals',
+      'importer': 'flask.templating',
+    }),
+    dict({
+      'imported': 'flask.app',
+      'importer': 'flask.testing',
+    }),
+    dict({
+      'imported': 'flask.cli',
+      'importer': 'flask.testing',
+    }),
+    dict({
+      'imported': 'flask.sessions',
+      'importer': 'flask.testing',
+    }),
+    dict({
+      'imported': 'flask.globals',
+      'importer': 'flask.views',
+    }),
+    dict({
+      'imported': 'flask.typing',
+      'importer': 'flask.views',
+    }),
+    dict({
+      'imported': 'flask.debughelpers',
+      'importer': 'flask.wrappers',
+    }),
+    dict({
+      'imported': 'flask.globals',
+      'importer': 'flask.wrappers',
+    }),
+    dict({
+      'imported': 'flask.helpers',
+      'importer': 'flask.wrappers',
+    }),
+    dict({
+      'imported': 'flask.json',
+      'importer': 'flask.wrappers',
+    }),
+  ])
+# ---
+# name: test_build_graph_on_real_package[google.cloud.audit]
+  list([
+  ])
+# ---
+# name: test_build_graph_on_real_package[requests]
+  list([
+    dict({
+      'imported': 'requests.__version__',
+      'importer': 'requests',
+    }),
+    dict({
+      'imported': 'requests.api',
+      'importer': 'requests',
+    }),
+    dict({
+      'imported': 'requests.exceptions',
+      'importer': 'requests',
+    }),
+    dict({
+      'imported': 'requests.models',
+      'importer': 'requests',
+    }),
+    dict({
+      'imported': 'requests.packages',
+      'importer': 'requests',
+    }),
+    dict({
+      'imported': 'requests.sessions',
+      'importer': 'requests',
+    }),
+    dict({
+      'imported': 'requests.status_codes',
+      'importer': 'requests',
+    }),
+    dict({
+      'imported': 'requests.utils',
+      'importer': 'requests',
+    }),
+    dict({
+      'imported': 'requests.compat',
+      'importer': 'requests._internal_utils',
+    }),
+    dict({
+      'imported': 'requests.auth',
+      'importer': 'requests.adapters',
+    }),
+    dict({
+      'imported': 'requests.compat',
+      'importer': 'requests.adapters',
+    }),
+    dict({
+      'imported': 'requests.cookies',
+      'importer': 'requests.adapters',
+    }),
+    dict({
+      'imported': 'requests.exceptions',
+      'importer': 'requests.adapters',
+    }),
+    dict({
+      'imported': 'requests.models',
+      'importer': 'requests.adapters',
+    }),
+    dict({
+      'imported': 'requests.structures',
+      'importer': 'requests.adapters',
+    }),
+    dict({
+      'imported': 'requests.utils',
+      'importer': 'requests.adapters',
+    }),
+    dict({
+      'imported': 'requests.sessions',
+      'importer': 'requests.api',
+    }),
+    dict({
+      'imported': 'requests._internal_utils',
+      'importer': 'requests.auth',
+    }),
+    dict({
+      'imported': 'requests.compat',
+      'importer': 'requests.auth',
+    }),
+    dict({
+      'imported': 'requests.cookies',
+      'importer': 'requests.auth',
+    }),
+    dict({
+      'imported': 'requests.utils',
+      'importer': 'requests.auth',
+    }),
+    dict({
+      'imported': 'requests._internal_utils',
+      'importer': 'requests.cookies',
+    }),
+    dict({
+      'imported': 'requests.compat',
+      'importer': 'requests.cookies',
+    }),
+    dict({
+      'imported': 'requests.compat',
+      'importer': 'requests.exceptions',
+    }),
+    dict({
+      'imported': 'requests.__version__',
+      'importer': 'requests.help',
+    }),
+    dict({
+      'imported': 'requests._internal_utils',
+      'importer': 'requests.models',
+    }),
+    dict({
+      'imported': 'requests.auth',
+      'importer': 'requests.models',
+    }),
+    dict({
+      'imported': 'requests.compat',
+      'importer': 'requests.models',
+    }),
+    dict({
+      'imported': 'requests.cookies',
+      'importer': 'requests.models',
+    }),
+    dict({
+      'imported': 'requests.exceptions',
+      'importer': 'requests.models',
+    }),
+    dict({
+      'imported': 'requests.hooks',
+      'importer': 'requests.models',
+    }),
+    dict({
+      'imported': 'requests.status_codes',
+      'importer': 'requests.models',
+    }),
+    dict({
+      'imported': 'requests.structures',
+      'importer': 'requests.models',
+    }),
+    dict({
+      'imported': 'requests.utils',
+      'importer': 'requests.models',
+    }),
+    dict({
+      'imported': 'requests.compat',
+      'importer': 'requests.packages',
+    }),
+    dict({
+      'imported': 'requests._internal_utils',
+      'importer': 'requests.sessions',
+    }),
+    dict({
+      'imported': 'requests.adapters',
+      'importer': 'requests.sessions',
+    }),
+    dict({
+      'imported': 'requests.auth',
+      'importer': 'requests.sessions',
+    }),
+    dict({
+      'imported': 'requests.compat',
+      'importer': 'requests.sessions',
+    }),
+    dict({
+      'imported': 'requests.cookies',
+      'importer': 'requests.sessions',
+    }),
+    dict({
+      'imported': 'requests.exceptions',
+      'importer': 'requests.sessions',
+    }),
+    dict({
+      'imported': 'requests.hooks',
+      'importer': 'requests.sessions',
+    }),
+    dict({
+      'imported': 'requests.models',
+      'importer': 'requests.sessions',
+    }),
+    dict({
+      'imported': 'requests.status_codes',
+      'importer': 'requests.sessions',
+    }),
+    dict({
+      'imported': 'requests.structures',
+      'importer': 'requests.sessions',
+    }),
+    dict({
+      'imported': 'requests.utils',
+      'importer': 'requests.sessions',
+    }),
+    dict({
+      'imported': 'requests.structures',
+      'importer': 'requests.status_codes',
+    }),
+    dict({
+      'imported': 'requests.compat',
+      'importer': 'requests.structures',
+    }),
+    dict({
+      'imported': 'requests.__version__',
+      'importer': 'requests.utils',
+    }),
+    dict({
+      'imported': 'requests._internal_utils',
+      'importer': 'requests.utils',
+    }),
+    dict({
+      'imported': 'requests.certs',
+      'importer': 'requests.utils',
+    }),
+    dict({
+      'imported': 'requests.compat',
+      'importer': 'requests.utils',
+    }),
+    dict({
+      'imported': 'requests.cookies',
+      'importer': 'requests.utils',
+    }),
+    dict({
+      'imported': 'requests.exceptions',
+      'importer': 'requests.utils',
+    }),
+    dict({
+      'imported': 'requests.structures',
+      'importer': 'requests.utils',
+    }),
+  ])
+# ---
+# name: test_build_graph_on_real_package[sqlalchemy]
+  list([
+    dict({
+      'imported': 'sqlalchemy.engine',
+      'importer': 'sqlalchemy',
+    }),
+    dict({
+      'imported': 'sqlalchemy.exc',
+      'importer': 'sqlalchemy',
+    }),
+    dict({
+      'imported': 'sqlalchemy.inspection',
+      'importer': 'sqlalchemy',
+    }),
+    dict({
+      'imported': 'sqlalchemy.pool',
+      'importer': 'sqlalchemy',
+    }),
+    dict({
+      'imported': 'sqlalchemy.schema',
+      'importer': 'sqlalchemy',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql',
+      'importer': 'sqlalchemy',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.expression',
+      'importer': 'sqlalchemy',
+    }),
+    dict({
+      'imported': 'sqlalchemy.types',
+      'importer': 'sqlalchemy',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.interfaces',
+      'importer': 'sqlalchemy.connectors',
+    }),
+    dict({
+      'imported': 'sqlalchemy.connectors.asyncio',
+      'importer': 'sqlalchemy.connectors.aioodbc',
+    }),
+    dict({
+      'imported': 'sqlalchemy.connectors.pyodbc',
+      'importer': 'sqlalchemy.connectors.aioodbc',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.interfaces',
+      'importer': 'sqlalchemy.connectors.aioodbc',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.url',
+      'importer': 'sqlalchemy.connectors.aioodbc',
+    }),
+    dict({
+      'imported': 'sqlalchemy.pool',
+      'importer': 'sqlalchemy.connectors.aioodbc',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.connectors.aioodbc',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util.concurrency',
+      'importer': 'sqlalchemy.connectors.aioodbc',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine',
+      'importer': 'sqlalchemy.connectors.asyncio',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util.concurrency',
+      'importer': 'sqlalchemy.connectors.asyncio',
+    }),
+    dict({
+      'imported': 'sqlalchemy',
+      'importer': 'sqlalchemy.connectors.pyodbc',
+    }),
+    dict({
+      'imported': 'sqlalchemy.connectors',
+      'importer': 'sqlalchemy.connectors.pyodbc',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine',
+      'importer': 'sqlalchemy.connectors.pyodbc',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.interfaces',
+      'importer': 'sqlalchemy.connectors.pyodbc',
+    }),
+    dict({
+      'imported': 'sqlalchemy.pool',
+      'importer': 'sqlalchemy.connectors.pyodbc',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.type_api',
+      'importer': 'sqlalchemy.connectors.pyodbc',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.connectors.pyodbc',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.interfaces',
+      'importer': 'sqlalchemy.dialects',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.dialects',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql._typing',
+      'importer': 'sqlalchemy.dialects._typing',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.elements',
+      'importer': 'sqlalchemy.dialects._typing',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.schema',
+      'importer': 'sqlalchemy.dialects._typing',
+    }),
+    dict({
+      'imported': 'sqlalchemy.dialects.mssql.aioodbc',
+      'importer': 'sqlalchemy.dialects.mssql',
+    }),
+    dict({
+      'imported': 'sqlalchemy.dialects.mssql.base',
+      'importer': 'sqlalchemy.dialects.mssql',
+    }),
+    dict({
+      'imported': 'sqlalchemy.dialects.mssql.pymssql',
+      'importer': 'sqlalchemy.dialects.mssql',
+    }),
+    dict({
+      'imported': 'sqlalchemy.dialects.mssql.pyodbc',
+      'importer': 'sqlalchemy.dialects.mssql',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql',
+      'importer': 'sqlalchemy.dialects.mssql',
+    }),
+    dict({
+      'imported': 'sqlalchemy.connectors.aioodbc',
+      'importer': 'sqlalchemy.dialects.mssql.aioodbc',
+    }),
+    dict({
+      'imported': 'sqlalchemy.dialects.mssql.pyodbc',
+      'importer': 'sqlalchemy.dialects.mssql.aioodbc',
+    }),
+    dict({
+      'imported': 'sqlalchemy',
+      'importer': 'sqlalchemy.dialects.mssql.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.dialects.mssql.information_schema',
+      'importer': 'sqlalchemy.dialects.mssql.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.dialects.mssql.json',
+      'importer': 'sqlalchemy.dialects.mssql.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.cursor',
+      'importer': 'sqlalchemy.dialects.mssql.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.default',
+      'importer': 'sqlalchemy.dialects.mssql.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.reflection',
+      'importer': 'sqlalchemy.dialects.mssql.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.exc',
+      'importer': 'sqlalchemy.dialects.mssql.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.schema',
+      'importer': 'sqlalchemy.dialects.mssql.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql',
+      'importer': 'sqlalchemy.dialects.mssql.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql._typing',
+      'importer': 'sqlalchemy.dialects.mssql.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.coercions',
+      'importer': 'sqlalchemy.dialects.mssql.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.compiler',
+      'importer': 'sqlalchemy.dialects.mssql.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.dml',
+      'importer': 'sqlalchemy.dialects.mssql.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.elements',
+      'importer': 'sqlalchemy.dialects.mssql.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.expression',
+      'importer': 'sqlalchemy.dialects.mssql.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.roles',
+      'importer': 'sqlalchemy.dialects.mssql.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.selectable',
+      'importer': 'sqlalchemy.dialects.mssql.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.sqltypes',
+      'importer': 'sqlalchemy.dialects.mssql.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.util',
+      'importer': 'sqlalchemy.dialects.mssql.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.types',
+      'importer': 'sqlalchemy.dialects.mssql.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.dialects.mssql.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util.typing',
+      'importer': 'sqlalchemy.dialects.mssql.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy',
+      'importer': 'sqlalchemy.dialects.mssql.information_schema',
+    }),
+    dict({
+      'imported': 'sqlalchemy.dialects.mssql.base',
+      'importer': 'sqlalchemy.dialects.mssql.information_schema',
+    }),
+    dict({
+      'imported': 'sqlalchemy.ext.compiler',
+      'importer': 'sqlalchemy.dialects.mssql.information_schema',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.expression',
+      'importer': 'sqlalchemy.dialects.mssql.information_schema',
+    }),
+    dict({
+      'imported': 'sqlalchemy.types',
+      'importer': 'sqlalchemy.dialects.mssql.information_schema',
+    }),
+    dict({
+      'imported': 'sqlalchemy.types',
+      'importer': 'sqlalchemy.dialects.mssql.json',
+    }),
+    dict({
+      'imported': 'sqlalchemy',
+      'importer': 'sqlalchemy.dialects.mssql.provision',
+    }),
+    dict({
+      'imported': 'sqlalchemy.exc',
+      'importer': 'sqlalchemy.dialects.mssql.provision',
+    }),
+    dict({
+      'imported': 'sqlalchemy.schema',
+      'importer': 'sqlalchemy.dialects.mssql.provision',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing.provision',
+      'importer': 'sqlalchemy.dialects.mssql.provision',
+    }),
+    dict({
+      'imported': 'sqlalchemy.dialects.mssql.base',
+      'importer': 'sqlalchemy.dialects.mssql.pymssql',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.processors',
+      'importer': 'sqlalchemy.dialects.mssql.pymssql',
+    }),
+    dict({
+      'imported': 'sqlalchemy.types',
+      'importer': 'sqlalchemy.dialects.mssql.pymssql',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.dialects.mssql.pymssql',
+    }),
+    dict({
+      'imported': 'sqlalchemy.connectors.pyodbc',
+      'importer': 'sqlalchemy.dialects.mssql.pyodbc',
+    }),
+    dict({
+      'imported': 'sqlalchemy.dialects.mssql.base',
+      'importer': 'sqlalchemy.dialects.mssql.pyodbc',
+    }),
+    dict({
+      'imported': 'sqlalchemy.dialects.mssql.json',
+      'importer': 'sqlalchemy.dialects.mssql.pyodbc',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.cursor',
+      'importer': 'sqlalchemy.dialects.mssql.pyodbc',
+    }),
+    dict({
+      'imported': 'sqlalchemy.exc',
+      'importer': 'sqlalchemy.dialects.mssql.pyodbc',
+    }),
+    dict({
+      'imported': 'sqlalchemy.types',
+      'importer': 'sqlalchemy.dialects.mssql.pyodbc',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.dialects.mssql.pyodbc',
+    }),
+    dict({
+      'imported': 'sqlalchemy.dialects.mysql.aiomysql',
+      'importer': 'sqlalchemy.dialects.mysql',
+    }),
+    dict({
+      'imported': 'sqlalchemy.dialects.mysql.asyncmy',
+      'importer': 'sqlalchemy.dialects.mysql',
+    }),
+    dict({
+      'imported': 'sqlalchemy.dialects.mysql.base',
+      'importer': 'sqlalchemy.dialects.mysql',
+    }),
+    dict({
+      'imported': 'sqlalchemy.dialects.mysql.cymysql',
+      'importer': 'sqlalchemy.dialects.mysql',
+    }),
+    dict({
+      'imported': 'sqlalchemy.dialects.mysql.dml',
+      'importer': 'sqlalchemy.dialects.mysql',
+    }),
+    dict({
+      'imported': 'sqlalchemy.dialects.mysql.expression',
+      'importer': 'sqlalchemy.dialects.mysql',
+    }),
+    dict({
+      'imported': 'sqlalchemy.dialects.mysql.mariadbconnector',
+      'importer': 'sqlalchemy.dialects.mysql',
+    }),
+    dict({
+      'imported': 'sqlalchemy.dialects.mysql.mysqlconnector',
+      'importer': 'sqlalchemy.dialects.mysql',
+    }),
+    dict({
+      'imported': 'sqlalchemy.dialects.mysql.mysqldb',
+      'importer': 'sqlalchemy.dialects.mysql',
+    }),
+    dict({
+      'imported': 'sqlalchemy.dialects.mysql.pymysql',
+      'importer': 'sqlalchemy.dialects.mysql',
+    }),
+    dict({
+      'imported': 'sqlalchemy.dialects.mysql.pyodbc',
+      'importer': 'sqlalchemy.dialects.mysql',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util.compat',
+      'importer': 'sqlalchemy.dialects.mysql',
+    }),
+    dict({
+      'imported': 'sqlalchemy.dialects.mysql.pymysql',
+      'importer': 'sqlalchemy.dialects.mysql.aiomysql',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine',
+      'importer': 'sqlalchemy.dialects.mysql.aiomysql',
+    }),
+    dict({
+      'imported': 'sqlalchemy.pool',
+      'importer': 'sqlalchemy.dialects.mysql.aiomysql',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.dialects.mysql.aiomysql',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util.concurrency',
+      'importer': 'sqlalchemy.dialects.mysql.aiomysql',
+    }),
+    dict({
+      'imported': 'sqlalchemy.dialects.mysql.pymysql',
+      'importer': 'sqlalchemy.dialects.mysql.asyncmy',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine',
+      'importer': 'sqlalchemy.dialects.mysql.asyncmy',
+    }),
+    dict({
+      'imported': 'sqlalchemy.pool',
+      'importer': 'sqlalchemy.dialects.mysql.asyncmy',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.dialects.mysql.asyncmy',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util.concurrency',
+      'importer': 'sqlalchemy.dialects.mysql.asyncmy',
+    }),
+    dict({
+      'imported': 'sqlalchemy',
+      'importer': 'sqlalchemy.dialects.mysql.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.dialects.mysql.enumerated',
+      'importer': 'sqlalchemy.dialects.mysql.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.dialects.mysql.json',
+      'importer': 'sqlalchemy.dialects.mysql.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.dialects.mysql.reflection',
+      'importer': 'sqlalchemy.dialects.mysql.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.dialects.mysql.reserved_words',
+      'importer': 'sqlalchemy.dialects.mysql.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.dialects.mysql.types',
+      'importer': 'sqlalchemy.dialects.mysql.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.cursor',
+      'importer': 'sqlalchemy.dialects.mysql.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.default',
+      'importer': 'sqlalchemy.dialects.mysql.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.reflection',
+      'importer': 'sqlalchemy.dialects.mysql.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.exc',
+      'importer': 'sqlalchemy.dialects.mysql.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.log',
+      'importer': 'sqlalchemy.dialects.mysql.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.schema',
+      'importer': 'sqlalchemy.dialects.mysql.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql',
+      'importer': 'sqlalchemy.dialects.mysql.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.coercions',
+      'importer': 'sqlalchemy.dialects.mysql.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.compiler',
+      'importer': 'sqlalchemy.dialects.mysql.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.elements',
+      'importer': 'sqlalchemy.dialects.mysql.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.functions',
+      'importer': 'sqlalchemy.dialects.mysql.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.operators',
+      'importer': 'sqlalchemy.dialects.mysql.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.roles',
+      'importer': 'sqlalchemy.dialects.mysql.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.schema',
+      'importer': 'sqlalchemy.dialects.mysql.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.sqltypes',
+      'importer': 'sqlalchemy.dialects.mysql.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.util',
+      'importer': 'sqlalchemy.dialects.mysql.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.visitors',
+      'importer': 'sqlalchemy.dialects.mysql.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.types',
+      'importer': 'sqlalchemy.dialects.mysql.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.dialects.mysql.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util.topological',
+      'importer': 'sqlalchemy.dialects.mysql.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.dialects.mysql.base',
+      'importer': 'sqlalchemy.dialects.mysql.cymysql',
+    }),
+    dict({
+      'imported': 'sqlalchemy.dialects.mysql.mysqldb',
+      'importer': 'sqlalchemy.dialects.mysql.cymysql',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.dialects.mysql.cymysql',
+    }),
+    dict({
+      'imported': 'sqlalchemy.exc',
+      'importer': 'sqlalchemy.dialects.mysql.dml',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql._typing',
+      'importer': 'sqlalchemy.dialects.mysql.dml',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.base',
+      'importer': 'sqlalchemy.dialects.mysql.dml',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.dml',
+      'importer': 'sqlalchemy.dialects.mysql.dml',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.elements',
+      'importer': 'sqlalchemy.dialects.mysql.dml',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.expression',
+      'importer': 'sqlalchemy.dialects.mysql.dml',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.selectable',
+      'importer': 'sqlalchemy.dialects.mysql.dml',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.dialects.mysql.dml',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util.typing',
+      'importer': 'sqlalchemy.dialects.mysql.dml',
+    }),
+    dict({
+      'imported': 'sqlalchemy.dialects.mysql.types',
+      'importer': 'sqlalchemy.dialects.mysql.enumerated',
+    }),
+    dict({
+      'imported': 'sqlalchemy.exc',
+      'importer': 'sqlalchemy.dialects.mysql.enumerated',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql',
+      'importer': 'sqlalchemy.dialects.mysql.enumerated',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.sqltypes',
+      'importer': 'sqlalchemy.dialects.mysql.enumerated',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.dialects.mysql.enumerated',
+    }),
+    dict({
+      'imported': 'sqlalchemy.exc',
+      'importer': 'sqlalchemy.dialects.mysql.expression',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.base',
+      'importer': 'sqlalchemy.dialects.mysql.expression',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.coercions',
+      'importer': 'sqlalchemy.dialects.mysql.expression',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.elements',
+      'importer': 'sqlalchemy.dialects.mysql.expression',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.operators',
+      'importer': 'sqlalchemy.dialects.mysql.expression',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.roles',
+      'importer': 'sqlalchemy.dialects.mysql.expression',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.dialects.mysql.expression',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util.typing',
+      'importer': 'sqlalchemy.dialects.mysql.expression',
+    }),
+    dict({
+      'imported': 'sqlalchemy.types',
+      'importer': 'sqlalchemy.dialects.mysql.json',
+    }),
+    dict({
+      'imported': 'sqlalchemy.dialects.mysql.base',
+      'importer': 'sqlalchemy.dialects.mysql.mariadb',
+    }),
+    dict({
+      'imported': 'sqlalchemy.dialects.mysql.base',
+      'importer': 'sqlalchemy.dialects.mysql.mariadbconnector',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql',
+      'importer': 'sqlalchemy.dialects.mysql.mariadbconnector',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.sqltypes',
+      'importer': 'sqlalchemy.dialects.mysql.mariadbconnector',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.dialects.mysql.mariadbconnector',
+    }),
+    dict({
+      'imported': 'sqlalchemy.dialects.mysql.base',
+      'importer': 'sqlalchemy.dialects.mysql.mysqlconnector',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.dialects.mysql.mysqlconnector',
+    }),
+    dict({
+      'imported': 'sqlalchemy.dialects.mysql.base',
+      'importer': 'sqlalchemy.dialects.mysql.mysqldb',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql',
+      'importer': 'sqlalchemy.dialects.mysql.mysqldb',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.dialects.mysql.mysqldb',
+    }),
+    dict({
+      'imported': 'sqlalchemy.dialects.mysql',
+      'importer': 'sqlalchemy.dialects.mysql.provision',
+    }),
+    dict({
+      'imported': 'sqlalchemy.exc',
+      'importer': 'sqlalchemy.dialects.mysql.provision',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing.provision',
+      'importer': 'sqlalchemy.dialects.mysql.provision',
+    }),
+    dict({
+      'imported': 'sqlalchemy.dialects.mysql.mysqldb',
+      'importer': 'sqlalchemy.dialects.mysql.pymysql',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util.langhelpers',
+      'importer': 'sqlalchemy.dialects.mysql.pymysql',
+    }),
+    dict({
+      'imported': 'sqlalchemy.connectors.pyodbc',
+      'importer': 'sqlalchemy.dialects.mysql.pyodbc',
+    }),
+    dict({
+      'imported': 'sqlalchemy.dialects.mysql.base',
+      'importer': 'sqlalchemy.dialects.mysql.pyodbc',
+    }),
+    dict({
+      'imported': 'sqlalchemy.dialects.mysql.types',
+      'importer': 'sqlalchemy.dialects.mysql.pyodbc',
+    }),
+    dict({
+      'imported': 'sqlalchemy.exc',
+      'importer': 'sqlalchemy.dialects.mysql.pyodbc',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.sqltypes',
+      'importer': 'sqlalchemy.dialects.mysql.pyodbc',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.dialects.mysql.pyodbc',
+    }),
+    dict({
+      'imported': 'sqlalchemy.dialects.mysql.enumerated',
+      'importer': 'sqlalchemy.dialects.mysql.reflection',
+    }),
+    dict({
+      'imported': 'sqlalchemy.dialects.mysql.types',
+      'importer': 'sqlalchemy.dialects.mysql.reflection',
+    }),
+    dict({
+      'imported': 'sqlalchemy.log',
+      'importer': 'sqlalchemy.dialects.mysql.reflection',
+    }),
+    dict({
+      'imported': 'sqlalchemy.types',
+      'importer': 'sqlalchemy.dialects.mysql.reflection',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.dialects.mysql.reflection',
+    }),
+    dict({
+      'imported': 'sqlalchemy.exc',
+      'importer': 'sqlalchemy.dialects.mysql.types',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.sqltypes',
+      'importer': 'sqlalchemy.dialects.mysql.types',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.dialects.mysql.types',
+    }),
+    dict({
+      'imported': 'sqlalchemy.dialects.oracle.base',
+      'importer': 'sqlalchemy.dialects.oracle',
+    }),
+    dict({
+      'imported': 'sqlalchemy.dialects.oracle.cx_oracle',
+      'importer': 'sqlalchemy.dialects.oracle',
+    }),
+    dict({
+      'imported': 'sqlalchemy.dialects.oracle.oracledb',
+      'importer': 'sqlalchemy.dialects.oracle',
+    }),
+    dict({
+      'imported': 'sqlalchemy',
+      'importer': 'sqlalchemy.dialects.oracle.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.dialects.oracle.dictionary',
+      'importer': 'sqlalchemy.dialects.oracle.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.dialects.oracle.types',
+      'importer': 'sqlalchemy.dialects.oracle.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine',
+      'importer': 'sqlalchemy.dialects.oracle.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.default',
+      'importer': 'sqlalchemy.dialects.oracle.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.reflection',
+      'importer': 'sqlalchemy.dialects.oracle.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.exc',
+      'importer': 'sqlalchemy.dialects.oracle.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.schema',
+      'importer': 'sqlalchemy.dialects.oracle.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql',
+      'importer': 'sqlalchemy.dialects.oracle.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.compiler',
+      'importer': 'sqlalchemy.dialects.oracle.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.expression',
+      'importer': 'sqlalchemy.dialects.oracle.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.sqltypes',
+      'importer': 'sqlalchemy.dialects.oracle.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.util',
+      'importer': 'sqlalchemy.dialects.oracle.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.visitors',
+      'importer': 'sqlalchemy.dialects.oracle.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.types',
+      'importer': 'sqlalchemy.dialects.oracle.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.dialects.oracle.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.dialects.oracle.base',
+      'importer': 'sqlalchemy.dialects.oracle.cx_oracle',
+    }),
+    dict({
+      'imported': 'sqlalchemy.dialects.oracle.types',
+      'importer': 'sqlalchemy.dialects.oracle.cx_oracle',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.cursor',
+      'importer': 'sqlalchemy.dialects.oracle.cx_oracle',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.interfaces',
+      'importer': 'sqlalchemy.dialects.oracle.cx_oracle',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.processors',
+      'importer': 'sqlalchemy.dialects.oracle.cx_oracle',
+    }),
+    dict({
+      'imported': 'sqlalchemy.exc',
+      'importer': 'sqlalchemy.dialects.oracle.cx_oracle',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql._typing',
+      'importer': 'sqlalchemy.dialects.oracle.cx_oracle',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.sqltypes',
+      'importer': 'sqlalchemy.dialects.oracle.cx_oracle',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.dialects.oracle.cx_oracle',
+    }),
+    dict({
+      'imported': 'sqlalchemy',
+      'importer': 'sqlalchemy.dialects.oracle.dictionary',
+    }),
+    dict({
+      'imported': 'sqlalchemy.dialects.oracle.types',
+      'importer': 'sqlalchemy.dialects.oracle.dictionary',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.sqltypes',
+      'importer': 'sqlalchemy.dialects.oracle.dictionary',
+    }),
+    dict({
+      'imported': 'sqlalchemy.connectors.asyncio',
+      'importer': 'sqlalchemy.dialects.oracle.oracledb',
+    }),
+    dict({
+      'imported': 'sqlalchemy.dialects.oracle.cx_oracle',
+      'importer': 'sqlalchemy.dialects.oracle.oracledb',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.default',
+      'importer': 'sqlalchemy.dialects.oracle.oracledb',
+    }),
+    dict({
+      'imported': 'sqlalchemy.exc',
+      'importer': 'sqlalchemy.dialects.oracle.oracledb',
+    }),
+    dict({
+      'imported': 'sqlalchemy.pool',
+      'importer': 'sqlalchemy.dialects.oracle.oracledb',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.dialects.oracle.oracledb',
+    }),
+    dict({
+      'imported': 'sqlalchemy',
+      'importer': 'sqlalchemy.dialects.oracle.provision',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.url',
+      'importer': 'sqlalchemy.dialects.oracle.provision',
+    }),
+    dict({
+      'imported': 'sqlalchemy.event',
+      'importer': 'sqlalchemy.dialects.oracle.provision',
+    }),
+    dict({
+      'imported': 'sqlalchemy.exc',
+      'importer': 'sqlalchemy.dialects.oracle.provision',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing.provision',
+      'importer': 'sqlalchemy.dialects.oracle.provision',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.interfaces',
+      'importer': 'sqlalchemy.dialects.oracle.types',
+    }),
+    dict({
+      'imported': 'sqlalchemy.exc',
+      'importer': 'sqlalchemy.dialects.oracle.types',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.sqltypes',
+      'importer': 'sqlalchemy.dialects.oracle.types',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.type_api',
+      'importer': 'sqlalchemy.dialects.oracle.types',
+    }),
+    dict({
+      'imported': 'sqlalchemy.types',
+      'importer': 'sqlalchemy.dialects.oracle.types',
+    }),
+    dict({
+      'imported': 'sqlalchemy.dialects.postgresql.array',
+      'importer': 'sqlalchemy.dialects.postgresql',
+    }),
+    dict({
+      'imported': 'sqlalchemy.dialects.postgresql.asyncpg',
+      'importer': 'sqlalchemy.dialects.postgresql',
+    }),
+    dict({
+      'imported': 'sqlalchemy.dialects.postgresql.base',
+      'importer': 'sqlalchemy.dialects.postgresql',
+    }),
+    dict({
+      'imported': 'sqlalchemy.dialects.postgresql.dml',
+      'importer': 'sqlalchemy.dialects.postgresql',
+    }),
+    dict({
+      'imported': 'sqlalchemy.dialects.postgresql.ext',
+      'importer': 'sqlalchemy.dialects.postgresql',
+    }),
+    dict({
+      'imported': 'sqlalchemy.dialects.postgresql.hstore',
+      'importer': 'sqlalchemy.dialects.postgresql',
+    }),
+    dict({
+      'imported': 'sqlalchemy.dialects.postgresql.json',
+      'importer': 'sqlalchemy.dialects.postgresql',
+    }),
+    dict({
+      'imported': 'sqlalchemy.dialects.postgresql.named_types',
+      'importer': 'sqlalchemy.dialects.postgresql',
+    }),
+    dict({
+      'imported': 'sqlalchemy.dialects.postgresql.pg8000',
+      'importer': 'sqlalchemy.dialects.postgresql',
+    }),
+    dict({
+      'imported': 'sqlalchemy.dialects.postgresql.psycopg',
+      'importer': 'sqlalchemy.dialects.postgresql',
+    }),
+    dict({
+      'imported': 'sqlalchemy.dialects.postgresql.psycopg2',
+      'importer': 'sqlalchemy.dialects.postgresql',
+    }),
+    dict({
+      'imported': 'sqlalchemy.dialects.postgresql.psycopg2cffi',
+      'importer': 'sqlalchemy.dialects.postgresql',
+    }),
+    dict({
+      'imported': 'sqlalchemy.dialects.postgresql.ranges',
+      'importer': 'sqlalchemy.dialects.postgresql',
+    }),
+    dict({
+      'imported': 'sqlalchemy.dialects.postgresql.types',
+      'importer': 'sqlalchemy.dialects.postgresql',
+    }),
+    dict({
+      'imported': 'sqlalchemy.dialects.postgresql.array',
+      'importer': 'sqlalchemy.dialects.postgresql._psycopg_common',
+    }),
+    dict({
+      'imported': 'sqlalchemy.dialects.postgresql.base',
+      'importer': 'sqlalchemy.dialects.postgresql._psycopg_common',
+    }),
+    dict({
+      'imported': 'sqlalchemy.dialects.postgresql.hstore',
+      'importer': 'sqlalchemy.dialects.postgresql._psycopg_common',
+    }),
+    dict({
+      'imported': 'sqlalchemy.dialects.postgresql.pg_catalog',
+      'importer': 'sqlalchemy.dialects.postgresql._psycopg_common',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.processors',
+      'importer': 'sqlalchemy.dialects.postgresql._psycopg_common',
+    }),
+    dict({
+      'imported': 'sqlalchemy.exc',
+      'importer': 'sqlalchemy.dialects.postgresql._psycopg_common',
+    }),
+    dict({
+      'imported': 'sqlalchemy.types',
+      'importer': 'sqlalchemy.dialects.postgresql._psycopg_common',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.dialects.postgresql._psycopg_common',
+    }),
+    dict({
+      'imported': 'sqlalchemy.dialects.postgresql.operators',
+      'importer': 'sqlalchemy.dialects.postgresql.array',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql._typing',
+      'importer': 'sqlalchemy.dialects.postgresql.array',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.expression',
+      'importer': 'sqlalchemy.dialects.postgresql.array',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.operators',
+      'importer': 'sqlalchemy.dialects.postgresql.array',
+    }),
+    dict({
+      'imported': 'sqlalchemy.types',
+      'importer': 'sqlalchemy.dialects.postgresql.array',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.dialects.postgresql.array',
+    }),
+    dict({
+      'imported': 'sqlalchemy.dialects.postgresql.array',
+      'importer': 'sqlalchemy.dialects.postgresql.asyncpg',
+    }),
+    dict({
+      'imported': 'sqlalchemy.dialects.postgresql.base',
+      'importer': 'sqlalchemy.dialects.postgresql.asyncpg',
+    }),
+    dict({
+      'imported': 'sqlalchemy.dialects.postgresql.json',
+      'importer': 'sqlalchemy.dialects.postgresql.asyncpg',
+    }),
+    dict({
+      'imported': 'sqlalchemy.dialects.postgresql.ranges',
+      'importer': 'sqlalchemy.dialects.postgresql.asyncpg',
+    }),
+    dict({
+      'imported': 'sqlalchemy.dialects.postgresql.types',
+      'importer': 'sqlalchemy.dialects.postgresql.asyncpg',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine',
+      'importer': 'sqlalchemy.dialects.postgresql.asyncpg',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.processors',
+      'importer': 'sqlalchemy.dialects.postgresql.asyncpg',
+    }),
+    dict({
+      'imported': 'sqlalchemy.exc',
+      'importer': 'sqlalchemy.dialects.postgresql.asyncpg',
+    }),
+    dict({
+      'imported': 'sqlalchemy.pool',
+      'importer': 'sqlalchemy.dialects.postgresql.asyncpg',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.sqltypes',
+      'importer': 'sqlalchemy.dialects.postgresql.asyncpg',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.dialects.postgresql.asyncpg',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util.concurrency',
+      'importer': 'sqlalchemy.dialects.postgresql.asyncpg',
+    }),
+    dict({
+      'imported': 'sqlalchemy',
+      'importer': 'sqlalchemy.dialects.postgresql.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.dialects.postgresql',
+      'importer': 'sqlalchemy.dialects.postgresql.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.dialects.postgresql.ext',
+      'importer': 'sqlalchemy.dialects.postgresql.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.dialects.postgresql.hstore',
+      'importer': 'sqlalchemy.dialects.postgresql.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.dialects.postgresql.json',
+      'importer': 'sqlalchemy.dialects.postgresql.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.dialects.postgresql.named_types',
+      'importer': 'sqlalchemy.dialects.postgresql.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.dialects.postgresql.pg_catalog',
+      'importer': 'sqlalchemy.dialects.postgresql.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.dialects.postgresql.ranges',
+      'importer': 'sqlalchemy.dialects.postgresql.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.dialects.postgresql.types',
+      'importer': 'sqlalchemy.dialects.postgresql.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine',
+      'importer': 'sqlalchemy.dialects.postgresql.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.characteristics',
+      'importer': 'sqlalchemy.dialects.postgresql.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.default',
+      'importer': 'sqlalchemy.dialects.postgresql.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.interfaces',
+      'importer': 'sqlalchemy.dialects.postgresql.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.reflection',
+      'importer': 'sqlalchemy.dialects.postgresql.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.exc',
+      'importer': 'sqlalchemy.dialects.postgresql.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.schema',
+      'importer': 'sqlalchemy.dialects.postgresql.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql',
+      'importer': 'sqlalchemy.dialects.postgresql.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.coercions',
+      'importer': 'sqlalchemy.dialects.postgresql.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.compiler',
+      'importer': 'sqlalchemy.dialects.postgresql.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.elements',
+      'importer': 'sqlalchemy.dialects.postgresql.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.expression',
+      'importer': 'sqlalchemy.dialects.postgresql.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.roles',
+      'importer': 'sqlalchemy.dialects.postgresql.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.sqltypes',
+      'importer': 'sqlalchemy.dialects.postgresql.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.util',
+      'importer': 'sqlalchemy.dialects.postgresql.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.visitors',
+      'importer': 'sqlalchemy.dialects.postgresql.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.types',
+      'importer': 'sqlalchemy.dialects.postgresql.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.dialects.postgresql.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util.typing',
+      'importer': 'sqlalchemy.dialects.postgresql.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.dialects._typing',
+      'importer': 'sqlalchemy.dialects.postgresql.dml',
+    }),
+    dict({
+      'imported': 'sqlalchemy.dialects.postgresql.ext',
+      'importer': 'sqlalchemy.dialects.postgresql.dml',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql._typing',
+      'importer': 'sqlalchemy.dialects.postgresql.dml',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.base',
+      'importer': 'sqlalchemy.dialects.postgresql.dml',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.coercions',
+      'importer': 'sqlalchemy.dialects.postgresql.dml',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.dml',
+      'importer': 'sqlalchemy.dialects.postgresql.dml',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.elements',
+      'importer': 'sqlalchemy.dialects.postgresql.dml',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.expression',
+      'importer': 'sqlalchemy.dialects.postgresql.dml',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.roles',
+      'importer': 'sqlalchemy.dialects.postgresql.dml',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.schema',
+      'importer': 'sqlalchemy.dialects.postgresql.dml',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.dialects.postgresql.dml',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util.typing',
+      'importer': 'sqlalchemy.dialects.postgresql.dml',
+    }),
+    dict({
+      'imported': 'sqlalchemy.dialects.postgresql.array',
+      'importer': 'sqlalchemy.dialects.postgresql.ext',
+    }),
+    dict({
+      'imported': 'sqlalchemy.dialects.postgresql.types',
+      'importer': 'sqlalchemy.dialects.postgresql.ext',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.coercions',
+      'importer': 'sqlalchemy.dialects.postgresql.ext',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.elements',
+      'importer': 'sqlalchemy.dialects.postgresql.ext',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.expression',
+      'importer': 'sqlalchemy.dialects.postgresql.ext',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.functions',
+      'importer': 'sqlalchemy.dialects.postgresql.ext',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.roles',
+      'importer': 'sqlalchemy.dialects.postgresql.ext',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.schema',
+      'importer': 'sqlalchemy.dialects.postgresql.ext',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.sqltypes',
+      'importer': 'sqlalchemy.dialects.postgresql.ext',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.visitors',
+      'importer': 'sqlalchemy.dialects.postgresql.ext',
+    }),
+    dict({
+      'imported': 'sqlalchemy.dialects.postgresql.array',
+      'importer': 'sqlalchemy.dialects.postgresql.hstore',
+    }),
+    dict({
+      'imported': 'sqlalchemy.dialects.postgresql.operators',
+      'importer': 'sqlalchemy.dialects.postgresql.hstore',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.functions',
+      'importer': 'sqlalchemy.dialects.postgresql.hstore',
+    }),
+    dict({
+      'imported': 'sqlalchemy.types',
+      'importer': 'sqlalchemy.dialects.postgresql.hstore',
+    }),
+    dict({
+      'imported': 'sqlalchemy.dialects.postgresql.array',
+      'importer': 'sqlalchemy.dialects.postgresql.json',
+    }),
+    dict({
+      'imported': 'sqlalchemy.dialects.postgresql.operators',
+      'importer': 'sqlalchemy.dialects.postgresql.json',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql',
+      'importer': 'sqlalchemy.dialects.postgresql.json',
+    }),
+    dict({
+      'imported': 'sqlalchemy.types',
+      'importer': 'sqlalchemy.dialects.postgresql.json',
+    }),
+    dict({
+      'imported': 'sqlalchemy.schema',
+      'importer': 'sqlalchemy.dialects.postgresql.named_types',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql._typing',
+      'importer': 'sqlalchemy.dialects.postgresql.named_types',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.base',
+      'importer': 'sqlalchemy.dialects.postgresql.named_types',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.coercions',
+      'importer': 'sqlalchemy.dialects.postgresql.named_types',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.ddl',
+      'importer': 'sqlalchemy.dialects.postgresql.named_types',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.elements',
+      'importer': 'sqlalchemy.dialects.postgresql.named_types',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.roles',
+      'importer': 'sqlalchemy.dialects.postgresql.named_types',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.sqltypes',
+      'importer': 'sqlalchemy.dialects.postgresql.named_types',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.type_api',
+      'importer': 'sqlalchemy.dialects.postgresql.named_types',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.dialects.postgresql.named_types',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.operators',
+      'importer': 'sqlalchemy.dialects.postgresql.operators',
+    }),
+    dict({
+      'imported': 'sqlalchemy.dialects.postgresql.array',
+      'importer': 'sqlalchemy.dialects.postgresql.pg8000',
+    }),
+    dict({
+      'imported': 'sqlalchemy.dialects.postgresql.base',
+      'importer': 'sqlalchemy.dialects.postgresql.pg8000',
+    }),
+    dict({
+      'imported': 'sqlalchemy.dialects.postgresql.json',
+      'importer': 'sqlalchemy.dialects.postgresql.pg8000',
+    }),
+    dict({
+      'imported': 'sqlalchemy.dialects.postgresql.pg_catalog',
+      'importer': 'sqlalchemy.dialects.postgresql.pg8000',
+    }),
+    dict({
+      'imported': 'sqlalchemy.dialects.postgresql.ranges',
+      'importer': 'sqlalchemy.dialects.postgresql.pg8000',
+    }),
+    dict({
+      'imported': 'sqlalchemy.dialects.postgresql.types',
+      'importer': 'sqlalchemy.dialects.postgresql.pg8000',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.processors',
+      'importer': 'sqlalchemy.dialects.postgresql.pg8000',
+    }),
+    dict({
+      'imported': 'sqlalchemy.exc',
+      'importer': 'sqlalchemy.dialects.postgresql.pg8000',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.elements',
+      'importer': 'sqlalchemy.dialects.postgresql.pg8000',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.sqltypes',
+      'importer': 'sqlalchemy.dialects.postgresql.pg8000',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.dialects.postgresql.pg8000',
+    }),
+    dict({
+      'imported': 'sqlalchemy',
+      'importer': 'sqlalchemy.dialects.postgresql.pg_catalog',
+    }),
+    dict({
+      'imported': 'sqlalchemy.dialects.postgresql.array',
+      'importer': 'sqlalchemy.dialects.postgresql.pg_catalog',
+    }),
+    dict({
+      'imported': 'sqlalchemy.dialects.postgresql.types',
+      'importer': 'sqlalchemy.dialects.postgresql.pg_catalog',
+    }),
+    dict({
+      'imported': 'sqlalchemy.types',
+      'importer': 'sqlalchemy.dialects.postgresql.pg_catalog',
+    }),
+    dict({
+      'imported': 'sqlalchemy',
+      'importer': 'sqlalchemy.dialects.postgresql.provision',
+    }),
+    dict({
+      'imported': 'sqlalchemy.dialects.postgresql',
+      'importer': 'sqlalchemy.dialects.postgresql.provision',
+    }),
+    dict({
+      'imported': 'sqlalchemy.exc',
+      'importer': 'sqlalchemy.dialects.postgresql.provision',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing',
+      'importer': 'sqlalchemy.dialects.postgresql.provision',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing.provision',
+      'importer': 'sqlalchemy.dialects.postgresql.provision',
+    }),
+    dict({
+      'imported': 'sqlalchemy.dialects.postgresql._psycopg_common',
+      'importer': 'sqlalchemy.dialects.postgresql.psycopg',
+    }),
+    dict({
+      'imported': 'sqlalchemy.dialects.postgresql.base',
+      'importer': 'sqlalchemy.dialects.postgresql.psycopg',
+    }),
+    dict({
+      'imported': 'sqlalchemy.dialects.postgresql.json',
+      'importer': 'sqlalchemy.dialects.postgresql.psycopg',
+    }),
+    dict({
+      'imported': 'sqlalchemy.dialects.postgresql.ranges',
+      'importer': 'sqlalchemy.dialects.postgresql.psycopg',
+    }),
+    dict({
+      'imported': 'sqlalchemy.dialects.postgresql.types',
+      'importer': 'sqlalchemy.dialects.postgresql.psycopg',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine',
+      'importer': 'sqlalchemy.dialects.postgresql.psycopg',
+    }),
+    dict({
+      'imported': 'sqlalchemy.pool',
+      'importer': 'sqlalchemy.dialects.postgresql.psycopg',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.sqltypes',
+      'importer': 'sqlalchemy.dialects.postgresql.psycopg',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.dialects.postgresql.psycopg',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util.concurrency',
+      'importer': 'sqlalchemy.dialects.postgresql.psycopg',
+    }),
+    dict({
+      'imported': 'sqlalchemy.dialects.postgresql._psycopg_common',
+      'importer': 'sqlalchemy.dialects.postgresql.psycopg2',
+    }),
+    dict({
+      'imported': 'sqlalchemy.dialects.postgresql.base',
+      'importer': 'sqlalchemy.dialects.postgresql.psycopg2',
+    }),
+    dict({
+      'imported': 'sqlalchemy.dialects.postgresql.json',
+      'importer': 'sqlalchemy.dialects.postgresql.psycopg2',
+    }),
+    dict({
+      'imported': 'sqlalchemy.dialects.postgresql.ranges',
+      'importer': 'sqlalchemy.dialects.postgresql.psycopg2',
+    }),
+    dict({
+      'imported': 'sqlalchemy.types',
+      'importer': 'sqlalchemy.dialects.postgresql.psycopg2',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.dialects.postgresql.psycopg2',
+    }),
+    dict({
+      'imported': 'sqlalchemy.dialects.postgresql.psycopg2',
+      'importer': 'sqlalchemy.dialects.postgresql.psycopg2cffi',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.dialects.postgresql.psycopg2cffi',
+    }),
+    dict({
+      'imported': 'sqlalchemy.dialects.postgresql.operators',
+      'importer': 'sqlalchemy.dialects.postgresql.ranges',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.elements',
+      'importer': 'sqlalchemy.dialects.postgresql.ranges',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.operators',
+      'importer': 'sqlalchemy.dialects.postgresql.ranges',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.type_api',
+      'importer': 'sqlalchemy.dialects.postgresql.ranges',
+    }),
+    dict({
+      'imported': 'sqlalchemy.types',
+      'importer': 'sqlalchemy.dialects.postgresql.ranges',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.dialects.postgresql.ranges',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util.typing',
+      'importer': 'sqlalchemy.dialects.postgresql.ranges',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.interfaces',
+      'importer': 'sqlalchemy.dialects.postgresql.types',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.operators',
+      'importer': 'sqlalchemy.dialects.postgresql.types',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.sqltypes',
+      'importer': 'sqlalchemy.dialects.postgresql.types',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.type_api',
+      'importer': 'sqlalchemy.dialects.postgresql.types',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util.typing',
+      'importer': 'sqlalchemy.dialects.postgresql.types',
+    }),
+    dict({
+      'imported': 'sqlalchemy.dialects.sqlite.aiosqlite',
+      'importer': 'sqlalchemy.dialects.sqlite',
+    }),
+    dict({
+      'imported': 'sqlalchemy.dialects.sqlite.base',
+      'importer': 'sqlalchemy.dialects.sqlite',
+    }),
+    dict({
+      'imported': 'sqlalchemy.dialects.sqlite.dml',
+      'importer': 'sqlalchemy.dialects.sqlite',
+    }),
+    dict({
+      'imported': 'sqlalchemy.dialects.sqlite.pysqlcipher',
+      'importer': 'sqlalchemy.dialects.sqlite',
+    }),
+    dict({
+      'imported': 'sqlalchemy.dialects.sqlite.pysqlite',
+      'importer': 'sqlalchemy.dialects.sqlite',
+    }),
+    dict({
+      'imported': 'sqlalchemy.dialects.sqlite.base',
+      'importer': 'sqlalchemy.dialects.sqlite.aiosqlite',
+    }),
+    dict({
+      'imported': 'sqlalchemy.dialects.sqlite.pysqlite',
+      'importer': 'sqlalchemy.dialects.sqlite.aiosqlite',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine',
+      'importer': 'sqlalchemy.dialects.sqlite.aiosqlite',
+    }),
+    dict({
+      'imported': 'sqlalchemy.pool',
+      'importer': 'sqlalchemy.dialects.sqlite.aiosqlite',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.dialects.sqlite.aiosqlite',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util.concurrency',
+      'importer': 'sqlalchemy.dialects.sqlite.aiosqlite',
+    }),
+    dict({
+      'imported': 'sqlalchemy',
+      'importer': 'sqlalchemy.dialects.sqlite.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.dialects.sqlite.json',
+      'importer': 'sqlalchemy.dialects.sqlite.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.default',
+      'importer': 'sqlalchemy.dialects.sqlite.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.processors',
+      'importer': 'sqlalchemy.dialects.sqlite.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.reflection',
+      'importer': 'sqlalchemy.dialects.sqlite.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.exc',
+      'importer': 'sqlalchemy.dialects.sqlite.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.schema',
+      'importer': 'sqlalchemy.dialects.sqlite.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql',
+      'importer': 'sqlalchemy.dialects.sqlite.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.coercions',
+      'importer': 'sqlalchemy.dialects.sqlite.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.compiler',
+      'importer': 'sqlalchemy.dialects.sqlite.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.elements',
+      'importer': 'sqlalchemy.dialects.sqlite.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.roles',
+      'importer': 'sqlalchemy.dialects.sqlite.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.schema',
+      'importer': 'sqlalchemy.dialects.sqlite.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.types',
+      'importer': 'sqlalchemy.dialects.sqlite.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.dialects.sqlite.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.dialects._typing',
+      'importer': 'sqlalchemy.dialects.sqlite.dml',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql._typing',
+      'importer': 'sqlalchemy.dialects.sqlite.dml',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.base',
+      'importer': 'sqlalchemy.dialects.sqlite.dml',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.coercions',
+      'importer': 'sqlalchemy.dialects.sqlite.dml',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.dml',
+      'importer': 'sqlalchemy.dialects.sqlite.dml',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.elements',
+      'importer': 'sqlalchemy.dialects.sqlite.dml',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.expression',
+      'importer': 'sqlalchemy.dialects.sqlite.dml',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.roles',
+      'importer': 'sqlalchemy.dialects.sqlite.dml',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.dialects.sqlite.dml',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util.typing',
+      'importer': 'sqlalchemy.dialects.sqlite.dml',
+    }),
+    dict({
+      'imported': 'sqlalchemy.types',
+      'importer': 'sqlalchemy.dialects.sqlite.json',
+    }),
+    dict({
+      'imported': 'sqlalchemy.dialects.sqlite',
+      'importer': 'sqlalchemy.dialects.sqlite.provision',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.url',
+      'importer': 'sqlalchemy.dialects.sqlite.provision',
+    }),
+    dict({
+      'imported': 'sqlalchemy.event',
+      'importer': 'sqlalchemy.dialects.sqlite.provision',
+    }),
+    dict({
+      'imported': 'sqlalchemy.exc',
+      'importer': 'sqlalchemy.dialects.sqlite.provision',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing.provision',
+      'importer': 'sqlalchemy.dialects.sqlite.provision',
+    }),
+    dict({
+      'imported': 'sqlalchemy.dialects.sqlite.pysqlite',
+      'importer': 'sqlalchemy.dialects.sqlite.pysqlcipher',
+    }),
+    dict({
+      'imported': 'sqlalchemy.pool',
+      'importer': 'sqlalchemy.dialects.sqlite.pysqlcipher',
+    }),
+    dict({
+      'imported': 'sqlalchemy.dialects.sqlite.base',
+      'importer': 'sqlalchemy.dialects.sqlite.pysqlite',
+    }),
+    dict({
+      'imported': 'sqlalchemy.exc',
+      'importer': 'sqlalchemy.dialects.sqlite.pysqlite',
+    }),
+    dict({
+      'imported': 'sqlalchemy.pool',
+      'importer': 'sqlalchemy.dialects.sqlite.pysqlite',
+    }),
+    dict({
+      'imported': 'sqlalchemy.types',
+      'importer': 'sqlalchemy.dialects.sqlite.pysqlite',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.dialects.sqlite.pysqlite',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.base',
+      'importer': 'sqlalchemy.engine',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.create',
+      'importer': 'sqlalchemy.engine',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.cursor',
+      'importer': 'sqlalchemy.engine',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.events',
+      'importer': 'sqlalchemy.engine',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.interfaces',
+      'importer': 'sqlalchemy.engine',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.mock',
+      'importer': 'sqlalchemy.engine',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.reflection',
+      'importer': 'sqlalchemy.engine',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.result',
+      'importer': 'sqlalchemy.engine',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.row',
+      'importer': 'sqlalchemy.engine',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.url',
+      'importer': 'sqlalchemy.engine',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.util',
+      'importer': 'sqlalchemy.engine',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.ddl',
+      'importer': 'sqlalchemy.engine',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.result',
+      'importer': 'sqlalchemy.engine._py_row',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.interfaces',
+      'importer': 'sqlalchemy.engine._py_util',
+    }),
+    dict({
+      'imported': 'sqlalchemy.exc',
+      'importer': 'sqlalchemy.engine._py_util',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine',
+      'importer': 'sqlalchemy.engine.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.interfaces',
+      'importer': 'sqlalchemy.engine.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.reflection',
+      'importer': 'sqlalchemy.engine.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.url',
+      'importer': 'sqlalchemy.engine.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.util',
+      'importer': 'sqlalchemy.engine.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.event',
+      'importer': 'sqlalchemy.engine.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.exc',
+      'importer': 'sqlalchemy.engine.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.inspection',
+      'importer': 'sqlalchemy.engine.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.log',
+      'importer': 'sqlalchemy.engine.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.pool',
+      'importer': 'sqlalchemy.engine.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql',
+      'importer': 'sqlalchemy.engine.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql._typing',
+      'importer': 'sqlalchemy.engine.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.compiler',
+      'importer': 'sqlalchemy.engine.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.ddl',
+      'importer': 'sqlalchemy.engine.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.functions',
+      'importer': 'sqlalchemy.engine.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.schema',
+      'importer': 'sqlalchemy.engine.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.selectable',
+      'importer': 'sqlalchemy.engine.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.util',
+      'importer': 'sqlalchemy.engine.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.engine.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.base',
+      'importer': 'sqlalchemy.engine.characteristics',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.interfaces',
+      'importer': 'sqlalchemy.engine.characteristics',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.base',
+      'importer': 'sqlalchemy.engine.create',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.interfaces',
+      'importer': 'sqlalchemy.engine.create',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.mock',
+      'importer': 'sqlalchemy.engine.create',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.url',
+      'importer': 'sqlalchemy.engine.create',
+    }),
+    dict({
+      'imported': 'sqlalchemy.event',
+      'importer': 'sqlalchemy.engine.create',
+    }),
+    dict({
+      'imported': 'sqlalchemy.exc',
+      'importer': 'sqlalchemy.engine.create',
+    }),
+    dict({
+      'imported': 'sqlalchemy.log',
+      'importer': 'sqlalchemy.engine.create',
+    }),
+    dict({
+      'imported': 'sqlalchemy.pool',
+      'importer': 'sqlalchemy.engine.create',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.compiler',
+      'importer': 'sqlalchemy.engine.create',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.engine.create',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util.typing',
+      'importer': 'sqlalchemy.engine.create',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.base',
+      'importer': 'sqlalchemy.engine.cursor',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.default',
+      'importer': 'sqlalchemy.engine.cursor',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.interfaces',
+      'importer': 'sqlalchemy.engine.cursor',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.result',
+      'importer': 'sqlalchemy.engine.cursor',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.row',
+      'importer': 'sqlalchemy.engine.cursor',
+    }),
+    dict({
+      'imported': 'sqlalchemy.exc',
+      'importer': 'sqlalchemy.engine.cursor',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.base',
+      'importer': 'sqlalchemy.engine.cursor',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.compiler',
+      'importer': 'sqlalchemy.engine.cursor',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.elements',
+      'importer': 'sqlalchemy.engine.cursor',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.sqltypes',
+      'importer': 'sqlalchemy.engine.cursor',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.type_api',
+      'importer': 'sqlalchemy.engine.cursor',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.util',
+      'importer': 'sqlalchemy.engine.cursor',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.engine.cursor',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util.compat',
+      'importer': 'sqlalchemy.engine.cursor',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util.typing',
+      'importer': 'sqlalchemy.engine.cursor',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.base',
+      'importer': 'sqlalchemy.engine.default',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.characteristics',
+      'importer': 'sqlalchemy.engine.default',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.cursor',
+      'importer': 'sqlalchemy.engine.default',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.interfaces',
+      'importer': 'sqlalchemy.engine.default',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.reflection',
+      'importer': 'sqlalchemy.engine.default',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.row',
+      'importer': 'sqlalchemy.engine.default',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.url',
+      'importer': 'sqlalchemy.engine.default',
+    }),
+    dict({
+      'imported': 'sqlalchemy.event',
+      'importer': 'sqlalchemy.engine.default',
+    }),
+    dict({
+      'imported': 'sqlalchemy.exc',
+      'importer': 'sqlalchemy.engine.default',
+    }),
+    dict({
+      'imported': 'sqlalchemy.pool',
+      'importer': 'sqlalchemy.engine.default',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql',
+      'importer': 'sqlalchemy.engine.default',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql._typing',
+      'importer': 'sqlalchemy.engine.default',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.base',
+      'importer': 'sqlalchemy.engine.default',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.compiler',
+      'importer': 'sqlalchemy.engine.default',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.dml',
+      'importer': 'sqlalchemy.engine.default',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.elements',
+      'importer': 'sqlalchemy.engine.default',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.expression',
+      'importer': 'sqlalchemy.engine.default',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.schema',
+      'importer': 'sqlalchemy.engine.default',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.type_api',
+      'importer': 'sqlalchemy.engine.default',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.util',
+      'importer': 'sqlalchemy.engine.default',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.engine.default',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util.typing',
+      'importer': 'sqlalchemy.engine.default',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.base',
+      'importer': 'sqlalchemy.engine.events',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.interfaces',
+      'importer': 'sqlalchemy.engine.events',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.result',
+      'importer': 'sqlalchemy.engine.events',
+    }),
+    dict({
+      'imported': 'sqlalchemy.event',
+      'importer': 'sqlalchemy.engine.events',
+    }),
+    dict({
+      'imported': 'sqlalchemy.exc',
+      'importer': 'sqlalchemy.engine.events',
+    }),
+    dict({
+      'imported': 'sqlalchemy.pool',
+      'importer': 'sqlalchemy.engine.events',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql',
+      'importer': 'sqlalchemy.engine.events',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.elements',
+      'importer': 'sqlalchemy.engine.events',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util.typing',
+      'importer': 'sqlalchemy.engine.events',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.base',
+      'importer': 'sqlalchemy.engine.interfaces',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.cursor',
+      'importer': 'sqlalchemy.engine.interfaces',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.url',
+      'importer': 'sqlalchemy.engine.interfaces',
+    }),
+    dict({
+      'imported': 'sqlalchemy.event',
+      'importer': 'sqlalchemy.engine.interfaces',
+    }),
+    dict({
+      'imported': 'sqlalchemy.exc',
+      'importer': 'sqlalchemy.engine.interfaces',
+    }),
+    dict({
+      'imported': 'sqlalchemy.pool',
+      'importer': 'sqlalchemy.engine.interfaces',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql',
+      'importer': 'sqlalchemy.engine.interfaces',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.compiler',
+      'importer': 'sqlalchemy.engine.interfaces',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.elements',
+      'importer': 'sqlalchemy.engine.interfaces',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.schema',
+      'importer': 'sqlalchemy.engine.interfaces',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.sqltypes',
+      'importer': 'sqlalchemy.engine.interfaces',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.type_api',
+      'importer': 'sqlalchemy.engine.interfaces',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.engine.interfaces',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util.concurrency',
+      'importer': 'sqlalchemy.engine.interfaces',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util.typing',
+      'importer': 'sqlalchemy.engine.interfaces',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.base',
+      'importer': 'sqlalchemy.engine.mock',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.interfaces',
+      'importer': 'sqlalchemy.engine.mock',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.url',
+      'importer': 'sqlalchemy.engine.mock',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.base',
+      'importer': 'sqlalchemy.engine.mock',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.ddl',
+      'importer': 'sqlalchemy.engine.mock',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.schema',
+      'importer': 'sqlalchemy.engine.mock',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.engine.mock',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine._py_processors',
+      'importer': 'sqlalchemy.engine.processors',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util._has_cy',
+      'importer': 'sqlalchemy.engine.processors',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.base',
+      'importer': 'sqlalchemy.engine.reflection',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.interfaces',
+      'importer': 'sqlalchemy.engine.reflection',
+    }),
+    dict({
+      'imported': 'sqlalchemy.exc',
+      'importer': 'sqlalchemy.engine.reflection',
+    }),
+    dict({
+      'imported': 'sqlalchemy.inspection',
+      'importer': 'sqlalchemy.engine.reflection',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql',
+      'importer': 'sqlalchemy.engine.reflection',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.cache_key',
+      'importer': 'sqlalchemy.engine.reflection',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.elements',
+      'importer': 'sqlalchemy.engine.reflection',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.operators',
+      'importer': 'sqlalchemy.engine.reflection',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.schema',
+      'importer': 'sqlalchemy.engine.reflection',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.type_api',
+      'importer': 'sqlalchemy.engine.reflection',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.visitors',
+      'importer': 'sqlalchemy.engine.reflection',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.engine.reflection',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util.topological',
+      'importer': 'sqlalchemy.engine.reflection',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util.typing',
+      'importer': 'sqlalchemy.engine.reflection',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine._py_row',
+      'importer': 'sqlalchemy.engine.result',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.row',
+      'importer': 'sqlalchemy.engine.result',
+    }),
+    dict({
+      'imported': 'sqlalchemy.exc',
+      'importer': 'sqlalchemy.engine.result',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.base',
+      'importer': 'sqlalchemy.engine.result',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.schema',
+      'importer': 'sqlalchemy.engine.result',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.type_api',
+      'importer': 'sqlalchemy.engine.result',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.engine.result',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util._has_cy',
+      'importer': 'sqlalchemy.engine.result',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util.typing',
+      'importer': 'sqlalchemy.engine.result',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine._py_row',
+      'importer': 'sqlalchemy.engine.row',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.result',
+      'importer': 'sqlalchemy.engine.row',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.util',
+      'importer': 'sqlalchemy.engine.row',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.engine.row',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util._has_cy',
+      'importer': 'sqlalchemy.engine.row',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.mock',
+      'importer': 'sqlalchemy.engine.strategies',
+    }),
+    dict({
+      'imported': 'sqlalchemy.dialects',
+      'importer': 'sqlalchemy.engine.url',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.interfaces',
+      'importer': 'sqlalchemy.engine.url',
+    }),
+    dict({
+      'imported': 'sqlalchemy.exc',
+      'importer': 'sqlalchemy.engine.url',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.engine.url',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine._py_util',
+      'importer': 'sqlalchemy.engine.util',
+    }),
+    dict({
+      'imported': 'sqlalchemy.exc',
+      'importer': 'sqlalchemy.engine.util',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.engine.util',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util._has_cy',
+      'importer': 'sqlalchemy.engine.util',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util.typing',
+      'importer': 'sqlalchemy.engine.util',
+    }),
+    dict({
+      'imported': 'sqlalchemy.event.api',
+      'importer': 'sqlalchemy.event',
+    }),
+    dict({
+      'imported': 'sqlalchemy.event.attr',
+      'importer': 'sqlalchemy.event',
+    }),
+    dict({
+      'imported': 'sqlalchemy.event.base',
+      'importer': 'sqlalchemy.event',
+    }),
+    dict({
+      'imported': 'sqlalchemy.event.legacy',
+      'importer': 'sqlalchemy.event',
+    }),
+    dict({
+      'imported': 'sqlalchemy.event.registry',
+      'importer': 'sqlalchemy.event',
+    }),
+    dict({
+      'imported': 'sqlalchemy.event.base',
+      'importer': 'sqlalchemy.event.api',
+    }),
+    dict({
+      'imported': 'sqlalchemy.event.registry',
+      'importer': 'sqlalchemy.event.api',
+    }),
+    dict({
+      'imported': 'sqlalchemy.exc',
+      'importer': 'sqlalchemy.event.api',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.event.api',
+    }),
+    dict({
+      'imported': 'sqlalchemy.event.base',
+      'importer': 'sqlalchemy.event.attr',
+    }),
+    dict({
+      'imported': 'sqlalchemy.event.legacy',
+      'importer': 'sqlalchemy.event.attr',
+    }),
+    dict({
+      'imported': 'sqlalchemy.event.registry',
+      'importer': 'sqlalchemy.event.attr',
+    }),
+    dict({
+      'imported': 'sqlalchemy.exc',
+      'importer': 'sqlalchemy.event.attr',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.event.attr',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util.concurrency',
+      'importer': 'sqlalchemy.event.attr',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util.typing',
+      'importer': 'sqlalchemy.event.attr',
+    }),
+    dict({
+      'imported': 'sqlalchemy.event.attr',
+      'importer': 'sqlalchemy.event.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.event.registry',
+      'importer': 'sqlalchemy.event.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.event.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util.typing',
+      'importer': 'sqlalchemy.event.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.event.attr',
+      'importer': 'sqlalchemy.event.legacy',
+    }),
+    dict({
+      'imported': 'sqlalchemy.event.base',
+      'importer': 'sqlalchemy.event.legacy',
+    }),
+    dict({
+      'imported': 'sqlalchemy.event.registry',
+      'importer': 'sqlalchemy.event.legacy',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.event.legacy',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util.compat',
+      'importer': 'sqlalchemy.event.legacy',
+    }),
+    dict({
+      'imported': 'sqlalchemy.event.attr',
+      'importer': 'sqlalchemy.event.registry',
+    }),
+    dict({
+      'imported': 'sqlalchemy.event.base',
+      'importer': 'sqlalchemy.event.registry',
+    }),
+    dict({
+      'imported': 'sqlalchemy.exc',
+      'importer': 'sqlalchemy.event.registry',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.event.registry',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.events',
+      'importer': 'sqlalchemy.events',
+    }),
+    dict({
+      'imported': 'sqlalchemy.pool',
+      'importer': 'sqlalchemy.events',
+    }),
+    dict({
+      'imported': 'sqlalchemy.pool.events',
+      'importer': 'sqlalchemy.events',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.base',
+      'importer': 'sqlalchemy.events',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.events',
+      'importer': 'sqlalchemy.events',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.interfaces',
+      'importer': 'sqlalchemy.exc',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.compiler',
+      'importer': 'sqlalchemy.exc',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.elements',
+      'importer': 'sqlalchemy.exc',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util.compat',
+      'importer': 'sqlalchemy.exc',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util.preloaded',
+      'importer': 'sqlalchemy.exc',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.ext',
+    }),
+    dict({
+      'imported': 'sqlalchemy',
+      'importer': 'sqlalchemy.ext.associationproxy',
+    }),
+    dict({
+      'imported': 'sqlalchemy.exc',
+      'importer': 'sqlalchemy.ext.associationproxy',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm',
+      'importer': 'sqlalchemy.ext.associationproxy',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.base',
+      'importer': 'sqlalchemy.ext.associationproxy',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.collections',
+      'importer': 'sqlalchemy.ext.associationproxy',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.interfaces',
+      'importer': 'sqlalchemy.ext.associationproxy',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.mapper',
+      'importer': 'sqlalchemy.ext.associationproxy',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql',
+      'importer': 'sqlalchemy.ext.associationproxy',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql._typing',
+      'importer': 'sqlalchemy.ext.associationproxy',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.base',
+      'importer': 'sqlalchemy.ext.associationproxy',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.operators',
+      'importer': 'sqlalchemy.ext.associationproxy',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.ext.associationproxy',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util.typing',
+      'importer': 'sqlalchemy.ext.associationproxy',
+    }),
+    dict({
+      'imported': 'sqlalchemy.ext.asyncio.engine',
+      'importer': 'sqlalchemy.ext.asyncio',
+    }),
+    dict({
+      'imported': 'sqlalchemy.ext.asyncio.result',
+      'importer': 'sqlalchemy.ext.asyncio',
+    }),
+    dict({
+      'imported': 'sqlalchemy.ext.asyncio.scoping',
+      'importer': 'sqlalchemy.ext.asyncio',
+    }),
+    dict({
+      'imported': 'sqlalchemy.ext.asyncio.session',
+      'importer': 'sqlalchemy.ext.asyncio',
+    }),
+    dict({
+      'imported': 'sqlalchemy.ext.asyncio.exc',
+      'importer': 'sqlalchemy.ext.asyncio.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.ext.asyncio.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util.typing',
+      'importer': 'sqlalchemy.ext.asyncio.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine',
+      'importer': 'sqlalchemy.ext.asyncio.engine',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.base',
+      'importer': 'sqlalchemy.ext.asyncio.engine',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.cursor',
+      'importer': 'sqlalchemy.ext.asyncio.engine',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.interfaces',
+      'importer': 'sqlalchemy.ext.asyncio.engine',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.result',
+      'importer': 'sqlalchemy.ext.asyncio.engine',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.url',
+      'importer': 'sqlalchemy.ext.asyncio.engine',
+    }),
+    dict({
+      'imported': 'sqlalchemy.exc',
+      'importer': 'sqlalchemy.ext.asyncio.engine',
+    }),
+    dict({
+      'imported': 'sqlalchemy.ext.asyncio.base',
+      'importer': 'sqlalchemy.ext.asyncio.engine',
+    }),
+    dict({
+      'imported': 'sqlalchemy.ext.asyncio.exc',
+      'importer': 'sqlalchemy.ext.asyncio.engine',
+    }),
+    dict({
+      'imported': 'sqlalchemy.ext.asyncio.result',
+      'importer': 'sqlalchemy.ext.asyncio.engine',
+    }),
+    dict({
+      'imported': 'sqlalchemy.inspection',
+      'importer': 'sqlalchemy.ext.asyncio.engine',
+    }),
+    dict({
+      'imported': 'sqlalchemy.pool',
+      'importer': 'sqlalchemy.ext.asyncio.engine',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql._typing',
+      'importer': 'sqlalchemy.ext.asyncio.engine',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.base',
+      'importer': 'sqlalchemy.ext.asyncio.engine',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.selectable',
+      'importer': 'sqlalchemy.ext.asyncio.engine',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.ext.asyncio.engine',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util.concurrency',
+      'importer': 'sqlalchemy.ext.asyncio.engine',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util.typing',
+      'importer': 'sqlalchemy.ext.asyncio.engine',
+    }),
+    dict({
+      'imported': 'sqlalchemy.exc',
+      'importer': 'sqlalchemy.ext.asyncio.exc',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine',
+      'importer': 'sqlalchemy.ext.asyncio.result',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.result',
+      'importer': 'sqlalchemy.ext.asyncio.result',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.row',
+      'importer': 'sqlalchemy.ext.asyncio.result',
+    }),
+    dict({
+      'imported': 'sqlalchemy.ext.asyncio.exc',
+      'importer': 'sqlalchemy.ext.asyncio.result',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.base',
+      'importer': 'sqlalchemy.ext.asyncio.result',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.ext.asyncio.result',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util.concurrency',
+      'importer': 'sqlalchemy.ext.asyncio.result',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util.typing',
+      'importer': 'sqlalchemy.ext.asyncio.result',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine',
+      'importer': 'sqlalchemy.ext.asyncio.scoping',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.interfaces',
+      'importer': 'sqlalchemy.ext.asyncio.scoping',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.result',
+      'importer': 'sqlalchemy.ext.asyncio.scoping',
+    }),
+    dict({
+      'imported': 'sqlalchemy.exc',
+      'importer': 'sqlalchemy.ext.asyncio.scoping',
+    }),
+    dict({
+      'imported': 'sqlalchemy.ext.asyncio.engine',
+      'importer': 'sqlalchemy.ext.asyncio.scoping',
+    }),
+    dict({
+      'imported': 'sqlalchemy.ext.asyncio.result',
+      'importer': 'sqlalchemy.ext.asyncio.scoping',
+    }),
+    dict({
+      'imported': 'sqlalchemy.ext.asyncio.session',
+      'importer': 'sqlalchemy.ext.asyncio.scoping',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm._typing',
+      'importer': 'sqlalchemy.ext.asyncio.scoping',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.interfaces',
+      'importer': 'sqlalchemy.ext.asyncio.scoping',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.session',
+      'importer': 'sqlalchemy.ext.asyncio.scoping',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.base',
+      'importer': 'sqlalchemy.ext.asyncio.scoping',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.dml',
+      'importer': 'sqlalchemy.ext.asyncio.scoping',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.elements',
+      'importer': 'sqlalchemy.ext.asyncio.scoping',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.selectable',
+      'importer': 'sqlalchemy.ext.asyncio.scoping',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.ext.asyncio.scoping',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine',
+      'importer': 'sqlalchemy.ext.asyncio.session',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.interfaces',
+      'importer': 'sqlalchemy.ext.asyncio.session',
+    }),
+    dict({
+      'imported': 'sqlalchemy.event',
+      'importer': 'sqlalchemy.ext.asyncio.session',
+    }),
+    dict({
+      'imported': 'sqlalchemy.ext.asyncio.base',
+      'importer': 'sqlalchemy.ext.asyncio.session',
+    }),
+    dict({
+      'imported': 'sqlalchemy.ext.asyncio.engine',
+      'importer': 'sqlalchemy.ext.asyncio.session',
+    }),
+    dict({
+      'imported': 'sqlalchemy.ext.asyncio.result',
+      'importer': 'sqlalchemy.ext.asyncio.session',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm',
+      'importer': 'sqlalchemy.ext.asyncio.session',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm._typing',
+      'importer': 'sqlalchemy.ext.asyncio.session',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.identity',
+      'importer': 'sqlalchemy.ext.asyncio.session',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.interfaces',
+      'importer': 'sqlalchemy.ext.asyncio.session',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.session',
+      'importer': 'sqlalchemy.ext.asyncio.session',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.state',
+      'importer': 'sqlalchemy.ext.asyncio.session',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql._typing',
+      'importer': 'sqlalchemy.ext.asyncio.session',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.base',
+      'importer': 'sqlalchemy.ext.asyncio.session',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.dml',
+      'importer': 'sqlalchemy.ext.asyncio.session',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.elements',
+      'importer': 'sqlalchemy.ext.asyncio.session',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.selectable',
+      'importer': 'sqlalchemy.ext.asyncio.session',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.ext.asyncio.session',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util.concurrency',
+      'importer': 'sqlalchemy.ext.asyncio.session',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util.typing',
+      'importer': 'sqlalchemy.ext.asyncio.session',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.base',
+      'importer': 'sqlalchemy.ext.automap',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm',
+      'importer': 'sqlalchemy.ext.automap',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.base',
+      'importer': 'sqlalchemy.ext.automap',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.decl_base',
+      'importer': 'sqlalchemy.ext.automap',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.exc',
+      'importer': 'sqlalchemy.ext.automap',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.interfaces',
+      'importer': 'sqlalchemy.ext.automap',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.mapper',
+      'importer': 'sqlalchemy.ext.automap',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.relationships',
+      'importer': 'sqlalchemy.ext.automap',
+    }),
+    dict({
+      'imported': 'sqlalchemy.schema',
+      'importer': 'sqlalchemy.ext.automap',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql',
+      'importer': 'sqlalchemy.ext.automap',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.schema',
+      'importer': 'sqlalchemy.ext.automap',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.ext.automap',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util.typing',
+      'importer': 'sqlalchemy.ext.automap',
+    }),
+    dict({
+      'imported': 'sqlalchemy.exc',
+      'importer': 'sqlalchemy.ext.baked',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.exc',
+      'importer': 'sqlalchemy.ext.baked',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.query',
+      'importer': 'sqlalchemy.ext.baked',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.session',
+      'importer': 'sqlalchemy.ext.baked',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql',
+      'importer': 'sqlalchemy.ext.baked',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.util',
+      'importer': 'sqlalchemy.ext.baked',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.ext.baked',
+    }),
+    dict({
+      'imported': 'sqlalchemy.exc',
+      'importer': 'sqlalchemy.ext.compiler',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.sqltypes',
+      'importer': 'sqlalchemy.ext.compiler',
+    }),
+    dict({
+      'imported': 'sqlalchemy.ext.declarative.extensions',
+      'importer': 'sqlalchemy.ext.declarative',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.decl_api',
+      'importer': 'sqlalchemy.ext.declarative',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.ext.declarative',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine',
+      'importer': 'sqlalchemy.ext.declarative.extensions',
+    }),
+    dict({
+      'imported': 'sqlalchemy.exc',
+      'importer': 'sqlalchemy.ext.declarative.extensions',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.base',
+      'importer': 'sqlalchemy.ext.declarative.extensions',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.clsregistry',
+      'importer': 'sqlalchemy.ext.declarative.extensions',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.decl_base',
+      'importer': 'sqlalchemy.ext.declarative.extensions',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.exc',
+      'importer': 'sqlalchemy.ext.declarative.extensions',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.relationships',
+      'importer': 'sqlalchemy.ext.declarative.extensions',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.util',
+      'importer': 'sqlalchemy.ext.declarative.extensions',
+    }),
+    dict({
+      'imported': 'sqlalchemy.schema',
+      'importer': 'sqlalchemy.ext.declarative.extensions',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.schema',
+      'importer': 'sqlalchemy.ext.declarative.extensions',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.ext.declarative.extensions',
+    }),
+    dict({
+      'imported': 'sqlalchemy',
+      'importer': 'sqlalchemy.ext.horizontal_shard',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.base',
+      'importer': 'sqlalchemy.ext.horizontal_shard',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.result',
+      'importer': 'sqlalchemy.ext.horizontal_shard',
+    }),
+    dict({
+      'imported': 'sqlalchemy.event',
+      'importer': 'sqlalchemy.ext.horizontal_shard',
+    }),
+    dict({
+      'imported': 'sqlalchemy.exc',
+      'importer': 'sqlalchemy.ext.horizontal_shard',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm',
+      'importer': 'sqlalchemy.ext.horizontal_shard',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm._typing',
+      'importer': 'sqlalchemy.ext.horizontal_shard',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.bulk_persistence',
+      'importer': 'sqlalchemy.ext.horizontal_shard',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.context',
+      'importer': 'sqlalchemy.ext.horizontal_shard',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.interfaces',
+      'importer': 'sqlalchemy.ext.horizontal_shard',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.mapper',
+      'importer': 'sqlalchemy.ext.horizontal_shard',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.query',
+      'importer': 'sqlalchemy.ext.horizontal_shard',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.session',
+      'importer': 'sqlalchemy.ext.horizontal_shard',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.state',
+      'importer': 'sqlalchemy.ext.horizontal_shard',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql',
+      'importer': 'sqlalchemy.ext.horizontal_shard',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql._typing',
+      'importer': 'sqlalchemy.ext.horizontal_shard',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.elements',
+      'importer': 'sqlalchemy.ext.horizontal_shard',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.ext.horizontal_shard',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util.typing',
+      'importer': 'sqlalchemy.ext.horizontal_shard',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm',
+      'importer': 'sqlalchemy.ext.hybrid',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.attributes',
+      'importer': 'sqlalchemy.ext.hybrid',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.interfaces',
+      'importer': 'sqlalchemy.ext.hybrid',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.util',
+      'importer': 'sqlalchemy.ext.hybrid',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql',
+      'importer': 'sqlalchemy.ext.hybrid',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql._typing',
+      'importer': 'sqlalchemy.ext.hybrid',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.elements',
+      'importer': 'sqlalchemy.ext.hybrid',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.operators',
+      'importer': 'sqlalchemy.ext.hybrid',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.roles',
+      'importer': 'sqlalchemy.ext.hybrid',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.ext.hybrid',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util.typing',
+      'importer': 'sqlalchemy.ext.hybrid',
+    }),
+    dict({
+      'imported': 'sqlalchemy',
+      'importer': 'sqlalchemy.ext.indexable',
+    }),
+    dict({
+      'imported': 'sqlalchemy.ext.hybrid',
+      'importer': 'sqlalchemy.ext.indexable',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.attributes',
+      'importer': 'sqlalchemy.ext.indexable',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.attributes',
+      'importer': 'sqlalchemy.ext.instrumentation',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.base',
+      'importer': 'sqlalchemy.ext.instrumentation',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.collections',
+      'importer': 'sqlalchemy.ext.instrumentation',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.exc',
+      'importer': 'sqlalchemy.ext.instrumentation',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.instrumentation',
+      'importer': 'sqlalchemy.ext.instrumentation',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.util',
+      'importer': 'sqlalchemy.ext.instrumentation',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.ext.instrumentation',
+    }),
+    dict({
+      'imported': 'sqlalchemy',
+      'importer': 'sqlalchemy.ext.mutable',
+    }),
+    dict({
+      'imported': 'sqlalchemy.event',
+      'importer': 'sqlalchemy.ext.mutable',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm',
+      'importer': 'sqlalchemy.ext.mutable',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm._typing',
+      'importer': 'sqlalchemy.ext.mutable',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.attributes',
+      'importer': 'sqlalchemy.ext.mutable',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.context',
+      'importer': 'sqlalchemy.ext.mutable',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.decl_api',
+      'importer': 'sqlalchemy.ext.mutable',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.state',
+      'importer': 'sqlalchemy.ext.mutable',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.unitofwork',
+      'importer': 'sqlalchemy.ext.mutable',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.base',
+      'importer': 'sqlalchemy.ext.mutable',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.schema',
+      'importer': 'sqlalchemy.ext.mutable',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.type_api',
+      'importer': 'sqlalchemy.ext.mutable',
+    }),
+    dict({
+      'imported': 'sqlalchemy.types',
+      'importer': 'sqlalchemy.ext.mutable',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.ext.mutable',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util.typing',
+      'importer': 'sqlalchemy.ext.mutable',
+    }),
+    dict({
+      'imported': 'sqlalchemy.ext.mypy.infer',
+      'importer': 'sqlalchemy.ext.mypy.apply',
+    }),
+    dict({
+      'imported': 'sqlalchemy.ext.mypy.names',
+      'importer': 'sqlalchemy.ext.mypy.apply',
+    }),
+    dict({
+      'imported': 'sqlalchemy.ext.mypy.util',
+      'importer': 'sqlalchemy.ext.mypy.apply',
+    }),
+    dict({
+      'imported': 'sqlalchemy.ext.mypy.apply',
+      'importer': 'sqlalchemy.ext.mypy.decl_class',
+    }),
+    dict({
+      'imported': 'sqlalchemy.ext.mypy.infer',
+      'importer': 'sqlalchemy.ext.mypy.decl_class',
+    }),
+    dict({
+      'imported': 'sqlalchemy.ext.mypy.names',
+      'importer': 'sqlalchemy.ext.mypy.decl_class',
+    }),
+    dict({
+      'imported': 'sqlalchemy.ext.mypy.util',
+      'importer': 'sqlalchemy.ext.mypy.decl_class',
+    }),
+    dict({
+      'imported': 'sqlalchemy.ext.mypy.names',
+      'importer': 'sqlalchemy.ext.mypy.infer',
+    }),
+    dict({
+      'imported': 'sqlalchemy.ext.mypy.util',
+      'importer': 'sqlalchemy.ext.mypy.infer',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.ext.mypy.names',
+    }),
+    dict({
+      'imported': 'sqlalchemy.ext.mypy.decl_class',
+      'importer': 'sqlalchemy.ext.mypy.plugin',
+    }),
+    dict({
+      'imported': 'sqlalchemy.ext.mypy.names',
+      'importer': 'sqlalchemy.ext.mypy.plugin',
+    }),
+    dict({
+      'imported': 'sqlalchemy.ext.mypy.util',
+      'importer': 'sqlalchemy.ext.mypy.plugin',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.collections',
+      'importer': 'sqlalchemy.ext.orderinglist',
+    }),
+    dict({
+      'imported': 'sqlalchemy',
+      'importer': 'sqlalchemy.ext.serializer',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine',
+      'importer': 'sqlalchemy.ext.serializer',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm',
+      'importer': 'sqlalchemy.ext.serializer',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.interfaces',
+      'importer': 'sqlalchemy.ext.serializer',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.mapper',
+      'importer': 'sqlalchemy.ext.serializer',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.session',
+      'importer': 'sqlalchemy.ext.serializer',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.ext.serializer',
+    }),
+    dict({
+      'imported': 'sqlalchemy.future.engine',
+      'importer': 'sqlalchemy.future',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql._selectable_constructors',
+      'importer': 'sqlalchemy.future',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine',
+      'importer': 'sqlalchemy.future.engine',
+    }),
+    dict({
+      'imported': 'sqlalchemy.exc',
+      'importer': 'sqlalchemy.inspection',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util.typing',
+      'importer': 'sqlalchemy.inspection',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.log',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util.typing',
+      'importer': 'sqlalchemy.log',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm._orm_constructors',
+      'importer': 'sqlalchemy.orm',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.attributes',
+      'importer': 'sqlalchemy.orm',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.base',
+      'importer': 'sqlalchemy.orm',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.context',
+      'importer': 'sqlalchemy.orm',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.decl_api',
+      'importer': 'sqlalchemy.orm',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.decl_base',
+      'importer': 'sqlalchemy.orm',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.descriptor_props',
+      'importer': 'sqlalchemy.orm',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.dynamic',
+      'importer': 'sqlalchemy.orm',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.events',
+      'importer': 'sqlalchemy.orm',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.exc',
+      'importer': 'sqlalchemy.orm',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.identity',
+      'importer': 'sqlalchemy.orm',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.instrumentation',
+      'importer': 'sqlalchemy.orm',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.interfaces',
+      'importer': 'sqlalchemy.orm',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.loading',
+      'importer': 'sqlalchemy.orm',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.mapped_collection',
+      'importer': 'sqlalchemy.orm',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.mapper',
+      'importer': 'sqlalchemy.orm',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.properties',
+      'importer': 'sqlalchemy.orm',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.query',
+      'importer': 'sqlalchemy.orm',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.relationships',
+      'importer': 'sqlalchemy.orm',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.scoping',
+      'importer': 'sqlalchemy.orm',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.session',
+      'importer': 'sqlalchemy.orm',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.state',
+      'importer': 'sqlalchemy.orm',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.strategy_options',
+      'importer': 'sqlalchemy.orm',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.unitofwork',
+      'importer': 'sqlalchemy.orm',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.util',
+      'importer': 'sqlalchemy.orm',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.writeonly',
+      'importer': 'sqlalchemy.orm',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.orm',
+    }),
+    dict({
+      'imported': 'sqlalchemy.exc',
+      'importer': 'sqlalchemy.orm._orm_constructors',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm',
+      'importer': 'sqlalchemy.orm._orm_constructors',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm._typing',
+      'importer': 'sqlalchemy.orm._orm_constructors',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.descriptor_props',
+      'importer': 'sqlalchemy.orm._orm_constructors',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.interfaces',
+      'importer': 'sqlalchemy.orm._orm_constructors',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.mapper',
+      'importer': 'sqlalchemy.orm._orm_constructors',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.properties',
+      'importer': 'sqlalchemy.orm._orm_constructors',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.query',
+      'importer': 'sqlalchemy.orm._orm_constructors',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.relationships',
+      'importer': 'sqlalchemy.orm._orm_constructors',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.session',
+      'importer': 'sqlalchemy.orm._orm_constructors',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.util',
+      'importer': 'sqlalchemy.orm._orm_constructors',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql',
+      'importer': 'sqlalchemy.orm._orm_constructors',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql._typing',
+      'importer': 'sqlalchemy.orm._orm_constructors',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.base',
+      'importer': 'sqlalchemy.orm._orm_constructors',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.elements',
+      'importer': 'sqlalchemy.orm._orm_constructors',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.schema',
+      'importer': 'sqlalchemy.orm._orm_constructors',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.selectable',
+      'importer': 'sqlalchemy.orm._orm_constructors',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.orm._orm_constructors',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util.typing',
+      'importer': 'sqlalchemy.orm._orm_constructors',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.interfaces',
+      'importer': 'sqlalchemy.orm._typing',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.attributes',
+      'importer': 'sqlalchemy.orm._typing',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.base',
+      'importer': 'sqlalchemy.orm._typing',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.decl_api',
+      'importer': 'sqlalchemy.orm._typing',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.interfaces',
+      'importer': 'sqlalchemy.orm._typing',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.mapper',
+      'importer': 'sqlalchemy.orm._typing',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.relationships',
+      'importer': 'sqlalchemy.orm._typing',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.state',
+      'importer': 'sqlalchemy.orm._typing',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.util',
+      'importer': 'sqlalchemy.orm._typing',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql._orm_types',
+      'importer': 'sqlalchemy.orm._typing',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql._typing',
+      'importer': 'sqlalchemy.orm._typing',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.base',
+      'importer': 'sqlalchemy.orm._typing',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.elements',
+      'importer': 'sqlalchemy.orm._typing',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.roles',
+      'importer': 'sqlalchemy.orm._typing',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util.typing',
+      'importer': 'sqlalchemy.orm._typing',
+    }),
+    dict({
+      'imported': 'sqlalchemy.event',
+      'importer': 'sqlalchemy.orm.attributes',
+    }),
+    dict({
+      'imported': 'sqlalchemy.event.base',
+      'importer': 'sqlalchemy.orm.attributes',
+    }),
+    dict({
+      'imported': 'sqlalchemy.exc',
+      'importer': 'sqlalchemy.orm.attributes',
+    }),
+    dict({
+      'imported': 'sqlalchemy.inspection',
+      'importer': 'sqlalchemy.orm.attributes',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm._typing',
+      'importer': 'sqlalchemy.orm.attributes',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.base',
+      'importer': 'sqlalchemy.orm.attributes',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.collections',
+      'importer': 'sqlalchemy.orm.attributes',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.exc',
+      'importer': 'sqlalchemy.orm.attributes',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.interfaces',
+      'importer': 'sqlalchemy.orm.attributes',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.relationships',
+      'importer': 'sqlalchemy.orm.attributes',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.state',
+      'importer': 'sqlalchemy.orm.attributes',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.util',
+      'importer': 'sqlalchemy.orm.attributes',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.writeonly',
+      'importer': 'sqlalchemy.orm.attributes',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql._typing',
+      'importer': 'sqlalchemy.orm.attributes',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.annotation',
+      'importer': 'sqlalchemy.orm.attributes',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.base',
+      'importer': 'sqlalchemy.orm.attributes',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.cache_key',
+      'importer': 'sqlalchemy.orm.attributes',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.coercions',
+      'importer': 'sqlalchemy.orm.attributes',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.elements',
+      'importer': 'sqlalchemy.orm.attributes',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.operators',
+      'importer': 'sqlalchemy.orm.attributes',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.roles',
+      'importer': 'sqlalchemy.orm.attributes',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.selectable',
+      'importer': 'sqlalchemy.orm.attributes',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.visitors',
+      'importer': 'sqlalchemy.orm.attributes',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.orm.attributes',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util.typing',
+      'importer': 'sqlalchemy.orm.attributes',
+    }),
+    dict({
+      'imported': 'sqlalchemy.exc',
+      'importer': 'sqlalchemy.orm.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.inspection',
+      'importer': 'sqlalchemy.orm.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm._typing',
+      'importer': 'sqlalchemy.orm.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.attributes',
+      'importer': 'sqlalchemy.orm.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.dynamic',
+      'importer': 'sqlalchemy.orm.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.exc',
+      'importer': 'sqlalchemy.orm.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.instrumentation',
+      'importer': 'sqlalchemy.orm.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.interfaces',
+      'importer': 'sqlalchemy.orm.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.mapper',
+      'importer': 'sqlalchemy.orm.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.state',
+      'importer': 'sqlalchemy.orm.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.util',
+      'importer': 'sqlalchemy.orm.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.writeonly',
+      'importer': 'sqlalchemy.orm.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql._typing',
+      'importer': 'sqlalchemy.orm.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.elements',
+      'importer': 'sqlalchemy.orm.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.operators',
+      'importer': 'sqlalchemy.orm.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.roles',
+      'importer': 'sqlalchemy.orm.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.orm.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util.langhelpers',
+      'importer': 'sqlalchemy.orm.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util.typing',
+      'importer': 'sqlalchemy.orm.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine',
+      'importer': 'sqlalchemy.orm.bulk_persistence',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.cursor',
+      'importer': 'sqlalchemy.orm.bulk_persistence',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.interfaces',
+      'importer': 'sqlalchemy.orm.bulk_persistence',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.result',
+      'importer': 'sqlalchemy.orm.bulk_persistence',
+    }),
+    dict({
+      'imported': 'sqlalchemy.exc',
+      'importer': 'sqlalchemy.orm.bulk_persistence',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm._typing',
+      'importer': 'sqlalchemy.orm.bulk_persistence',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.attributes',
+      'importer': 'sqlalchemy.orm.bulk_persistence',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.base',
+      'importer': 'sqlalchemy.orm.bulk_persistence',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.context',
+      'importer': 'sqlalchemy.orm.bulk_persistence',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.evaluator',
+      'importer': 'sqlalchemy.orm.bulk_persistence',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.exc',
+      'importer': 'sqlalchemy.orm.bulk_persistence',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.loading',
+      'importer': 'sqlalchemy.orm.bulk_persistence',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.mapper',
+      'importer': 'sqlalchemy.orm.bulk_persistence',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.persistence',
+      'importer': 'sqlalchemy.orm.bulk_persistence',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.session',
+      'importer': 'sqlalchemy.orm.bulk_persistence',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.state',
+      'importer': 'sqlalchemy.orm.bulk_persistence',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql',
+      'importer': 'sqlalchemy.orm.bulk_persistence',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.base',
+      'importer': 'sqlalchemy.orm.bulk_persistence',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.coercions',
+      'importer': 'sqlalchemy.orm.bulk_persistence',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.dml',
+      'importer': 'sqlalchemy.orm.bulk_persistence',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.expression',
+      'importer': 'sqlalchemy.orm.bulk_persistence',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.roles',
+      'importer': 'sqlalchemy.orm.bulk_persistence',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.sqltypes',
+      'importer': 'sqlalchemy.orm.bulk_persistence',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.orm.bulk_persistence',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util.typing',
+      'importer': 'sqlalchemy.orm.bulk_persistence',
+    }),
+    dict({
+      'imported': 'sqlalchemy',
+      'importer': 'sqlalchemy.orm.clsregistry',
+    }),
+    dict({
+      'imported': 'sqlalchemy.exc',
+      'importer': 'sqlalchemy.orm.clsregistry',
+    }),
+    dict({
+      'imported': 'sqlalchemy.inspection',
+      'importer': 'sqlalchemy.orm.clsregistry',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm',
+      'importer': 'sqlalchemy.orm.clsregistry',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.attributes',
+      'importer': 'sqlalchemy.orm.clsregistry',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.descriptor_props',
+      'importer': 'sqlalchemy.orm.clsregistry',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.interfaces',
+      'importer': 'sqlalchemy.orm.clsregistry',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.properties',
+      'importer': 'sqlalchemy.orm.clsregistry',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.relationships',
+      'importer': 'sqlalchemy.orm.clsregistry',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.util',
+      'importer': 'sqlalchemy.orm.clsregistry',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.schema',
+      'importer': 'sqlalchemy.orm.clsregistry',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.orm.clsregistry',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util.typing',
+      'importer': 'sqlalchemy.orm.clsregistry',
+    }),
+    dict({
+      'imported': 'sqlalchemy.exc',
+      'importer': 'sqlalchemy.orm.collections',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.attributes',
+      'importer': 'sqlalchemy.orm.collections',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.base',
+      'importer': 'sqlalchemy.orm.collections',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.mapped_collection',
+      'importer': 'sqlalchemy.orm.collections',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.state',
+      'importer': 'sqlalchemy.orm.collections',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.base',
+      'importer': 'sqlalchemy.orm.collections',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.orm.collections',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util.compat',
+      'importer': 'sqlalchemy.orm.collections',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util.typing',
+      'importer': 'sqlalchemy.orm.collections',
+    }),
+    dict({
+      'imported': 'sqlalchemy',
+      'importer': 'sqlalchemy.orm.context',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine',
+      'importer': 'sqlalchemy.orm.context',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.interfaces',
+      'importer': 'sqlalchemy.orm.context',
+    }),
+    dict({
+      'imported': 'sqlalchemy.exc',
+      'importer': 'sqlalchemy.orm.context',
+    }),
+    dict({
+      'imported': 'sqlalchemy.future',
+      'importer': 'sqlalchemy.orm.context',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm._typing',
+      'importer': 'sqlalchemy.orm.context',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.attributes',
+      'importer': 'sqlalchemy.orm.context',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.base',
+      'importer': 'sqlalchemy.orm.context',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.interfaces',
+      'importer': 'sqlalchemy.orm.context',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.loading',
+      'importer': 'sqlalchemy.orm.context',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.mapper',
+      'importer': 'sqlalchemy.orm.context',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.path_registry',
+      'importer': 'sqlalchemy.orm.context',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.query',
+      'importer': 'sqlalchemy.orm.context',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.session',
+      'importer': 'sqlalchemy.orm.context',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.util',
+      'importer': 'sqlalchemy.orm.context',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql',
+      'importer': 'sqlalchemy.orm.context',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql._typing',
+      'importer': 'sqlalchemy.orm.context',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.base',
+      'importer': 'sqlalchemy.orm.context',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.coercions',
+      'importer': 'sqlalchemy.orm.context',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.compiler',
+      'importer': 'sqlalchemy.orm.context',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.dml',
+      'importer': 'sqlalchemy.orm.context',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.elements',
+      'importer': 'sqlalchemy.orm.context',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.expression',
+      'importer': 'sqlalchemy.orm.context',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.roles',
+      'importer': 'sqlalchemy.orm.context',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.selectable',
+      'importer': 'sqlalchemy.orm.context',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.type_api',
+      'importer': 'sqlalchemy.orm.context',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.util',
+      'importer': 'sqlalchemy.orm.context',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.visitors',
+      'importer': 'sqlalchemy.orm.context',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.orm.context',
+    }),
+    dict({
+      'imported': 'sqlalchemy.exc',
+      'importer': 'sqlalchemy.orm.decl_api',
+    }),
+    dict({
+      'imported': 'sqlalchemy.inspection',
+      'importer': 'sqlalchemy.orm.decl_api',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm',
+      'importer': 'sqlalchemy.orm.decl_api',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm._orm_constructors',
+      'importer': 'sqlalchemy.orm.decl_api',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm._typing',
+      'importer': 'sqlalchemy.orm.decl_api',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.attributes',
+      'importer': 'sqlalchemy.orm.decl_api',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.base',
+      'importer': 'sqlalchemy.orm.decl_api',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.clsregistry',
+      'importer': 'sqlalchemy.orm.decl_api',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.decl_base',
+      'importer': 'sqlalchemy.orm.decl_api',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.descriptor_props',
+      'importer': 'sqlalchemy.orm.decl_api',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.instrumentation',
+      'importer': 'sqlalchemy.orm.decl_api',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.interfaces',
+      'importer': 'sqlalchemy.orm.decl_api',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.mapper',
+      'importer': 'sqlalchemy.orm.decl_api',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.properties',
+      'importer': 'sqlalchemy.orm.decl_api',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.relationships',
+      'importer': 'sqlalchemy.orm.decl_api',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.state',
+      'importer': 'sqlalchemy.orm.decl_api',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql._typing',
+      'importer': 'sqlalchemy.orm.decl_api',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.base',
+      'importer': 'sqlalchemy.orm.decl_api',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.elements',
+      'importer': 'sqlalchemy.orm.decl_api',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.schema',
+      'importer': 'sqlalchemy.orm.decl_api',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.selectable',
+      'importer': 'sqlalchemy.orm.decl_api',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.sqltypes',
+      'importer': 'sqlalchemy.orm.decl_api',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.type_api',
+      'importer': 'sqlalchemy.orm.decl_api',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.orm.decl_api',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util.typing',
+      'importer': 'sqlalchemy.orm.decl_api',
+    }),
+    dict({
+      'imported': 'sqlalchemy.event',
+      'importer': 'sqlalchemy.orm.decl_base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.exc',
+      'importer': 'sqlalchemy.orm.decl_base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm',
+      'importer': 'sqlalchemy.orm.decl_base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm._typing',
+      'importer': 'sqlalchemy.orm.decl_base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.attributes',
+      'importer': 'sqlalchemy.orm.decl_base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.base',
+      'importer': 'sqlalchemy.orm.decl_base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.clsregistry',
+      'importer': 'sqlalchemy.orm.decl_base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.decl_api',
+      'importer': 'sqlalchemy.orm.decl_base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.descriptor_props',
+      'importer': 'sqlalchemy.orm.decl_base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.exc',
+      'importer': 'sqlalchemy.orm.decl_base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.instrumentation',
+      'importer': 'sqlalchemy.orm.decl_base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.interfaces',
+      'importer': 'sqlalchemy.orm.decl_base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.mapper',
+      'importer': 'sqlalchemy.orm.decl_base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.properties',
+      'importer': 'sqlalchemy.orm.decl_base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.util',
+      'importer': 'sqlalchemy.orm.decl_base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.base',
+      'importer': 'sqlalchemy.orm.decl_base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.elements',
+      'importer': 'sqlalchemy.orm.decl_base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.expression',
+      'importer': 'sqlalchemy.orm.decl_base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.schema',
+      'importer': 'sqlalchemy.orm.decl_base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.selectable',
+      'importer': 'sqlalchemy.orm.decl_base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.orm.decl_base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util.topological',
+      'importer': 'sqlalchemy.orm.decl_base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util.typing',
+      'importer': 'sqlalchemy.orm.decl_base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.exc',
+      'importer': 'sqlalchemy.orm.dependency',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.attributes',
+      'importer': 'sqlalchemy.orm.dependency',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.exc',
+      'importer': 'sqlalchemy.orm.dependency',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.interfaces',
+      'importer': 'sqlalchemy.orm.dependency',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.sync',
+      'importer': 'sqlalchemy.orm.dependency',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.unitofwork',
+      'importer': 'sqlalchemy.orm.dependency',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.util',
+      'importer': 'sqlalchemy.orm.dependency',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql',
+      'importer': 'sqlalchemy.orm.dependency',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.orm.dependency',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.base',
+      'importer': 'sqlalchemy.orm.descriptor_props',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.row',
+      'importer': 'sqlalchemy.orm.descriptor_props',
+    }),
+    dict({
+      'imported': 'sqlalchemy.event',
+      'importer': 'sqlalchemy.orm.descriptor_props',
+    }),
+    dict({
+      'imported': 'sqlalchemy.exc',
+      'importer': 'sqlalchemy.orm.descriptor_props',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm._typing',
+      'importer': 'sqlalchemy.orm.descriptor_props',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.attributes',
+      'importer': 'sqlalchemy.orm.descriptor_props',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.base',
+      'importer': 'sqlalchemy.orm.descriptor_props',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.context',
+      'importer': 'sqlalchemy.orm.descriptor_props',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.decl_base',
+      'importer': 'sqlalchemy.orm.descriptor_props',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.interfaces',
+      'importer': 'sqlalchemy.orm.descriptor_props',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.mapper',
+      'importer': 'sqlalchemy.orm.descriptor_props',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.properties',
+      'importer': 'sqlalchemy.orm.descriptor_props',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.state',
+      'importer': 'sqlalchemy.orm.descriptor_props',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.util',
+      'importer': 'sqlalchemy.orm.descriptor_props',
+    }),
+    dict({
+      'imported': 'sqlalchemy.schema',
+      'importer': 'sqlalchemy.orm.descriptor_props',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql',
+      'importer': 'sqlalchemy.orm.descriptor_props',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql._typing',
+      'importer': 'sqlalchemy.orm.descriptor_props',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.elements',
+      'importer': 'sqlalchemy.orm.descriptor_props',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.expression',
+      'importer': 'sqlalchemy.orm.descriptor_props',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.operators',
+      'importer': 'sqlalchemy.orm.descriptor_props',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.schema',
+      'importer': 'sqlalchemy.orm.descriptor_props',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.selectable',
+      'importer': 'sqlalchemy.orm.descriptor_props',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.orm.descriptor_props',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util.typing',
+      'importer': 'sqlalchemy.orm.descriptor_props',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.result',
+      'importer': 'sqlalchemy.orm.dynamic',
+    }),
+    dict({
+      'imported': 'sqlalchemy.event',
+      'importer': 'sqlalchemy.orm.dynamic',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm',
+      'importer': 'sqlalchemy.orm.dynamic',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.attributes',
+      'importer': 'sqlalchemy.orm.dynamic',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.base',
+      'importer': 'sqlalchemy.orm.dynamic',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.exc',
+      'importer': 'sqlalchemy.orm.dynamic',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.mapper',
+      'importer': 'sqlalchemy.orm.dynamic',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.query',
+      'importer': 'sqlalchemy.orm.dynamic',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.relationships',
+      'importer': 'sqlalchemy.orm.dynamic',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.session',
+      'importer': 'sqlalchemy.orm.dynamic',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.state',
+      'importer': 'sqlalchemy.orm.dynamic',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.util',
+      'importer': 'sqlalchemy.orm.dynamic',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.writeonly',
+      'importer': 'sqlalchemy.orm.dynamic',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.elements',
+      'importer': 'sqlalchemy.orm.dynamic',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.orm.dynamic',
+    }),
+    dict({
+      'imported': 'sqlalchemy',
+      'importer': 'sqlalchemy.orm.evaluator',
+    }),
+    dict({
+      'imported': 'sqlalchemy.exc',
+      'importer': 'sqlalchemy.orm.evaluator',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.base',
+      'importer': 'sqlalchemy.orm.evaluator',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.exc',
+      'importer': 'sqlalchemy.orm.evaluator',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql',
+      'importer': 'sqlalchemy.orm.evaluator',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.operators',
+      'importer': 'sqlalchemy.orm.evaluator',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.sqltypes',
+      'importer': 'sqlalchemy.orm.evaluator',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.orm.evaluator',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine',
+      'importer': 'sqlalchemy.orm.events',
+    }),
+    dict({
+      'imported': 'sqlalchemy.event',
+      'importer': 'sqlalchemy.orm.events',
+    }),
+    dict({
+      'imported': 'sqlalchemy.event.base',
+      'importer': 'sqlalchemy.orm.events',
+    }),
+    dict({
+      'imported': 'sqlalchemy.event.registry',
+      'importer': 'sqlalchemy.orm.events',
+    }),
+    dict({
+      'imported': 'sqlalchemy.exc',
+      'importer': 'sqlalchemy.orm.events',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm',
+      'importer': 'sqlalchemy.orm.events',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm._typing',
+      'importer': 'sqlalchemy.orm.events',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.attributes',
+      'importer': 'sqlalchemy.orm.events',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.base',
+      'importer': 'sqlalchemy.orm.events',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.collections',
+      'importer': 'sqlalchemy.orm.events',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.context',
+      'importer': 'sqlalchemy.orm.events',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.decl_api',
+      'importer': 'sqlalchemy.orm.events',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.instrumentation',
+      'importer': 'sqlalchemy.orm.events',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.interfaces',
+      'importer': 'sqlalchemy.orm.events',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.mapper',
+      'importer': 'sqlalchemy.orm.events',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.query',
+      'importer': 'sqlalchemy.orm.events',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.scoping',
+      'importer': 'sqlalchemy.orm.events',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.session',
+      'importer': 'sqlalchemy.orm.events',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.state',
+      'importer': 'sqlalchemy.orm.events',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.unitofwork',
+      'importer': 'sqlalchemy.orm.events',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.orm.events',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util.compat',
+      'importer': 'sqlalchemy.orm.events',
+    }),
+    dict({
+      'imported': 'sqlalchemy.exc',
+      'importer': 'sqlalchemy.orm.exc',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.interfaces',
+      'importer': 'sqlalchemy.orm.exc',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.state',
+      'importer': 'sqlalchemy.orm.exc',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.util',
+      'importer': 'sqlalchemy.orm.exc',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.orm.exc',
+    }),
+    dict({
+      'imported': 'sqlalchemy.exc',
+      'importer': 'sqlalchemy.orm.identity',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm._typing',
+      'importer': 'sqlalchemy.orm.identity',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.state',
+      'importer': 'sqlalchemy.orm.identity',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.util',
+      'importer': 'sqlalchemy.orm.identity',
+    }),
+    dict({
+      'imported': 'sqlalchemy.event',
+      'importer': 'sqlalchemy.orm.instrumentation',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm._typing',
+      'importer': 'sqlalchemy.orm.instrumentation',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.attributes',
+      'importer': 'sqlalchemy.orm.instrumentation',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.base',
+      'importer': 'sqlalchemy.orm.instrumentation',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.collections',
+      'importer': 'sqlalchemy.orm.instrumentation',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.decl_base',
+      'importer': 'sqlalchemy.orm.instrumentation',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.events',
+      'importer': 'sqlalchemy.orm.instrumentation',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.exc',
+      'importer': 'sqlalchemy.orm.instrumentation',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.interfaces',
+      'importer': 'sqlalchemy.orm.instrumentation',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.mapper',
+      'importer': 'sqlalchemy.orm.instrumentation',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.state',
+      'importer': 'sqlalchemy.orm.instrumentation',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.orm.instrumentation',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util.typing',
+      'importer': 'sqlalchemy.orm.instrumentation',
+    }),
+    dict({
+      'imported': 'sqlalchemy',
+      'importer': 'sqlalchemy.orm.interfaces',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.result',
+      'importer': 'sqlalchemy.orm.interfaces',
+    }),
+    dict({
+      'imported': 'sqlalchemy.exc',
+      'importer': 'sqlalchemy.orm.interfaces',
+    }),
+    dict({
+      'imported': 'sqlalchemy.inspection',
+      'importer': 'sqlalchemy.orm.interfaces',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm._typing',
+      'importer': 'sqlalchemy.orm.interfaces',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.attributes',
+      'importer': 'sqlalchemy.orm.interfaces',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.base',
+      'importer': 'sqlalchemy.orm.interfaces',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.context',
+      'importer': 'sqlalchemy.orm.interfaces',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.decl_api',
+      'importer': 'sqlalchemy.orm.interfaces',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.decl_base',
+      'importer': 'sqlalchemy.orm.interfaces',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.exc',
+      'importer': 'sqlalchemy.orm.interfaces',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.loading',
+      'importer': 'sqlalchemy.orm.interfaces',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.mapper',
+      'importer': 'sqlalchemy.orm.interfaces',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.path_registry',
+      'importer': 'sqlalchemy.orm.interfaces',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.query',
+      'importer': 'sqlalchemy.orm.interfaces',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.session',
+      'importer': 'sqlalchemy.orm.interfaces',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.state',
+      'importer': 'sqlalchemy.orm.interfaces',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.strategy_options',
+      'importer': 'sqlalchemy.orm.interfaces',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.util',
+      'importer': 'sqlalchemy.orm.interfaces',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql._typing',
+      'importer': 'sqlalchemy.orm.interfaces',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.base',
+      'importer': 'sqlalchemy.orm.interfaces',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.cache_key',
+      'importer': 'sqlalchemy.orm.interfaces',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.operators',
+      'importer': 'sqlalchemy.orm.interfaces',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.roles',
+      'importer': 'sqlalchemy.orm.interfaces',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.schema',
+      'importer': 'sqlalchemy.orm.interfaces',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.type_api',
+      'importer': 'sqlalchemy.orm.interfaces',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.visitors',
+      'importer': 'sqlalchemy.orm.interfaces',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.orm.interfaces',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util.typing',
+      'importer': 'sqlalchemy.orm.interfaces',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine',
+      'importer': 'sqlalchemy.orm.loading',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.cursor',
+      'importer': 'sqlalchemy.orm.loading',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.interfaces',
+      'importer': 'sqlalchemy.orm.loading',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.result',
+      'importer': 'sqlalchemy.orm.loading',
+    }),
+    dict({
+      'imported': 'sqlalchemy.exc',
+      'importer': 'sqlalchemy.orm.loading',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm._typing',
+      'importer': 'sqlalchemy.orm.loading',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.attributes',
+      'importer': 'sqlalchemy.orm.loading',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.base',
+      'importer': 'sqlalchemy.orm.loading',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.context',
+      'importer': 'sqlalchemy.orm.loading',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.exc',
+      'importer': 'sqlalchemy.orm.loading',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.interfaces',
+      'importer': 'sqlalchemy.orm.loading',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.mapper',
+      'importer': 'sqlalchemy.orm.loading',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.path_registry',
+      'importer': 'sqlalchemy.orm.loading',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.query',
+      'importer': 'sqlalchemy.orm.loading',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.session',
+      'importer': 'sqlalchemy.orm.loading',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.state',
+      'importer': 'sqlalchemy.orm.loading',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.util',
+      'importer': 'sqlalchemy.orm.loading',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql',
+      'importer': 'sqlalchemy.orm.loading',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.selectable',
+      'importer': 'sqlalchemy.orm.loading',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.util',
+      'importer': 'sqlalchemy.orm.loading',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.orm.loading',
+    }),
+    dict({
+      'imported': 'sqlalchemy.exc',
+      'importer': 'sqlalchemy.orm.mapped_collection',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm',
+      'importer': 'sqlalchemy.orm.mapped_collection',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.base',
+      'importer': 'sqlalchemy.orm.mapped_collection',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.collections',
+      'importer': 'sqlalchemy.orm.mapped_collection',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.coercions',
+      'importer': 'sqlalchemy.orm.mapped_collection',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.elements',
+      'importer': 'sqlalchemy.orm.mapped_collection',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.expression',
+      'importer': 'sqlalchemy.orm.mapped_collection',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.roles',
+      'importer': 'sqlalchemy.orm.mapped_collection',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.orm.mapped_collection',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util.langhelpers',
+      'importer': 'sqlalchemy.orm.mapped_collection',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util.typing',
+      'importer': 'sqlalchemy.orm.mapped_collection',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine',
+      'importer': 'sqlalchemy.orm.mapper',
+    }),
+    dict({
+      'imported': 'sqlalchemy.event',
+      'importer': 'sqlalchemy.orm.mapper',
+    }),
+    dict({
+      'imported': 'sqlalchemy.exc',
+      'importer': 'sqlalchemy.orm.mapper',
+    }),
+    dict({
+      'imported': 'sqlalchemy.inspection',
+      'importer': 'sqlalchemy.orm.mapper',
+    }),
+    dict({
+      'imported': 'sqlalchemy.log',
+      'importer': 'sqlalchemy.orm.mapper',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm._typing',
+      'importer': 'sqlalchemy.orm.mapper',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.attributes',
+      'importer': 'sqlalchemy.orm.mapper',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.base',
+      'importer': 'sqlalchemy.orm.mapper',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.decl_api',
+      'importer': 'sqlalchemy.orm.mapper',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.dependency',
+      'importer': 'sqlalchemy.orm.mapper',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.descriptor_props',
+      'importer': 'sqlalchemy.orm.mapper',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.events',
+      'importer': 'sqlalchemy.orm.mapper',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.exc',
+      'importer': 'sqlalchemy.orm.mapper',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.instrumentation',
+      'importer': 'sqlalchemy.orm.mapper',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.interfaces',
+      'importer': 'sqlalchemy.orm.mapper',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.loading',
+      'importer': 'sqlalchemy.orm.mapper',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.path_registry',
+      'importer': 'sqlalchemy.orm.mapper',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.properties',
+      'importer': 'sqlalchemy.orm.mapper',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.relationships',
+      'importer': 'sqlalchemy.orm.mapper',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.state',
+      'importer': 'sqlalchemy.orm.mapper',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.util',
+      'importer': 'sqlalchemy.orm.mapper',
+    }),
+    dict({
+      'imported': 'sqlalchemy.schema',
+      'importer': 'sqlalchemy.orm.mapper',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql',
+      'importer': 'sqlalchemy.orm.mapper',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql._typing',
+      'importer': 'sqlalchemy.orm.mapper',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.base',
+      'importer': 'sqlalchemy.orm.mapper',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.cache_key',
+      'importer': 'sqlalchemy.orm.mapper',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.coercions',
+      'importer': 'sqlalchemy.orm.mapper',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.elements',
+      'importer': 'sqlalchemy.orm.mapper',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.expression',
+      'importer': 'sqlalchemy.orm.mapper',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.operators',
+      'importer': 'sqlalchemy.orm.mapper',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.roles',
+      'importer': 'sqlalchemy.orm.mapper',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.schema',
+      'importer': 'sqlalchemy.orm.mapper',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.selectable',
+      'importer': 'sqlalchemy.orm.mapper',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.util',
+      'importer': 'sqlalchemy.orm.mapper',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.visitors',
+      'importer': 'sqlalchemy.orm.mapper',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.orm.mapper',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util.typing',
+      'importer': 'sqlalchemy.orm.mapper',
+    }),
+    dict({
+      'imported': 'sqlalchemy.exc',
+      'importer': 'sqlalchemy.orm.path_registry',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm._typing',
+      'importer': 'sqlalchemy.orm.path_registry',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.base',
+      'importer': 'sqlalchemy.orm.path_registry',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.interfaces',
+      'importer': 'sqlalchemy.orm.path_registry',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.mapper',
+      'importer': 'sqlalchemy.orm.path_registry',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.relationships',
+      'importer': 'sqlalchemy.orm.path_registry',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.util',
+      'importer': 'sqlalchemy.orm.path_registry',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.cache_key',
+      'importer': 'sqlalchemy.orm.path_registry',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.elements',
+      'importer': 'sqlalchemy.orm.path_registry',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.visitors',
+      'importer': 'sqlalchemy.orm.path_registry',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.orm.path_registry',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util.typing',
+      'importer': 'sqlalchemy.orm.path_registry',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.cursor',
+      'importer': 'sqlalchemy.orm.persistence',
+    }),
+    dict({
+      'imported': 'sqlalchemy.exc',
+      'importer': 'sqlalchemy.orm.persistence',
+    }),
+    dict({
+      'imported': 'sqlalchemy.future',
+      'importer': 'sqlalchemy.orm.persistence',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.attributes',
+      'importer': 'sqlalchemy.orm.persistence',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.base',
+      'importer': 'sqlalchemy.orm.persistence',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.exc',
+      'importer': 'sqlalchemy.orm.persistence',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.loading',
+      'importer': 'sqlalchemy.orm.persistence',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.sync',
+      'importer': 'sqlalchemy.orm.persistence',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql',
+      'importer': 'sqlalchemy.orm.persistence',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.elements',
+      'importer': 'sqlalchemy.orm.persistence',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.operators',
+      'importer': 'sqlalchemy.orm.persistence',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.selectable',
+      'importer': 'sqlalchemy.orm.persistence',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.orm.persistence',
+    }),
+    dict({
+      'imported': 'sqlalchemy',
+      'importer': 'sqlalchemy.orm.properties',
+    }),
+    dict({
+      'imported': 'sqlalchemy.exc',
+      'importer': 'sqlalchemy.orm.properties',
+    }),
+    dict({
+      'imported': 'sqlalchemy.log',
+      'importer': 'sqlalchemy.orm.properties',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm._typing',
+      'importer': 'sqlalchemy.orm.properties',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.attributes',
+      'importer': 'sqlalchemy.orm.properties',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.base',
+      'importer': 'sqlalchemy.orm.properties',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.decl_base',
+      'importer': 'sqlalchemy.orm.properties',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.descriptor_props',
+      'importer': 'sqlalchemy.orm.properties',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.interfaces',
+      'importer': 'sqlalchemy.orm.properties',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.mapper',
+      'importer': 'sqlalchemy.orm.properties',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.relationships',
+      'importer': 'sqlalchemy.orm.properties',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.session',
+      'importer': 'sqlalchemy.orm.properties',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.state',
+      'importer': 'sqlalchemy.orm.properties',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.strategy_options',
+      'importer': 'sqlalchemy.orm.properties',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.util',
+      'importer': 'sqlalchemy.orm.properties',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql._typing',
+      'importer': 'sqlalchemy.orm.properties',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.base',
+      'importer': 'sqlalchemy.orm.properties',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.coercions',
+      'importer': 'sqlalchemy.orm.properties',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.elements',
+      'importer': 'sqlalchemy.orm.properties',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.operators',
+      'importer': 'sqlalchemy.orm.properties',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.roles',
+      'importer': 'sqlalchemy.orm.properties',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.schema',
+      'importer': 'sqlalchemy.orm.properties',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.type_api',
+      'importer': 'sqlalchemy.orm.properties',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.orm.properties',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util.typing',
+      'importer': 'sqlalchemy.orm.properties',
+    }),
+    dict({
+      'imported': 'sqlalchemy',
+      'importer': 'sqlalchemy.orm.query',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine',
+      'importer': 'sqlalchemy.orm.query',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.cursor',
+      'importer': 'sqlalchemy.orm.query',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.interfaces',
+      'importer': 'sqlalchemy.orm.query',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.result',
+      'importer': 'sqlalchemy.orm.query',
+    }),
+    dict({
+      'imported': 'sqlalchemy.event',
+      'importer': 'sqlalchemy.orm.query',
+    }),
+    dict({
+      'imported': 'sqlalchemy.exc',
+      'importer': 'sqlalchemy.orm.query',
+    }),
+    dict({
+      'imported': 'sqlalchemy.inspection',
+      'importer': 'sqlalchemy.orm.query',
+    }),
+    dict({
+      'imported': 'sqlalchemy.log',
+      'importer': 'sqlalchemy.orm.query',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm._typing',
+      'importer': 'sqlalchemy.orm.query',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.attributes',
+      'importer': 'sqlalchemy.orm.query',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.base',
+      'importer': 'sqlalchemy.orm.query',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.context',
+      'importer': 'sqlalchemy.orm.query',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.interfaces',
+      'importer': 'sqlalchemy.orm.query',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.loading',
+      'importer': 'sqlalchemy.orm.query',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.mapper',
+      'importer': 'sqlalchemy.orm.query',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.path_registry',
+      'importer': 'sqlalchemy.orm.query',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.session',
+      'importer': 'sqlalchemy.orm.query',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.state',
+      'importer': 'sqlalchemy.orm.query',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.util',
+      'importer': 'sqlalchemy.orm.query',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql',
+      'importer': 'sqlalchemy.orm.query',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql._typing',
+      'importer': 'sqlalchemy.orm.query',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.annotation',
+      'importer': 'sqlalchemy.orm.query',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.base',
+      'importer': 'sqlalchemy.orm.query',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.coercions',
+      'importer': 'sqlalchemy.orm.query',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.elements',
+      'importer': 'sqlalchemy.orm.query',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.expression',
+      'importer': 'sqlalchemy.orm.query',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.roles',
+      'importer': 'sqlalchemy.orm.query',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.selectable',
+      'importer': 'sqlalchemy.orm.query',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.util',
+      'importer': 'sqlalchemy.orm.query',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.visitors',
+      'importer': 'sqlalchemy.orm.query',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.orm.query',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util.typing',
+      'importer': 'sqlalchemy.orm.query',
+    }),
+    dict({
+      'imported': 'sqlalchemy',
+      'importer': 'sqlalchemy.orm.relationships',
+    }),
+    dict({
+      'imported': 'sqlalchemy.exc',
+      'importer': 'sqlalchemy.orm.relationships',
+    }),
+    dict({
+      'imported': 'sqlalchemy.inspection',
+      'importer': 'sqlalchemy.orm.relationships',
+    }),
+    dict({
+      'imported': 'sqlalchemy.log',
+      'importer': 'sqlalchemy.orm.relationships',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm._typing',
+      'importer': 'sqlalchemy.orm.relationships',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.attributes',
+      'importer': 'sqlalchemy.orm.relationships',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.base',
+      'importer': 'sqlalchemy.orm.relationships',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.clsregistry',
+      'importer': 'sqlalchemy.orm.relationships',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.decl_base',
+      'importer': 'sqlalchemy.orm.relationships',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.dependency',
+      'importer': 'sqlalchemy.orm.relationships',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.interfaces',
+      'importer': 'sqlalchemy.orm.relationships',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.mapper',
+      'importer': 'sqlalchemy.orm.relationships',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.query',
+      'importer': 'sqlalchemy.orm.relationships',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.session',
+      'importer': 'sqlalchemy.orm.relationships',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.state',
+      'importer': 'sqlalchemy.orm.relationships',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.strategies',
+      'importer': 'sqlalchemy.orm.relationships',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.strategy_options',
+      'importer': 'sqlalchemy.orm.relationships',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.util',
+      'importer': 'sqlalchemy.orm.relationships',
+    }),
+    dict({
+      'imported': 'sqlalchemy.schema',
+      'importer': 'sqlalchemy.orm.relationships',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql',
+      'importer': 'sqlalchemy.orm.relationships',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql._typing',
+      'importer': 'sqlalchemy.orm.relationships',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.annotation',
+      'importer': 'sqlalchemy.orm.relationships',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.coercions',
+      'importer': 'sqlalchemy.orm.relationships',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.elements',
+      'importer': 'sqlalchemy.orm.relationships',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.expression',
+      'importer': 'sqlalchemy.orm.relationships',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.operators',
+      'importer': 'sqlalchemy.orm.relationships',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.roles',
+      'importer': 'sqlalchemy.orm.relationships',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.schema',
+      'importer': 'sqlalchemy.orm.relationships',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.selectable',
+      'importer': 'sqlalchemy.orm.relationships',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.util',
+      'importer': 'sqlalchemy.orm.relationships',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.visitors',
+      'importer': 'sqlalchemy.orm.relationships',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.orm.relationships',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util.typing',
+      'importer': 'sqlalchemy.orm.relationships',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine',
+      'importer': 'sqlalchemy.orm.scoping',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.interfaces',
+      'importer': 'sqlalchemy.orm.scoping',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.result',
+      'importer': 'sqlalchemy.orm.scoping',
+    }),
+    dict({
+      'imported': 'sqlalchemy.exc',
+      'importer': 'sqlalchemy.orm.scoping',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm._typing',
+      'importer': 'sqlalchemy.orm.scoping',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.identity',
+      'importer': 'sqlalchemy.orm.scoping',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.interfaces',
+      'importer': 'sqlalchemy.orm.scoping',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.mapper',
+      'importer': 'sqlalchemy.orm.scoping',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.query',
+      'importer': 'sqlalchemy.orm.scoping',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.session',
+      'importer': 'sqlalchemy.orm.scoping',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql._typing',
+      'importer': 'sqlalchemy.orm.scoping',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.base',
+      'importer': 'sqlalchemy.orm.scoping',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.dml',
+      'importer': 'sqlalchemy.orm.scoping',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.elements',
+      'importer': 'sqlalchemy.orm.scoping',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.roles',
+      'importer': 'sqlalchemy.orm.scoping',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.selectable',
+      'importer': 'sqlalchemy.orm.scoping',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.orm.scoping',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util.typing',
+      'importer': 'sqlalchemy.orm.scoping',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine',
+      'importer': 'sqlalchemy.orm.session',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.base',
+      'importer': 'sqlalchemy.orm.session',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.interfaces',
+      'importer': 'sqlalchemy.orm.session',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.result',
+      'importer': 'sqlalchemy.orm.session',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.util',
+      'importer': 'sqlalchemy.orm.session',
+    }),
+    dict({
+      'imported': 'sqlalchemy.event',
+      'importer': 'sqlalchemy.orm.session',
+    }),
+    dict({
+      'imported': 'sqlalchemy.exc',
+      'importer': 'sqlalchemy.orm.session',
+    }),
+    dict({
+      'imported': 'sqlalchemy.inspection',
+      'importer': 'sqlalchemy.orm.session',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm._typing',
+      'importer': 'sqlalchemy.orm.session',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.attributes',
+      'importer': 'sqlalchemy.orm.session',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.base',
+      'importer': 'sqlalchemy.orm.session',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.bulk_persistence',
+      'importer': 'sqlalchemy.orm.session',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.context',
+      'importer': 'sqlalchemy.orm.session',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.descriptor_props',
+      'importer': 'sqlalchemy.orm.session',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.exc',
+      'importer': 'sqlalchemy.orm.session',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.identity',
+      'importer': 'sqlalchemy.orm.session',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.interfaces',
+      'importer': 'sqlalchemy.orm.session',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.loading',
+      'importer': 'sqlalchemy.orm.session',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.mapper',
+      'importer': 'sqlalchemy.orm.session',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.path_registry',
+      'importer': 'sqlalchemy.orm.session',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.query',
+      'importer': 'sqlalchemy.orm.session',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.state',
+      'importer': 'sqlalchemy.orm.session',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.state_changes',
+      'importer': 'sqlalchemy.orm.session',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.unitofwork',
+      'importer': 'sqlalchemy.orm.session',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql',
+      'importer': 'sqlalchemy.orm.session',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql._typing',
+      'importer': 'sqlalchemy.orm.session',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.base',
+      'importer': 'sqlalchemy.orm.session',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.coercions',
+      'importer': 'sqlalchemy.orm.session',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.dml',
+      'importer': 'sqlalchemy.orm.session',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.elements',
+      'importer': 'sqlalchemy.orm.session',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.roles',
+      'importer': 'sqlalchemy.orm.session',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.schema',
+      'importer': 'sqlalchemy.orm.session',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.selectable',
+      'importer': 'sqlalchemy.orm.session',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.visitors',
+      'importer': 'sqlalchemy.orm.session',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.orm.session',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util.typing',
+      'importer': 'sqlalchemy.orm.session',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine',
+      'importer': 'sqlalchemy.orm.state',
+    }),
+    dict({
+      'imported': 'sqlalchemy.exc',
+      'importer': 'sqlalchemy.orm.state',
+    }),
+    dict({
+      'imported': 'sqlalchemy.ext.asyncio.session',
+      'importer': 'sqlalchemy.orm.state',
+    }),
+    dict({
+      'imported': 'sqlalchemy.inspection',
+      'importer': 'sqlalchemy.orm.state',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm._typing',
+      'importer': 'sqlalchemy.orm.state',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.attributes',
+      'importer': 'sqlalchemy.orm.state',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.base',
+      'importer': 'sqlalchemy.orm.state',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.collections',
+      'importer': 'sqlalchemy.orm.state',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.exc',
+      'importer': 'sqlalchemy.orm.state',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.identity',
+      'importer': 'sqlalchemy.orm.state',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.instrumentation',
+      'importer': 'sqlalchemy.orm.state',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.interfaces',
+      'importer': 'sqlalchemy.orm.state',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.mapper',
+      'importer': 'sqlalchemy.orm.state',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.path_registry',
+      'importer': 'sqlalchemy.orm.state',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.session',
+      'importer': 'sqlalchemy.orm.state',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.orm.state',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util.typing',
+      'importer': 'sqlalchemy.orm.state',
+    }),
+    dict({
+      'imported': 'sqlalchemy.exc',
+      'importer': 'sqlalchemy.orm.state_changes',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.orm.state_changes',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util.typing',
+      'importer': 'sqlalchemy.orm.state_changes',
+    }),
+    dict({
+      'imported': 'sqlalchemy',
+      'importer': 'sqlalchemy.orm.strategies',
+    }),
+    dict({
+      'imported': 'sqlalchemy.event',
+      'importer': 'sqlalchemy.orm.strategies',
+    }),
+    dict({
+      'imported': 'sqlalchemy.exc',
+      'importer': 'sqlalchemy.orm.strategies',
+    }),
+    dict({
+      'imported': 'sqlalchemy.log',
+      'importer': 'sqlalchemy.orm.strategies',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.attributes',
+      'importer': 'sqlalchemy.orm.strategies',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.base',
+      'importer': 'sqlalchemy.orm.strategies',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.context',
+      'importer': 'sqlalchemy.orm.strategies',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.exc',
+      'importer': 'sqlalchemy.orm.strategies',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.interfaces',
+      'importer': 'sqlalchemy.orm.strategies',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.loading',
+      'importer': 'sqlalchemy.orm.strategies',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.path_registry',
+      'importer': 'sqlalchemy.orm.strategies',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.properties',
+      'importer': 'sqlalchemy.orm.strategies',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.query',
+      'importer': 'sqlalchemy.orm.strategies',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.relationships',
+      'importer': 'sqlalchemy.orm.strategies',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.session',
+      'importer': 'sqlalchemy.orm.strategies',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.state',
+      'importer': 'sqlalchemy.orm.strategies',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.strategy_options',
+      'importer': 'sqlalchemy.orm.strategies',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.unitofwork',
+      'importer': 'sqlalchemy.orm.strategies',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.util',
+      'importer': 'sqlalchemy.orm.strategies',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql',
+      'importer': 'sqlalchemy.orm.strategies',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.elements',
+      'importer': 'sqlalchemy.orm.strategies',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.selectable',
+      'importer': 'sqlalchemy.orm.strategies',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.util',
+      'importer': 'sqlalchemy.orm.strategies',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.visitors',
+      'importer': 'sqlalchemy.orm.strategies',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.orm.strategies',
+    }),
+    dict({
+      'imported': 'sqlalchemy',
+      'importer': 'sqlalchemy.orm.strategy_options',
+    }),
+    dict({
+      'imported': 'sqlalchemy.exc',
+      'importer': 'sqlalchemy.orm.strategy_options',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm._typing',
+      'importer': 'sqlalchemy.orm.strategy_options',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.attributes',
+      'importer': 'sqlalchemy.orm.strategy_options',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.base',
+      'importer': 'sqlalchemy.orm.strategy_options',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.context',
+      'importer': 'sqlalchemy.orm.strategy_options',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.interfaces',
+      'importer': 'sqlalchemy.orm.strategy_options',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.mapper',
+      'importer': 'sqlalchemy.orm.strategy_options',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.path_registry',
+      'importer': 'sqlalchemy.orm.strategy_options',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.util',
+      'importer': 'sqlalchemy.orm.strategy_options',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql',
+      'importer': 'sqlalchemy.orm.strategy_options',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql._typing',
+      'importer': 'sqlalchemy.orm.strategy_options',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.base',
+      'importer': 'sqlalchemy.orm.strategy_options',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.cache_key',
+      'importer': 'sqlalchemy.orm.strategy_options',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.coercions',
+      'importer': 'sqlalchemy.orm.strategy_options',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.roles',
+      'importer': 'sqlalchemy.orm.strategy_options',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.traversals',
+      'importer': 'sqlalchemy.orm.strategy_options',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.visitors',
+      'importer': 'sqlalchemy.orm.strategy_options',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.orm.strategy_options',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util.typing',
+      'importer': 'sqlalchemy.orm.strategy_options',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.base',
+      'importer': 'sqlalchemy.orm.sync',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.exc',
+      'importer': 'sqlalchemy.orm.sync',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.util',
+      'importer': 'sqlalchemy.orm.sync',
+    }),
+    dict({
+      'imported': 'sqlalchemy.event',
+      'importer': 'sqlalchemy.orm.unitofwork',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.attributes',
+      'importer': 'sqlalchemy.orm.unitofwork',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.dependency',
+      'importer': 'sqlalchemy.orm.unitofwork',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.exc',
+      'importer': 'sqlalchemy.orm.unitofwork',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.interfaces',
+      'importer': 'sqlalchemy.orm.unitofwork',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.mapper',
+      'importer': 'sqlalchemy.orm.unitofwork',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.session',
+      'importer': 'sqlalchemy.orm.unitofwork',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.state',
+      'importer': 'sqlalchemy.orm.unitofwork',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.util',
+      'importer': 'sqlalchemy.orm.unitofwork',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.orm.unitofwork',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util.topological',
+      'importer': 'sqlalchemy.orm.unitofwork',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine',
+      'importer': 'sqlalchemy.orm.util',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.result',
+      'importer': 'sqlalchemy.orm.util',
+    }),
+    dict({
+      'imported': 'sqlalchemy.event',
+      'importer': 'sqlalchemy.orm.util',
+    }),
+    dict({
+      'imported': 'sqlalchemy.exc',
+      'importer': 'sqlalchemy.orm.util',
+    }),
+    dict({
+      'imported': 'sqlalchemy.inspection',
+      'importer': 'sqlalchemy.orm.util',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm._typing',
+      'importer': 'sqlalchemy.orm.util',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.attributes',
+      'importer': 'sqlalchemy.orm.util',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.base',
+      'importer': 'sqlalchemy.orm.util',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.context',
+      'importer': 'sqlalchemy.orm.util',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.exc',
+      'importer': 'sqlalchemy.orm.util',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.interfaces',
+      'importer': 'sqlalchemy.orm.util',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.mapper',
+      'importer': 'sqlalchemy.orm.util',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.path_registry',
+      'importer': 'sqlalchemy.orm.util',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.query',
+      'importer': 'sqlalchemy.orm.util',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.relationships',
+      'importer': 'sqlalchemy.orm.util',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql',
+      'importer': 'sqlalchemy.orm.util',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql._typing',
+      'importer': 'sqlalchemy.orm.util',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.annotation',
+      'importer': 'sqlalchemy.orm.util',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.base',
+      'importer': 'sqlalchemy.orm.util',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.cache_key',
+      'importer': 'sqlalchemy.orm.util',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.coercions',
+      'importer': 'sqlalchemy.orm.util',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.elements',
+      'importer': 'sqlalchemy.orm.util',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.expression',
+      'importer': 'sqlalchemy.orm.util',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.lambdas',
+      'importer': 'sqlalchemy.orm.util',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.roles',
+      'importer': 'sqlalchemy.orm.util',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.selectable',
+      'importer': 'sqlalchemy.orm.util',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.util',
+      'importer': 'sqlalchemy.orm.util',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.visitors',
+      'importer': 'sqlalchemy.orm.util',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.orm.util',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util.langhelpers',
+      'importer': 'sqlalchemy.orm.util',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util.typing',
+      'importer': 'sqlalchemy.orm.util',
+    }),
+    dict({
+      'imported': 'sqlalchemy',
+      'importer': 'sqlalchemy.orm.writeonly',
+    }),
+    dict({
+      'imported': 'sqlalchemy.event',
+      'importer': 'sqlalchemy.orm.writeonly',
+    }),
+    dict({
+      'imported': 'sqlalchemy.exc',
+      'importer': 'sqlalchemy.orm.writeonly',
+    }),
+    dict({
+      'imported': 'sqlalchemy.log',
+      'importer': 'sqlalchemy.orm.writeonly',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm',
+      'importer': 'sqlalchemy.orm.writeonly',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm._typing',
+      'importer': 'sqlalchemy.orm.writeonly',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.attributes',
+      'importer': 'sqlalchemy.orm.writeonly',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.base',
+      'importer': 'sqlalchemy.orm.writeonly',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.collections',
+      'importer': 'sqlalchemy.orm.writeonly',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.interfaces',
+      'importer': 'sqlalchemy.orm.writeonly',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.mapper',
+      'importer': 'sqlalchemy.orm.writeonly',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.relationships',
+      'importer': 'sqlalchemy.orm.writeonly',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.state',
+      'importer': 'sqlalchemy.orm.writeonly',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.strategies',
+      'importer': 'sqlalchemy.orm.writeonly',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.util',
+      'importer': 'sqlalchemy.orm.writeonly',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql',
+      'importer': 'sqlalchemy.orm.writeonly',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.dml',
+      'importer': 'sqlalchemy.orm.writeonly',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.selectable',
+      'importer': 'sqlalchemy.orm.writeonly',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.orm.writeonly',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util.typing',
+      'importer': 'sqlalchemy.orm.writeonly',
+    }),
+    dict({
+      'imported': 'sqlalchemy.pool.base',
+      'importer': 'sqlalchemy.pool',
+    }),
+    dict({
+      'imported': 'sqlalchemy.pool.events',
+      'importer': 'sqlalchemy.pool',
+    }),
+    dict({
+      'imported': 'sqlalchemy.pool.impl',
+      'importer': 'sqlalchemy.pool',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.interfaces',
+      'importer': 'sqlalchemy.pool.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.event',
+      'importer': 'sqlalchemy.pool.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.exc',
+      'importer': 'sqlalchemy.pool.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.log',
+      'importer': 'sqlalchemy.pool.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql._typing',
+      'importer': 'sqlalchemy.pool.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.pool.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util.typing',
+      'importer': 'sqlalchemy.pool.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine',
+      'importer': 'sqlalchemy.pool.events',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.interfaces',
+      'importer': 'sqlalchemy.pool.events',
+    }),
+    dict({
+      'imported': 'sqlalchemy.event',
+      'importer': 'sqlalchemy.pool.events',
+    }),
+    dict({
+      'imported': 'sqlalchemy.pool.base',
+      'importer': 'sqlalchemy.pool.events',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.pool.events',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.interfaces',
+      'importer': 'sqlalchemy.pool.impl',
+    }),
+    dict({
+      'imported': 'sqlalchemy.exc',
+      'importer': 'sqlalchemy.pool.impl',
+    }),
+    dict({
+      'imported': 'sqlalchemy.pool.base',
+      'importer': 'sqlalchemy.pool.impl',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.pool.impl',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util.queue',
+      'importer': 'sqlalchemy.pool.impl',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util.typing',
+      'importer': 'sqlalchemy.pool.impl',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.base',
+      'importer': 'sqlalchemy.schema',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.ddl',
+      'importer': 'sqlalchemy.schema',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.naming',
+      'importer': 'sqlalchemy.schema',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.schema',
+      'importer': 'sqlalchemy.schema',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql._typing',
+      'importer': 'sqlalchemy.sql',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.annotation',
+      'importer': 'sqlalchemy.sql',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.base',
+      'importer': 'sqlalchemy.sql',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.coercions',
+      'importer': 'sqlalchemy.sql',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.compiler',
+      'importer': 'sqlalchemy.sql',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.ddl',
+      'importer': 'sqlalchemy.sql',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.elements',
+      'importer': 'sqlalchemy.sql',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.expression',
+      'importer': 'sqlalchemy.sql',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.lambdas',
+      'importer': 'sqlalchemy.sql',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.schema',
+      'importer': 'sqlalchemy.sql',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.selectable',
+      'importer': 'sqlalchemy.sql',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.traversals',
+      'importer': 'sqlalchemy.sql',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.type_api',
+      'importer': 'sqlalchemy.sql',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.visitors',
+      'importer': 'sqlalchemy.sql',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.sql',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql._typing',
+      'importer': 'sqlalchemy.sql._dml_constructors',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.dml',
+      'importer': 'sqlalchemy.sql._dml_constructors',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql._typing',
+      'importer': 'sqlalchemy.sql._elements_constructors',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.base',
+      'importer': 'sqlalchemy.sql._elements_constructors',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.coercions',
+      'importer': 'sqlalchemy.sql._elements_constructors',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.elements',
+      'importer': 'sqlalchemy.sql._elements_constructors',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.functions',
+      'importer': 'sqlalchemy.sql._elements_constructors',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.roles',
+      'importer': 'sqlalchemy.sql._elements_constructors',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.selectable',
+      'importer': 'sqlalchemy.sql._elements_constructors',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.type_api',
+      'importer': 'sqlalchemy.sql._elements_constructors',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util.typing',
+      'importer': 'sqlalchemy.sql._elements_constructors',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util.typing',
+      'importer': 'sqlalchemy.sql._orm_types',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.cache_key',
+      'importer': 'sqlalchemy.sql._py_util',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util.typing',
+      'importer': 'sqlalchemy.sql._py_util',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql._typing',
+      'importer': 'sqlalchemy.sql._selectable_constructors',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.coercions',
+      'importer': 'sqlalchemy.sql._selectable_constructors',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.elements',
+      'importer': 'sqlalchemy.sql._selectable_constructors',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.functions',
+      'importer': 'sqlalchemy.sql._selectable_constructors',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.roles',
+      'importer': 'sqlalchemy.sql._selectable_constructors',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.selectable',
+      'importer': 'sqlalchemy.sql._selectable_constructors',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine',
+      'importer': 'sqlalchemy.sql._typing',
+    }),
+    dict({
+      'imported': 'sqlalchemy.exc',
+      'importer': 'sqlalchemy.sql._typing',
+    }),
+    dict({
+      'imported': 'sqlalchemy.inspection',
+      'importer': 'sqlalchemy.sql._typing',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.base',
+      'importer': 'sqlalchemy.sql._typing',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.compiler',
+      'importer': 'sqlalchemy.sql._typing',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.dml',
+      'importer': 'sqlalchemy.sql._typing',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.elements',
+      'importer': 'sqlalchemy.sql._typing',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.lambdas',
+      'importer': 'sqlalchemy.sql._typing',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.roles',
+      'importer': 'sqlalchemy.sql._typing',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.schema',
+      'importer': 'sqlalchemy.sql._typing',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.selectable',
+      'importer': 'sqlalchemy.sql._typing',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.sqltypes',
+      'importer': 'sqlalchemy.sql._typing',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.type_api',
+      'importer': 'sqlalchemy.sql._typing',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.sql._typing',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util.typing',
+      'importer': 'sqlalchemy.sql._typing',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.base',
+      'importer': 'sqlalchemy.sql.annotation',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.cache_key',
+      'importer': 'sqlalchemy.sql.annotation',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.operators',
+      'importer': 'sqlalchemy.sql.annotation',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.visitors',
+      'importer': 'sqlalchemy.sql.annotation',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.sql.annotation',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util.typing',
+      'importer': 'sqlalchemy.sql.annotation',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine',
+      'importer': 'sqlalchemy.sql.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.interfaces',
+      'importer': 'sqlalchemy.sql.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.event',
+      'importer': 'sqlalchemy.sql.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.exc',
+      'importer': 'sqlalchemy.sql.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql._orm_types',
+      'importer': 'sqlalchemy.sql.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql._typing',
+      'importer': 'sqlalchemy.sql.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.cache_key',
+      'importer': 'sqlalchemy.sql.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.coercions',
+      'importer': 'sqlalchemy.sql.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.elements',
+      'importer': 'sqlalchemy.sql.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.roles',
+      'importer': 'sqlalchemy.sql.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.schema',
+      'importer': 'sqlalchemy.sql.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.selectable',
+      'importer': 'sqlalchemy.sql.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.traversals',
+      'importer': 'sqlalchemy.sql.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.type_api',
+      'importer': 'sqlalchemy.sql.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.visitors',
+      'importer': 'sqlalchemy.sql.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.sql.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util.typing',
+      'importer': 'sqlalchemy.sql.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.interfaces',
+      'importer': 'sqlalchemy.sql.cache_key',
+    }),
+    dict({
+      'imported': 'sqlalchemy.inspection',
+      'importer': 'sqlalchemy.sql.cache_key',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.elements',
+      'importer': 'sqlalchemy.sql.cache_key',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.visitors',
+      'importer': 'sqlalchemy.sql.cache_key',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.sql.cache_key',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util.typing',
+      'importer': 'sqlalchemy.sql.cache_key',
+    }),
+    dict({
+      'imported': 'sqlalchemy.exc',
+      'importer': 'sqlalchemy.sql.coercions',
+    }),
+    dict({
+      'imported': 'sqlalchemy.inspection',
+      'importer': 'sqlalchemy.sql.coercions',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql._typing',
+      'importer': 'sqlalchemy.sql.coercions',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.base',
+      'importer': 'sqlalchemy.sql.coercions',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.cache_key',
+      'importer': 'sqlalchemy.sql.coercions',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.dml',
+      'importer': 'sqlalchemy.sql.coercions',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.elements',
+      'importer': 'sqlalchemy.sql.coercions',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.lambdas',
+      'importer': 'sqlalchemy.sql.coercions',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.operators',
+      'importer': 'sqlalchemy.sql.coercions',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.roles',
+      'importer': 'sqlalchemy.sql.coercions',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.schema',
+      'importer': 'sqlalchemy.sql.coercions',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.selectable',
+      'importer': 'sqlalchemy.sql.coercions',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.util',
+      'importer': 'sqlalchemy.sql.coercions',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.visitors',
+      'importer': 'sqlalchemy.sql.coercions',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.sql.coercions',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util.typing',
+      'importer': 'sqlalchemy.sql.coercions',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.cursor',
+      'importer': 'sqlalchemy.sql.compiler',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.interfaces',
+      'importer': 'sqlalchemy.sql.compiler',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.result',
+      'importer': 'sqlalchemy.sql.compiler',
+    }),
+    dict({
+      'imported': 'sqlalchemy.exc',
+      'importer': 'sqlalchemy.sql.compiler',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql._typing',
+      'importer': 'sqlalchemy.sql.compiler',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.annotation',
+      'importer': 'sqlalchemy.sql.compiler',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.base',
+      'importer': 'sqlalchemy.sql.compiler',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.cache_key',
+      'importer': 'sqlalchemy.sql.compiler',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.coercions',
+      'importer': 'sqlalchemy.sql.compiler',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.crud',
+      'importer': 'sqlalchemy.sql.compiler',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.ddl',
+      'importer': 'sqlalchemy.sql.compiler',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.dml',
+      'importer': 'sqlalchemy.sql.compiler',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.elements',
+      'importer': 'sqlalchemy.sql.compiler',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.functions',
+      'importer': 'sqlalchemy.sql.compiler',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.operators',
+      'importer': 'sqlalchemy.sql.compiler',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.roles',
+      'importer': 'sqlalchemy.sql.compiler',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.schema',
+      'importer': 'sqlalchemy.sql.compiler',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.selectable',
+      'importer': 'sqlalchemy.sql.compiler',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.sqltypes',
+      'importer': 'sqlalchemy.sql.compiler',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.type_api',
+      'importer': 'sqlalchemy.sql.compiler',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.util',
+      'importer': 'sqlalchemy.sql.compiler',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.visitors',
+      'importer': 'sqlalchemy.sql.compiler',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.sql.compiler',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util.typing',
+      'importer': 'sqlalchemy.sql.compiler',
+    }),
+    dict({
+      'imported': 'sqlalchemy.exc',
+      'importer': 'sqlalchemy.sql.crud',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.base',
+      'importer': 'sqlalchemy.sql.crud',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.coercions',
+      'importer': 'sqlalchemy.sql.crud',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.compiler',
+      'importer': 'sqlalchemy.sql.crud',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.dml',
+      'importer': 'sqlalchemy.sql.crud',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.elements',
+      'importer': 'sqlalchemy.sql.crud',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.roles',
+      'importer': 'sqlalchemy.sql.crud',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.schema',
+      'importer': 'sqlalchemy.sql.crud',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.selectable',
+      'importer': 'sqlalchemy.sql.crud',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.sql.crud',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util.typing',
+      'importer': 'sqlalchemy.sql.crud',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.base',
+      'importer': 'sqlalchemy.sql.ddl',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.interfaces',
+      'importer': 'sqlalchemy.sql.ddl',
+    }),
+    dict({
+      'imported': 'sqlalchemy.exc',
+      'importer': 'sqlalchemy.sql.ddl',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.base',
+      'importer': 'sqlalchemy.sql.ddl',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.compiler',
+      'importer': 'sqlalchemy.sql.ddl',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.elements',
+      'importer': 'sqlalchemy.sql.ddl',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.roles',
+      'importer': 'sqlalchemy.sql.ddl',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.schema',
+      'importer': 'sqlalchemy.sql.ddl',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.selectable',
+      'importer': 'sqlalchemy.sql.ddl',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.sql.ddl',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util.topological',
+      'importer': 'sqlalchemy.sql.ddl',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util.typing',
+      'importer': 'sqlalchemy.sql.ddl',
+    }),
+    dict({
+      'imported': 'sqlalchemy.exc',
+      'importer': 'sqlalchemy.sql.default_comparator',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.coercions',
+      'importer': 'sqlalchemy.sql.default_comparator',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.elements',
+      'importer': 'sqlalchemy.sql.default_comparator',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.operators',
+      'importer': 'sqlalchemy.sql.default_comparator',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.roles',
+      'importer': 'sqlalchemy.sql.default_comparator',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.type_api',
+      'importer': 'sqlalchemy.sql.default_comparator',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.sql.default_comparator',
+    }),
+    dict({
+      'imported': 'sqlalchemy.exc',
+      'importer': 'sqlalchemy.sql.dml',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql._typing',
+      'importer': 'sqlalchemy.sql.dml',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.base',
+      'importer': 'sqlalchemy.sql.dml',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.coercions',
+      'importer': 'sqlalchemy.sql.dml',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.compiler',
+      'importer': 'sqlalchemy.sql.dml',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.elements',
+      'importer': 'sqlalchemy.sql.dml',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.roles',
+      'importer': 'sqlalchemy.sql.dml',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.selectable',
+      'importer': 'sqlalchemy.sql.dml',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.sqltypes',
+      'importer': 'sqlalchemy.sql.dml',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.util',
+      'importer': 'sqlalchemy.sql.dml',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.visitors',
+      'importer': 'sqlalchemy.sql.dml',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.sql.dml',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util.typing',
+      'importer': 'sqlalchemy.sql.dml',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine',
+      'importer': 'sqlalchemy.sql.elements',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.interfaces',
+      'importer': 'sqlalchemy.sql.elements',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.result',
+      'importer': 'sqlalchemy.sql.elements',
+    }),
+    dict({
+      'imported': 'sqlalchemy.exc',
+      'importer': 'sqlalchemy.sql.elements',
+    }),
+    dict({
+      'imported': 'sqlalchemy.inspection',
+      'importer': 'sqlalchemy.sql.elements',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql._typing',
+      'importer': 'sqlalchemy.sql.elements',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.annotation',
+      'importer': 'sqlalchemy.sql.elements',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.base',
+      'importer': 'sqlalchemy.sql.elements',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.cache_key',
+      'importer': 'sqlalchemy.sql.elements',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.coercions',
+      'importer': 'sqlalchemy.sql.elements',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.compiler',
+      'importer': 'sqlalchemy.sql.elements',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.functions',
+      'importer': 'sqlalchemy.sql.elements',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.operators',
+      'importer': 'sqlalchemy.sql.elements',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.roles',
+      'importer': 'sqlalchemy.sql.elements',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.schema',
+      'importer': 'sqlalchemy.sql.elements',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.selectable',
+      'importer': 'sqlalchemy.sql.elements',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.sqltypes',
+      'importer': 'sqlalchemy.sql.elements',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.traversals',
+      'importer': 'sqlalchemy.sql.elements',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.type_api',
+      'importer': 'sqlalchemy.sql.elements',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.visitors',
+      'importer': 'sqlalchemy.sql.elements',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.sql.elements',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util.typing',
+      'importer': 'sqlalchemy.sql.elements',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.base',
+      'importer': 'sqlalchemy.sql.events',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.interfaces',
+      'importer': 'sqlalchemy.sql.events',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.reflection',
+      'importer': 'sqlalchemy.sql.events',
+    }),
+    dict({
+      'imported': 'sqlalchemy.event',
+      'importer': 'sqlalchemy.sql.events',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.base',
+      'importer': 'sqlalchemy.sql.events',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.schema',
+      'importer': 'sqlalchemy.sql.events',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql._dml_constructors',
+      'importer': 'sqlalchemy.sql.expression',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql._elements_constructors',
+      'importer': 'sqlalchemy.sql.expression',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql._selectable_constructors',
+      'importer': 'sqlalchemy.sql.expression',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql._typing',
+      'importer': 'sqlalchemy.sql.expression',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.base',
+      'importer': 'sqlalchemy.sql.expression',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.cache_key',
+      'importer': 'sqlalchemy.sql.expression',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.dml',
+      'importer': 'sqlalchemy.sql.expression',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.elements',
+      'importer': 'sqlalchemy.sql.expression',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.functions',
+      'importer': 'sqlalchemy.sql.expression',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.lambdas',
+      'importer': 'sqlalchemy.sql.expression',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.operators',
+      'importer': 'sqlalchemy.sql.expression',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.selectable',
+      'importer': 'sqlalchemy.sql.expression',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.visitors',
+      'importer': 'sqlalchemy.sql.expression',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.base',
+      'importer': 'sqlalchemy.sql.functions',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.cursor',
+      'importer': 'sqlalchemy.sql.functions',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.interfaces',
+      'importer': 'sqlalchemy.sql.functions',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql._typing',
+      'importer': 'sqlalchemy.sql.functions',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.annotation',
+      'importer': 'sqlalchemy.sql.functions',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.base',
+      'importer': 'sqlalchemy.sql.functions',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.coercions',
+      'importer': 'sqlalchemy.sql.functions',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.elements',
+      'importer': 'sqlalchemy.sql.functions',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.operators',
+      'importer': 'sqlalchemy.sql.functions',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.roles',
+      'importer': 'sqlalchemy.sql.functions',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.schema',
+      'importer': 'sqlalchemy.sql.functions',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.selectable',
+      'importer': 'sqlalchemy.sql.functions',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.sqltypes',
+      'importer': 'sqlalchemy.sql.functions',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.type_api',
+      'importer': 'sqlalchemy.sql.functions',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.util',
+      'importer': 'sqlalchemy.sql.functions',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.visitors',
+      'importer': 'sqlalchemy.sql.functions',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.sql.functions',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util.typing',
+      'importer': 'sqlalchemy.sql.functions',
+    }),
+    dict({
+      'imported': 'sqlalchemy.exc',
+      'importer': 'sqlalchemy.sql.lambdas',
+    }),
+    dict({
+      'imported': 'sqlalchemy.inspection',
+      'importer': 'sqlalchemy.sql.lambdas',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.base',
+      'importer': 'sqlalchemy.sql.lambdas',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.cache_key',
+      'importer': 'sqlalchemy.sql.lambdas',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.coercions',
+      'importer': 'sqlalchemy.sql.lambdas',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.elements',
+      'importer': 'sqlalchemy.sql.lambdas',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.operators',
+      'importer': 'sqlalchemy.sql.lambdas',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.roles',
+      'importer': 'sqlalchemy.sql.lambdas',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.schema',
+      'importer': 'sqlalchemy.sql.lambdas',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.visitors',
+      'importer': 'sqlalchemy.sql.lambdas',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.sql.lambdas',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util.typing',
+      'importer': 'sqlalchemy.sql.lambdas',
+    }),
+    dict({
+      'imported': 'sqlalchemy.event',
+      'importer': 'sqlalchemy.sql.naming',
+    }),
+    dict({
+      'imported': 'sqlalchemy.exc',
+      'importer': 'sqlalchemy.sql.naming',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.base',
+      'importer': 'sqlalchemy.sql.naming',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.elements',
+      'importer': 'sqlalchemy.sql.naming',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.events',
+      'importer': 'sqlalchemy.sql.naming',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.schema',
+      'importer': 'sqlalchemy.sql.naming',
+    }),
+    dict({
+      'imported': 'sqlalchemy.exc',
+      'importer': 'sqlalchemy.sql.operators',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql._typing',
+      'importer': 'sqlalchemy.sql.operators',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.cache_key',
+      'importer': 'sqlalchemy.sql.operators',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.elements',
+      'importer': 'sqlalchemy.sql.operators',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.type_api',
+      'importer': 'sqlalchemy.sql.operators',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.sql.operators',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util.typing',
+      'importer': 'sqlalchemy.sql.operators',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql._typing',
+      'importer': 'sqlalchemy.sql.roles',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.elements',
+      'importer': 'sqlalchemy.sql.roles',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.selectable',
+      'importer': 'sqlalchemy.sql.roles',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.sql.roles',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util.typing',
+      'importer': 'sqlalchemy.sql.roles',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine',
+      'importer': 'sqlalchemy.sql.schema',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.interfaces',
+      'importer': 'sqlalchemy.sql.schema',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.mock',
+      'importer': 'sqlalchemy.sql.schema',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.reflection',
+      'importer': 'sqlalchemy.sql.schema',
+    }),
+    dict({
+      'imported': 'sqlalchemy.event',
+      'importer': 'sqlalchemy.sql.schema',
+    }),
+    dict({
+      'imported': 'sqlalchemy.exc',
+      'importer': 'sqlalchemy.sql.schema',
+    }),
+    dict({
+      'imported': 'sqlalchemy.inspection',
+      'importer': 'sqlalchemy.sql.schema',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql._typing',
+      'importer': 'sqlalchemy.sql.schema',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.base',
+      'importer': 'sqlalchemy.sql.schema',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.coercions',
+      'importer': 'sqlalchemy.sql.schema',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.compiler',
+      'importer': 'sqlalchemy.sql.schema',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.ddl',
+      'importer': 'sqlalchemy.sql.schema',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.elements',
+      'importer': 'sqlalchemy.sql.schema',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.functions',
+      'importer': 'sqlalchemy.sql.schema',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.roles',
+      'importer': 'sqlalchemy.sql.schema',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.selectable',
+      'importer': 'sqlalchemy.sql.schema',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.type_api',
+      'importer': 'sqlalchemy.sql.schema',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.visitors',
+      'importer': 'sqlalchemy.sql.schema',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.sql.schema',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util.typing',
+      'importer': 'sqlalchemy.sql.schema',
+    }),
+    dict({
+      'imported': 'sqlalchemy.exc',
+      'importer': 'sqlalchemy.sql.selectable',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql._typing',
+      'importer': 'sqlalchemy.sql.selectable',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.annotation',
+      'importer': 'sqlalchemy.sql.selectable',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.base',
+      'importer': 'sqlalchemy.sql.selectable',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.cache_key',
+      'importer': 'sqlalchemy.sql.selectable',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.coercions',
+      'importer': 'sqlalchemy.sql.selectable',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.compiler',
+      'importer': 'sqlalchemy.sql.selectable',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.dml',
+      'importer': 'sqlalchemy.sql.selectable',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.elements',
+      'importer': 'sqlalchemy.sql.selectable',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.functions',
+      'importer': 'sqlalchemy.sql.selectable',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.operators',
+      'importer': 'sqlalchemy.sql.selectable',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.roles',
+      'importer': 'sqlalchemy.sql.selectable',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.schema',
+      'importer': 'sqlalchemy.sql.selectable',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.sqltypes',
+      'importer': 'sqlalchemy.sql.selectable',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.traversals',
+      'importer': 'sqlalchemy.sql.selectable',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.type_api',
+      'importer': 'sqlalchemy.sql.selectable',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.visitors',
+      'importer': 'sqlalchemy.sql.selectable',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.sql.selectable',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util.typing',
+      'importer': 'sqlalchemy.sql.selectable',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.interfaces',
+      'importer': 'sqlalchemy.sql.sqltypes',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.processors',
+      'importer': 'sqlalchemy.sql.sqltypes',
+    }),
+    dict({
+      'imported': 'sqlalchemy.event',
+      'importer': 'sqlalchemy.sql.sqltypes',
+    }),
+    dict({
+      'imported': 'sqlalchemy.exc',
+      'importer': 'sqlalchemy.sql.sqltypes',
+    }),
+    dict({
+      'imported': 'sqlalchemy.inspection',
+      'importer': 'sqlalchemy.sql.sqltypes',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql._typing',
+      'importer': 'sqlalchemy.sql.sqltypes',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.base',
+      'importer': 'sqlalchemy.sql.sqltypes',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.cache_key',
+      'importer': 'sqlalchemy.sql.sqltypes',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.coercions',
+      'importer': 'sqlalchemy.sql.sqltypes',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.elements',
+      'importer': 'sqlalchemy.sql.sqltypes',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.operators',
+      'importer': 'sqlalchemy.sql.sqltypes',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.roles',
+      'importer': 'sqlalchemy.sql.sqltypes',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.schema',
+      'importer': 'sqlalchemy.sql.sqltypes',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.type_api',
+      'importer': 'sqlalchemy.sql.sqltypes',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.visitors',
+      'importer': 'sqlalchemy.sql.sqltypes',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.sql.sqltypes',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util.langhelpers',
+      'importer': 'sqlalchemy.sql.sqltypes',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util.typing',
+      'importer': 'sqlalchemy.sql.sqltypes',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.cache_key',
+      'importer': 'sqlalchemy.sql.traversals',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.operators',
+      'importer': 'sqlalchemy.sql.traversals',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.visitors',
+      'importer': 'sqlalchemy.sql.traversals',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.sql.traversals',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util.langhelpers',
+      'importer': 'sqlalchemy.sql.traversals',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util.typing',
+      'importer': 'sqlalchemy.sql.traversals',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.interfaces',
+      'importer': 'sqlalchemy.sql.type_api',
+    }),
+    dict({
+      'imported': 'sqlalchemy.exc',
+      'importer': 'sqlalchemy.sql.type_api',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql._typing',
+      'importer': 'sqlalchemy.sql.type_api',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.base',
+      'importer': 'sqlalchemy.sql.type_api',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.cache_key',
+      'importer': 'sqlalchemy.sql.type_api',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.elements',
+      'importer': 'sqlalchemy.sql.type_api',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.operators',
+      'importer': 'sqlalchemy.sql.type_api',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.sqltypes',
+      'importer': 'sqlalchemy.sql.type_api',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.visitors',
+      'importer': 'sqlalchemy.sql.type_api',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.sql.type_api',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util.typing',
+      'importer': 'sqlalchemy.sql.type_api',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.interfaces',
+      'importer': 'sqlalchemy.sql.util',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.row',
+      'importer': 'sqlalchemy.sql.util',
+    }),
+    dict({
+      'imported': 'sqlalchemy.exc',
+      'importer': 'sqlalchemy.sql.util',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql._typing',
+      'importer': 'sqlalchemy.sql.util',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.annotation',
+      'importer': 'sqlalchemy.sql.util',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.base',
+      'importer': 'sqlalchemy.sql.util',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.cache_key',
+      'importer': 'sqlalchemy.sql.util',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.coercions',
+      'importer': 'sqlalchemy.sql.util',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.ddl',
+      'importer': 'sqlalchemy.sql.util',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.elements',
+      'importer': 'sqlalchemy.sql.util',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.operators',
+      'importer': 'sqlalchemy.sql.util',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.roles',
+      'importer': 'sqlalchemy.sql.util',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.schema',
+      'importer': 'sqlalchemy.sql.util',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.selectable',
+      'importer': 'sqlalchemy.sql.util',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.visitors',
+      'importer': 'sqlalchemy.sql.util',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.sql.util',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util.typing',
+      'importer': 'sqlalchemy.sql.util',
+    }),
+    dict({
+      'imported': 'sqlalchemy.exc',
+      'importer': 'sqlalchemy.sql.visitors',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql._py_util',
+      'importer': 'sqlalchemy.sql.visitors',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.annotation',
+      'importer': 'sqlalchemy.sql.visitors',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.elements',
+      'importer': 'sqlalchemy.sql.visitors',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.sql.visitors',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util._has_cy',
+      'importer': 'sqlalchemy.sql.visitors',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util.langhelpers',
+      'importer': 'sqlalchemy.sql.visitors',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util.typing',
+      'importer': 'sqlalchemy.sql.visitors',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing.assertions',
+      'importer': 'sqlalchemy.testing',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing.config',
+      'importer': 'sqlalchemy.testing',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing.exclusions',
+      'importer': 'sqlalchemy.testing',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing.schema',
+      'importer': 'sqlalchemy.testing',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing.util',
+      'importer': 'sqlalchemy.testing',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing.warnings',
+      'importer': 'sqlalchemy.testing',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.default',
+      'importer': 'sqlalchemy.testing.assertions',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.url',
+      'importer': 'sqlalchemy.testing.assertions',
+    }),
+    dict({
+      'imported': 'sqlalchemy.exc',
+      'importer': 'sqlalchemy.testing.assertions',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm',
+      'importer': 'sqlalchemy.testing.assertions',
+    }),
+    dict({
+      'imported': 'sqlalchemy.schema',
+      'importer': 'sqlalchemy.testing.assertions',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql',
+      'importer': 'sqlalchemy.testing.assertions',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.selectable',
+      'importer': 'sqlalchemy.testing.assertions',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing',
+      'importer': 'sqlalchemy.testing.assertions',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing.assertsql',
+      'importer': 'sqlalchemy.testing.assertions',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing.config',
+      'importer': 'sqlalchemy.testing.assertions',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing.engines',
+      'importer': 'sqlalchemy.testing.assertions',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing.exclusions',
+      'importer': 'sqlalchemy.testing.assertions',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing.util',
+      'importer': 'sqlalchemy.testing.assertions',
+    }),
+    dict({
+      'imported': 'sqlalchemy.types',
+      'importer': 'sqlalchemy.testing.assertions',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.testing.assertions',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.default',
+      'importer': 'sqlalchemy.testing.assertsql',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.url',
+      'importer': 'sqlalchemy.testing.assertsql',
+    }),
+    dict({
+      'imported': 'sqlalchemy.event',
+      'importer': 'sqlalchemy.testing.assertsql',
+    }),
+    dict({
+      'imported': 'sqlalchemy.schema',
+      'importer': 'sqlalchemy.testing.assertsql',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing.config',
+      'importer': 'sqlalchemy.testing.asyncio',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util.concurrency',
+      'importer': 'sqlalchemy.testing.asyncio',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing',
+      'importer': 'sqlalchemy.testing.config',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing.plugin.plugin_base',
+      'importer': 'sqlalchemy.testing.config',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing.requirements',
+      'importer': 'sqlalchemy.testing.config',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing.util',
+      'importer': 'sqlalchemy.testing.config',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.testing.config',
+    }),
+    dict({
+      'imported': 'sqlalchemy',
+      'importer': 'sqlalchemy.testing.engines',
+    }),
+    dict({
+      'imported': 'sqlalchemy.dialects',
+      'importer': 'sqlalchemy.testing.engines',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine',
+      'importer': 'sqlalchemy.testing.engines',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.url',
+      'importer': 'sqlalchemy.testing.engines',
+    }),
+    dict({
+      'imported': 'sqlalchemy.event',
+      'importer': 'sqlalchemy.testing.engines',
+    }),
+    dict({
+      'imported': 'sqlalchemy.ext.asyncio',
+      'importer': 'sqlalchemy.testing.engines',
+    }),
+    dict({
+      'imported': 'sqlalchemy.pool',
+      'importer': 'sqlalchemy.testing.engines',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing.config',
+      'importer': 'sqlalchemy.testing.engines',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing.provision',
+      'importer': 'sqlalchemy.testing.engines',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing.util',
+      'importer': 'sqlalchemy.testing.engines',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.testing.engines',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util.typing',
+      'importer': 'sqlalchemy.testing.engines',
+    }),
+    dict({
+      'imported': 'sqlalchemy',
+      'importer': 'sqlalchemy.testing.entities',
+    }),
+    dict({
+      'imported': 'sqlalchemy.exc',
+      'importer': 'sqlalchemy.testing.entities',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.writeonly',
+      'importer': 'sqlalchemy.testing.entities',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing.config',
+      'importer': 'sqlalchemy.testing.exclusions',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.testing.exclusions',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util.compat',
+      'importer': 'sqlalchemy.testing.exclusions',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing.fixtures.base',
+      'importer': 'sqlalchemy.testing.fixtures',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing.fixtures.mypy',
+      'importer': 'sqlalchemy.testing.fixtures',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing.fixtures.orm',
+      'importer': 'sqlalchemy.testing.fixtures',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing.fixtures.sql',
+      'importer': 'sqlalchemy.testing.fixtures',
+    }),
+    dict({
+      'imported': 'sqlalchemy',
+      'importer': 'sqlalchemy.testing.fixtures.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm',
+      'importer': 'sqlalchemy.testing.fixtures.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.schema',
+      'importer': 'sqlalchemy.testing.fixtures.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing.assertions',
+      'importer': 'sqlalchemy.testing.fixtures.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing.config',
+      'importer': 'sqlalchemy.testing.fixtures.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing.engines',
+      'importer': 'sqlalchemy.testing.fixtures.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing.util',
+      'importer': 'sqlalchemy.testing.fixtures.base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.ext.mypy.util',
+      'importer': 'sqlalchemy.testing.fixtures.mypy',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing.assertions',
+      'importer': 'sqlalchemy.testing.fixtures.mypy',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing.config',
+      'importer': 'sqlalchemy.testing.fixtures.mypy',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing.fixtures.base',
+      'importer': 'sqlalchemy.testing.fixtures.mypy',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.testing.fixtures.mypy',
+    }),
+    dict({
+      'imported': 'sqlalchemy',
+      'importer': 'sqlalchemy.testing.fixtures.orm',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm',
+      'importer': 'sqlalchemy.testing.fixtures.orm',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.events',
+      'importer': 'sqlalchemy.testing.fixtures.orm',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing.assertions',
+      'importer': 'sqlalchemy.testing.fixtures.orm',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing.config',
+      'importer': 'sqlalchemy.testing.fixtures.orm',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing.entities',
+      'importer': 'sqlalchemy.testing.fixtures.orm',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing.fixtures.base',
+      'importer': 'sqlalchemy.testing.fixtures.orm',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing.fixtures.sql',
+      'importer': 'sqlalchemy.testing.fixtures.orm',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing.schema',
+      'importer': 'sqlalchemy.testing.fixtures.orm',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing.util',
+      'importer': 'sqlalchemy.testing.fixtures.orm',
+    }),
+    dict({
+      'imported': 'sqlalchemy',
+      'importer': 'sqlalchemy.testing.fixtures.sql',
+    }),
+    dict({
+      'imported': 'sqlalchemy.event',
+      'importer': 'sqlalchemy.testing.fixtures.sql',
+    }),
+    dict({
+      'imported': 'sqlalchemy.schema',
+      'importer': 'sqlalchemy.testing.fixtures.sql',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.elements',
+      'importer': 'sqlalchemy.testing.fixtures.sql',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.visitors',
+      'importer': 'sqlalchemy.testing.fixtures.sql',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing',
+      'importer': 'sqlalchemy.testing.fixtures.sql',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing.assertions',
+      'importer': 'sqlalchemy.testing.fixtures.sql',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing.config',
+      'importer': 'sqlalchemy.testing.fixtures.sql',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing.fixtures.base',
+      'importer': 'sqlalchemy.testing.fixtures.sql',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing.util',
+      'importer': 'sqlalchemy.testing.fixtures.sql',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.testing.fixtures.sql',
+    }),
+    dict({
+      'imported': 'sqlalchemy.schema',
+      'importer': 'sqlalchemy.testing.pickleable',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing.entities',
+      'importer': 'sqlalchemy.testing.pickleable',
+    }),
+    dict({
+      'imported': 'sqlalchemy.types',
+      'importer': 'sqlalchemy.testing.pickleable',
+    }),
+    dict({
+      'imported': 'sqlalchemy.dialects',
+      'importer': 'sqlalchemy.testing.plugin.plugin_base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.url',
+      'importer': 'sqlalchemy.testing.plugin.plugin_base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing',
+      'importer': 'sqlalchemy.testing.plugin.plugin_base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing.assertions',
+      'importer': 'sqlalchemy.testing.plugin.plugin_base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing.asyncio',
+      'importer': 'sqlalchemy.testing.plugin.plugin_base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing.config',
+      'importer': 'sqlalchemy.testing.plugin.plugin_base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing.engines',
+      'importer': 'sqlalchemy.testing.plugin.plugin_base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing.exclusions',
+      'importer': 'sqlalchemy.testing.plugin.plugin_base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing.fixtures',
+      'importer': 'sqlalchemy.testing.plugin.plugin_base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing.profiling',
+      'importer': 'sqlalchemy.testing.plugin.plugin_base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing.provision',
+      'importer': 'sqlalchemy.testing.plugin.plugin_base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing.warnings',
+      'importer': 'sqlalchemy.testing.plugin.plugin_base',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.testing.plugin.plugin_base',
+    }),
+    dict({
+      'imported': 'sqlalchemy',
+      'importer': 'sqlalchemy.testing.plugin.pytestplugin',
+    }),
+    dict({
+      'imported': 'sqlalchemy.cyextension',
+      'importer': 'sqlalchemy.testing.plugin.pytestplugin',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing.asyncio',
+      'importer': 'sqlalchemy.testing.plugin.pytestplugin',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing.config',
+      'importer': 'sqlalchemy.testing.plugin.pytestplugin',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing.exclusions',
+      'importer': 'sqlalchemy.testing.plugin.pytestplugin',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing.plugin.plugin_base',
+      'importer': 'sqlalchemy.testing.plugin.pytestplugin',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing.provision',
+      'importer': 'sqlalchemy.testing.plugin.pytestplugin',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.testing.plugin.pytestplugin',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util._has_cy',
+      'importer': 'sqlalchemy.testing.plugin.pytestplugin',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util.compat',
+      'importer': 'sqlalchemy.testing.plugin.pytestplugin',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util.langhelpers',
+      'importer': 'sqlalchemy.testing.plugin.pytestplugin',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing.config',
+      'importer': 'sqlalchemy.testing.profiling',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing.util',
+      'importer': 'sqlalchemy.testing.profiling',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.testing.profiling',
+    }),
+    dict({
+      'imported': 'sqlalchemy',
+      'importer': 'sqlalchemy.testing.provision',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.url',
+      'importer': 'sqlalchemy.testing.provision',
+    }),
+    dict({
+      'imported': 'sqlalchemy.exc',
+      'importer': 'sqlalchemy.testing.provision',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.ddl',
+      'importer': 'sqlalchemy.testing.provision',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.schema',
+      'importer': 'sqlalchemy.testing.provision',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing.config',
+      'importer': 'sqlalchemy.testing.provision',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing.engines',
+      'importer': 'sqlalchemy.testing.provision',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing.util',
+      'importer': 'sqlalchemy.testing.provision',
+    }),
+    dict({
+      'imported': 'sqlalchemy',
+      'importer': 'sqlalchemy.testing.requirements',
+    }),
+    dict({
+      'imported': 'sqlalchemy.pool',
+      'importer': 'sqlalchemy.testing.requirements',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing.asyncio',
+      'importer': 'sqlalchemy.testing.requirements',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing.config',
+      'importer': 'sqlalchemy.testing.requirements',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing.exclusions',
+      'importer': 'sqlalchemy.testing.requirements',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.testing.requirements',
+    }),
+    dict({
+      'imported': 'sqlalchemy.event',
+      'importer': 'sqlalchemy.testing.schema',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm',
+      'importer': 'sqlalchemy.testing.schema',
+    }),
+    dict({
+      'imported': 'sqlalchemy.schema',
+      'importer': 'sqlalchemy.testing.schema',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing.config',
+      'importer': 'sqlalchemy.testing.schema',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing.exclusions',
+      'importer': 'sqlalchemy.testing.schema',
+    }),
+    dict({
+      'imported': 'sqlalchemy.types',
+      'importer': 'sqlalchemy.testing.schema',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.testing.schema',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing.suite.test_cte',
+      'importer': 'sqlalchemy.testing.suite',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing.suite.test_ddl',
+      'importer': 'sqlalchemy.testing.suite',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing.suite.test_deprecations',
+      'importer': 'sqlalchemy.testing.suite',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing.suite.test_dialect',
+      'importer': 'sqlalchemy.testing.suite',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing.suite.test_insert',
+      'importer': 'sqlalchemy.testing.suite',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing.suite.test_reflection',
+      'importer': 'sqlalchemy.testing.suite',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing.suite.test_results',
+      'importer': 'sqlalchemy.testing.suite',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing.suite.test_rowcount',
+      'importer': 'sqlalchemy.testing.suite',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing.suite.test_select',
+      'importer': 'sqlalchemy.testing.suite',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing.suite.test_sequence',
+      'importer': 'sqlalchemy.testing.suite',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing.suite.test_types',
+      'importer': 'sqlalchemy.testing.suite',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing.suite.test_unicode_ddl',
+      'importer': 'sqlalchemy.testing.suite',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing.suite.test_update_delete',
+      'importer': 'sqlalchemy.testing.suite',
+    }),
+    dict({
+      'imported': 'sqlalchemy',
+      'importer': 'sqlalchemy.testing.suite.test_cte',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing',
+      'importer': 'sqlalchemy.testing.suite.test_cte',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing.assertions',
+      'importer': 'sqlalchemy.testing.suite.test_cte',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing.fixtures',
+      'importer': 'sqlalchemy.testing.suite.test_cte',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing.schema',
+      'importer': 'sqlalchemy.testing.suite.test_cte',
+    }),
+    dict({
+      'imported': 'sqlalchemy',
+      'importer': 'sqlalchemy.testing.suite.test_ddl',
+    }),
+    dict({
+      'imported': 'sqlalchemy.schema',
+      'importer': 'sqlalchemy.testing.suite.test_ddl',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing.assertions',
+      'importer': 'sqlalchemy.testing.suite.test_ddl',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing.config',
+      'importer': 'sqlalchemy.testing.suite.test_ddl',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing.fixtures',
+      'importer': 'sqlalchemy.testing.suite.test_ddl',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing.schema',
+      'importer': 'sqlalchemy.testing.suite.test_ddl',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing.suite',
+      'importer': 'sqlalchemy.testing.suite.test_ddl',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing.util',
+      'importer': 'sqlalchemy.testing.suite.test_ddl',
+    }),
+    dict({
+      'imported': 'sqlalchemy',
+      'importer': 'sqlalchemy.testing.suite.test_deprecations',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing',
+      'importer': 'sqlalchemy.testing.suite.test_deprecations',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing.assertions',
+      'importer': 'sqlalchemy.testing.suite.test_deprecations',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing.fixtures',
+      'importer': 'sqlalchemy.testing.suite.test_deprecations',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing.schema',
+      'importer': 'sqlalchemy.testing.suite.test_deprecations',
+    }),
+    dict({
+      'imported': 'sqlalchemy',
+      'importer': 'sqlalchemy.testing.suite.test_dialect',
+    }),
+    dict({
+      'imported': 'sqlalchemy.dialects',
+      'importer': 'sqlalchemy.testing.suite.test_dialect',
+    }),
+    dict({
+      'imported': 'sqlalchemy.event',
+      'importer': 'sqlalchemy.testing.suite.test_dialect',
+    }),
+    dict({
+      'imported': 'sqlalchemy.exc',
+      'importer': 'sqlalchemy.testing.suite.test_dialect',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.compiler',
+      'importer': 'sqlalchemy.testing.suite.test_dialect',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing',
+      'importer': 'sqlalchemy.testing.suite.test_dialect',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing.assertions',
+      'importer': 'sqlalchemy.testing.suite.test_dialect',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing.config',
+      'importer': 'sqlalchemy.testing.suite.test_dialect',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing.engines',
+      'importer': 'sqlalchemy.testing.suite.test_dialect',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing.fixtures',
+      'importer': 'sqlalchemy.testing.suite.test_dialect',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing.provision',
+      'importer': 'sqlalchemy.testing.suite.test_dialect',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing.schema',
+      'importer': 'sqlalchemy.testing.suite.test_dialect',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing.suite',
+      'importer': 'sqlalchemy.testing.suite.test_dialect',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.testing.suite.test_dialect',
+    }),
+    dict({
+      'imported': 'sqlalchemy',
+      'importer': 'sqlalchemy.testing.suite.test_insert',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing.assertions',
+      'importer': 'sqlalchemy.testing.suite.test_insert',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing.config',
+      'importer': 'sqlalchemy.testing.suite.test_insert',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing.fixtures',
+      'importer': 'sqlalchemy.testing.suite.test_insert',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing.schema',
+      'importer': 'sqlalchemy.testing.suite.test_insert',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing.suite',
+      'importer': 'sqlalchemy.testing.suite.test_insert',
+    }),
+    dict({
+      'imported': 'sqlalchemy.types',
+      'importer': 'sqlalchemy.testing.suite.test_insert',
+    }),
+    dict({
+      'imported': 'sqlalchemy',
+      'importer': 'sqlalchemy.testing.suite.test_reflection',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine',
+      'importer': 'sqlalchemy.testing.suite.test_reflection',
+    }),
+    dict({
+      'imported': 'sqlalchemy.event',
+      'importer': 'sqlalchemy.testing.suite.test_reflection',
+    }),
+    dict({
+      'imported': 'sqlalchemy.exc',
+      'importer': 'sqlalchemy.testing.suite.test_reflection',
+    }),
+    dict({
+      'imported': 'sqlalchemy.pool',
+      'importer': 'sqlalchemy.testing.suite.test_reflection',
+    }),
+    dict({
+      'imported': 'sqlalchemy.schema',
+      'importer': 'sqlalchemy.testing.suite.test_reflection',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.elements',
+      'importer': 'sqlalchemy.testing.suite.test_reflection',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.schema',
+      'importer': 'sqlalchemy.testing.suite.test_reflection',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing',
+      'importer': 'sqlalchemy.testing.suite.test_reflection',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing.config',
+      'importer': 'sqlalchemy.testing.suite.test_reflection',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing.engines',
+      'importer': 'sqlalchemy.testing.suite.test_reflection',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing.fixtures',
+      'importer': 'sqlalchemy.testing.suite.test_reflection',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing.provision',
+      'importer': 'sqlalchemy.testing.suite.test_reflection',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing.schema',
+      'importer': 'sqlalchemy.testing.suite.test_reflection',
+    }),
+    dict({
+      'imported': 'sqlalchemy.types',
+      'importer': 'sqlalchemy.testing.suite.test_reflection',
+    }),
+    dict({
+      'imported': 'sqlalchemy',
+      'importer': 'sqlalchemy.testing.suite.test_results',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql',
+      'importer': 'sqlalchemy.testing.suite.test_results',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing',
+      'importer': 'sqlalchemy.testing.suite.test_results',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing.assertions',
+      'importer': 'sqlalchemy.testing.suite.test_results',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing.config',
+      'importer': 'sqlalchemy.testing.suite.test_results',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing.engines',
+      'importer': 'sqlalchemy.testing.suite.test_results',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing.fixtures',
+      'importer': 'sqlalchemy.testing.suite.test_results',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing.schema',
+      'importer': 'sqlalchemy.testing.suite.test_results',
+    }),
+    dict({
+      'imported': 'sqlalchemy',
+      'importer': 'sqlalchemy.testing.suite.test_rowcount',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing',
+      'importer': 'sqlalchemy.testing.suite.test_rowcount',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing.fixtures',
+      'importer': 'sqlalchemy.testing.suite.test_rowcount',
+    }),
+    dict({
+      'imported': 'sqlalchemy',
+      'importer': 'sqlalchemy.testing.suite.test_select',
+    }),
+    dict({
+      'imported': 'sqlalchemy.exc',
+      'importer': 'sqlalchemy.testing.suite.test_select',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing',
+      'importer': 'sqlalchemy.testing.suite.test_select',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing.assertions',
+      'importer': 'sqlalchemy.testing.suite.test_select',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing.assertsql',
+      'importer': 'sqlalchemy.testing.suite.test_select',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing.config',
+      'importer': 'sqlalchemy.testing.suite.test_select',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing.fixtures',
+      'importer': 'sqlalchemy.testing.suite.test_select',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing.schema',
+      'importer': 'sqlalchemy.testing.suite.test_select',
+    }),
+    dict({
+      'imported': 'sqlalchemy',
+      'importer': 'sqlalchemy.testing.suite.test_sequence',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing',
+      'importer': 'sqlalchemy.testing.suite.test_sequence',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing.assertions',
+      'importer': 'sqlalchemy.testing.suite.test_sequence',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing.config',
+      'importer': 'sqlalchemy.testing.suite.test_sequence',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing.fixtures',
+      'importer': 'sqlalchemy.testing.suite.test_sequence',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing.provision',
+      'importer': 'sqlalchemy.testing.suite.test_sequence',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing.schema',
+      'importer': 'sqlalchemy.testing.suite.test_sequence',
+    }),
+    dict({
+      'imported': 'sqlalchemy',
+      'importer': 'sqlalchemy.testing.suite.test_types',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm',
+      'importer': 'sqlalchemy.testing.suite.test_types',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.sqltypes',
+      'importer': 'sqlalchemy.testing.suite.test_types',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing',
+      'importer': 'sqlalchemy.testing.suite.test_types',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing.assertions',
+      'importer': 'sqlalchemy.testing.suite.test_types',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing.config',
+      'importer': 'sqlalchemy.testing.suite.test_types',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing.engines',
+      'importer': 'sqlalchemy.testing.suite.test_types',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing.fixtures',
+      'importer': 'sqlalchemy.testing.suite.test_types',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing.schema',
+      'importer': 'sqlalchemy.testing.suite.test_types',
+    }),
+    dict({
+      'imported': 'sqlalchemy',
+      'importer': 'sqlalchemy.testing.suite.test_unicode_ddl',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing',
+      'importer': 'sqlalchemy.testing.suite.test_unicode_ddl',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing.fixtures',
+      'importer': 'sqlalchemy.testing.suite.test_unicode_ddl',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing.schema',
+      'importer': 'sqlalchemy.testing.suite.test_unicode_ddl',
+    }),
+    dict({
+      'imported': 'sqlalchemy',
+      'importer': 'sqlalchemy.testing.suite.test_update_delete',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing',
+      'importer': 'sqlalchemy.testing.suite.test_update_delete',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing.assertions',
+      'importer': 'sqlalchemy.testing.suite.test_update_delete',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing.fixtures',
+      'importer': 'sqlalchemy.testing.suite.test_update_delete',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing.schema',
+      'importer': 'sqlalchemy.testing.suite.test_update_delete',
+    }),
+    dict({
+      'imported': 'sqlalchemy',
+      'importer': 'sqlalchemy.testing.util',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine',
+      'importer': 'sqlalchemy.testing.util',
+    }),
+    dict({
+      'imported': 'sqlalchemy.schema',
+      'importer': 'sqlalchemy.testing.util',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.schema',
+      'importer': 'sqlalchemy.testing.util',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.sqltypes',
+      'importer': 'sqlalchemy.testing.util',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing',
+      'importer': 'sqlalchemy.testing.util',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing.assertions',
+      'importer': 'sqlalchemy.testing.util',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing.config',
+      'importer': 'sqlalchemy.testing.util',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing.engines',
+      'importer': 'sqlalchemy.testing.util',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing.fixtures',
+      'importer': 'sqlalchemy.testing.util',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.testing.util',
+    }),
+    dict({
+      'imported': 'sqlalchemy.exc',
+      'importer': 'sqlalchemy.testing.warnings',
+    }),
+    dict({
+      'imported': 'sqlalchemy.testing.assertions',
+      'importer': 'sqlalchemy.testing.warnings',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util.langhelpers',
+      'importer': 'sqlalchemy.testing.warnings',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.sqltypes',
+      'importer': 'sqlalchemy.types',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.type_api',
+      'importer': 'sqlalchemy.types',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util._collections',
+      'importer': 'sqlalchemy.util',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util.compat',
+      'importer': 'sqlalchemy.util',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util.concurrency',
+      'importer': 'sqlalchemy.util',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util.deprecations',
+      'importer': 'sqlalchemy.util',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util.langhelpers',
+      'importer': 'sqlalchemy.util',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util.preloaded',
+      'importer': 'sqlalchemy.util',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util.typing',
+      'importer': 'sqlalchemy.util',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util._has_cy',
+      'importer': 'sqlalchemy.util._collections',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util._py_collections',
+      'importer': 'sqlalchemy.util._collections',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util.typing',
+      'importer': 'sqlalchemy.util._collections',
+    }),
+    dict({
+      'imported': 'sqlalchemy.exc',
+      'importer': 'sqlalchemy.util._concurrency_py3k',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.util._concurrency_py3k',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util.langhelpers',
+      'importer': 'sqlalchemy.util._concurrency_py3k',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util.typing',
+      'importer': 'sqlalchemy.util._concurrency_py3k',
+    }),
+    dict({
+      'imported': 'sqlalchemy.cyextension',
+      'importer': 'sqlalchemy.util._has_cy',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util.typing',
+      'importer': 'sqlalchemy.util._py_collections',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util._concurrency_py3k',
+      'importer': 'sqlalchemy.util.concurrency',
+    }),
+    dict({
+      'imported': 'sqlalchemy.exc',
+      'importer': 'sqlalchemy.util.deprecations',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util.compat',
+      'importer': 'sqlalchemy.util.deprecations',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util.langhelpers',
+      'importer': 'sqlalchemy.util.deprecations',
+    }),
+    dict({
+      'imported': 'sqlalchemy.exc',
+      'importer': 'sqlalchemy.util.langhelpers',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util._collections',
+      'importer': 'sqlalchemy.util.langhelpers',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util._has_cy',
+      'importer': 'sqlalchemy.util.langhelpers',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util.compat',
+      'importer': 'sqlalchemy.util.langhelpers',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util.typing',
+      'importer': 'sqlalchemy.util.langhelpers',
+    }),
+    dict({
+      'imported': 'sqlalchemy.dialects',
+      'importer': 'sqlalchemy.util.preloaded',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.cursor',
+      'importer': 'sqlalchemy.util.preloaded',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.default',
+      'importer': 'sqlalchemy.util.preloaded',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.reflection',
+      'importer': 'sqlalchemy.util.preloaded',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.result',
+      'importer': 'sqlalchemy.util.preloaded',
+    }),
+    dict({
+      'imported': 'sqlalchemy.engine.url',
+      'importer': 'sqlalchemy.util.preloaded',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm',
+      'importer': 'sqlalchemy.util.preloaded',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.attributes',
+      'importer': 'sqlalchemy.util.preloaded',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.base',
+      'importer': 'sqlalchemy.util.preloaded',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.clsregistry',
+      'importer': 'sqlalchemy.util.preloaded',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.decl_api',
+      'importer': 'sqlalchemy.util.preloaded',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.decl_base',
+      'importer': 'sqlalchemy.util.preloaded',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.dependency',
+      'importer': 'sqlalchemy.util.preloaded',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.descriptor_props',
+      'importer': 'sqlalchemy.util.preloaded',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.properties',
+      'importer': 'sqlalchemy.util.preloaded',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.relationships',
+      'importer': 'sqlalchemy.util.preloaded',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.session',
+      'importer': 'sqlalchemy.util.preloaded',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.state',
+      'importer': 'sqlalchemy.util.preloaded',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.strategies',
+      'importer': 'sqlalchemy.util.preloaded',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.strategy_options',
+      'importer': 'sqlalchemy.util.preloaded',
+    }),
+    dict({
+      'imported': 'sqlalchemy.orm.util',
+      'importer': 'sqlalchemy.util.preloaded',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.default_comparator',
+      'importer': 'sqlalchemy.util.preloaded',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.dml',
+      'importer': 'sqlalchemy.util.preloaded',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.elements',
+      'importer': 'sqlalchemy.util.preloaded',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.functions',
+      'importer': 'sqlalchemy.util.preloaded',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.naming',
+      'importer': 'sqlalchemy.util.preloaded',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.schema',
+      'importer': 'sqlalchemy.util.preloaded',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.selectable',
+      'importer': 'sqlalchemy.util.preloaded',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.sqltypes',
+      'importer': 'sqlalchemy.util.preloaded',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.traversals',
+      'importer': 'sqlalchemy.util.preloaded',
+    }),
+    dict({
+      'imported': 'sqlalchemy.sql.util',
+      'importer': 'sqlalchemy.util.preloaded',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util.concurrency',
+      'importer': 'sqlalchemy.util.queue',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util.langhelpers',
+      'importer': 'sqlalchemy.util.queue',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util.compat',
+      'importer': 'sqlalchemy.util.tool_support',
+    }),
+    dict({
+      'imported': 'sqlalchemy.exc',
+      'importer': 'sqlalchemy.util.topological',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util',
+      'importer': 'sqlalchemy.util.topological',
+    }),
+    dict({
+      'imported': 'sqlalchemy.util.compat',
+      'importer': 'sqlalchemy.util.typing',
+    }),
+  ])
+# ---

--- a/tests/functional/test_build_graph_on_real_packages.py
+++ b/tests/functional/test_build_graph_on_real_packages.py
@@ -7,6 +7,7 @@ import grimp
     "package_name",
     ("django", "flask", "requests", "sqlalchemy", "google.cloud.audit"),
 )
-def test_build_graph_on_real_package(package_name):
-    # All we care about is whether or not the graph builds without raising an exception.
-    grimp.build_graph(package_name, cache_dir=None)
+def test_build_graph_on_real_package(package_name, snapshot):
+    graph = grimp.build_graph(package_name, cache_dir=None)
+    imports = graph.find_matching_direct_imports(import_expression="** -> **")
+    assert imports == snapshot

--- a/tox.ini
+++ b/tox.ini
@@ -12,6 +12,7 @@ deps =
     pyyaml==6.0.1
     pytest-cov==5.0.0
     pytest-benchmark==4.0.0
+    syrupy==4.9.1
     # External packages to attempt to build the graph from.
     Django==4.2.17  # N.B. Django 5 doesn't support Python 3.9.
     flask==3.0.3


### PR DESCRIPTION
Cherry-picked from https://github.com/seddonym/grimp/pull/222

This snapshot test captures the results of import scanning against real packages. This gives us a lot of confidence when refactoring the import scanning code (helpful as we move more of this code over to rust).

The snapshot test uses the popular syrupy[^1] pytest plugin.

[^1]: https://github.com/syrupy-project/syrupy