### PR TITLE
Add more useful benchmark for find_shortest_chains

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,6 +46,8 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
+      - name: Print versions
+        run: cargo version --verbose && cargo clippy --version
       - name: Run tests
         run: cargo test --no-default-features
         working-directory: ./rust

--- a/rust/src/filesystem.rs
+++ b/rust/src/filesystem.rs
@@ -87,12 +87,11 @@ impl FileSystem for RealBasicFileSystem {
 
         // Coding specification needs to be in the first two lines, or it's ignored.
         for line in s.lines().take(2) {
-            if let Some(captures) = encoding_re.captures(line) {
-                if let Some(encoding_name) = captures.get(1) {
+            if let Some(captures) = encoding_re.captures(line)
+                && let Some(encoding_name) = captures.get(1) {
                     detected_encoding = Some(encoding_name.as_str().to_string());
                     break;
                 }
-            }
         }
 
         if let Some(enc_name) = detected_encoding {

--- a/rust/src/graph/hierarchy_queries.rs
+++ b/rust/src/graph/hierarchy_queries.rs
@@ -17,7 +17,7 @@ impl Graph {
     }
 
     // TODO(peter) Guarantee order?
-    pub fn all_modules(&self) -> impl ModuleIterator {
+    pub fn all_modules(&self) -> impl ModuleIterator<'_> {
         self.modules.values()
     }
 
@@ -28,7 +28,7 @@ impl Graph {
         }
     }
 
-    pub fn get_module_children(&self, module: ModuleToken) -> impl ModuleIterator {
+    pub fn get_module_children(&self, module: ModuleToken) -> impl ModuleIterator<'_> {
         let children = match self.module_children.get(module) {
             Some(children) => children
                 .iter()
@@ -42,7 +42,7 @@ impl Graph {
     /// Returns an iterator over the passed modules descendants.
     ///
     /// Parent modules will be yielded before their child modules.
-    pub fn get_module_descendants(&self, module: ModuleToken) -> impl ModuleIterator {
+    pub fn get_module_descendants(&self, module: ModuleToken) -> impl ModuleIterator<'_> {
         let mut descendants = self.get_module_children(module).collect::<Vec<_>>();
         for child in descendants.clone() {
             descendants.extend(self.get_module_descendants(child.token).collect::<Vec<_>>())
@@ -53,7 +53,7 @@ impl Graph {
     pub fn find_matching_modules(
         &self,
         expression: &ModuleExpression,
-    ) -> impl ModuleIterator + use<'_> {
+    ) -> impl ModuleIterator<'_> + use<'_> {
         let interner = MODULE_NAMES.read().unwrap();
         let modules: FxHashSet<_> = self
             .modules

--- a/rust/src/import_scanning.rs
+++ b/rust/src/import_scanning.rs
@@ -140,8 +140,8 @@ fn scan_for_imports_no_py_single_module(
             }
             None => {
                 // It's an external import.
-                if include_external_packages {
-                    if let Some(imported_module) =
+                if include_external_packages
+                    && let Some(imported_module) =
                         _distill_external_module(&imported_object_name, found_packages)
                     {
                         imports.insert(DirectImport {
@@ -151,7 +151,6 @@ fn scan_for_imports_no_py_single_module(
                             line_contents: imported_object.line_contents,
                         });
                     }
-                }
             }
         }
     }


### PR DESCRIPTION
Preparatory commit cherry-picked from https://github.com/seddonym/grimp/pull/238. This preparatory commit slows the benchmark a lot, but this is okay since the scenario we're benchmarking has now changed, not the actual grimp code.

By putting this onto master first, we will then be able to more clearly see the improvement in https://github.com/seddonym/grimp/pull/238.