### PR TITLE
Non utf8 python file test

### DIFF
--- a/tests/assets/encodingpackage/shift_jis_importer.py
+++ b/tests/assets/encodingpackage/shift_jis_importer.py
@@ -1,0 +1,3 @@
+# -*- coding: shift_jis -*-
+
+from .imported import ƒÎ

--- a/tests/functional/test_encoding_handling.py
+++ b/tests/functional/test_encoding_handling.py
@@ -19,3 +19,23 @@ def test_build_graph_of_non_ascii_source():
             "line_contents": "from .imported import π",
         },
     ] == result
+
+
+def test_build_graph_of_non_utf8_source():
+    """
+    Tests we can cope with non UTF-8 Python source files.
+    """
+    graph = grimp.build_graph("encodingpackage", cache_dir=None)
+
+    result = graph.get_import_details(
+        importer="encodingpackage.shift_jis_importer", imported="encodingpackage.imported"
+    )
+
+    assert [
+        {
+            "importer": "encodingpackage.shift_jis_importer",
+            "imported": "encodingpackage.imported",
+            "line_number": 3,
+            "line_contents": "from .imported import π",
+        },
+    ] == result


### PR DESCRIPTION
Adds a regression test for reading the contents of Python files that aren't UTF-8-encoded.

This file was created in the Python repl using:

```
>>> with open(filename, "w", encoding="shift_jis") as f:
...     f.write("# -*- coding: shift_jis -*-\n\nfrom .imported import π")
```