### PR TITLE
Rename default branch to main

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,9 +3,9 @@ name: CI
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
-    branches: [master]
+    branches: [main]
   workflow_dispatch:
 
 jobs:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ Unreleased
 ----------
 
 * Add closed layers to layer contract.
+* Rename default repository branch to 'main'.
 
 3.9 (2025-05-05)
 ----------------

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -153,7 +153,7 @@ Releasing to Pypi
 =================
 
 1. Choose a new version number (based on `semver <https://semver.org/>`_).
-2. ``git pull origin master``
+2. ``git pull origin main``
 3. Update ``CHANGELOG.rst`` with the new version number.
 4. Update the ``release`` variable in ``docs/conf.py`` with the new version number.
 5. Update the ``__version__`` variable in ``src/grimp/__init__.py`` with the new version number.

--- a/README.rst
+++ b/README.rst
@@ -9,7 +9,7 @@ Grimp
     :alt: Python versions
     :target: https://pypi.org/project/grimp/
 
-.. image:: https://github.com/seddonym/grimp/workflows/CI/badge.svg?branch=master
+.. image:: https://github.com/seddonym/grimp/workflows/CI/badge.svg?branch=main
      :target: https://github.com/seddonym/grimp/actions?workflow=CI
      :alt: CI Status
 


### PR DESCRIPTION
The actual renaming is done within Github. This makes the necessary adjustments.