### PR TITLE
Switch to walltime runner for benchmarks

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -61,20 +61,24 @@ jobs:
         run: just test-rust
 
   benchmarks:
-      runs-on: ubuntu-24.04
+      runs-on: codspeed-macro
       steps:
         - uses: actions/checkout@v5
 
         - name: Install just
           uses: extractions/setup-just@v3
 
-        - name: Install uv
+        - name: Install uv and set the latest supported Python version
           uses: astral-sh/setup-uv@v7
+          with:
+            python-version: 3.13
 
+        - name: Update to a Cargo version that supports 2024 edition
+          run: rustup install 1.90.0 && rustup default 1.90.0
+          
         - name: Run benchmarks
           uses: CodSpeedHQ/action@v4
           with:
-            token: ${{ secrets.CODSPEED_TOKEN }}
-            mode: instrumentation
+            mode: walltime
             run: |
               just benchmark-ci


### PR DESCRIPTION
Moves to Codspeed's walltime runner for benchmarks, which is much faster than the CPU-based one.

I needed to move grimp out of my personal Github account to an organization, to get this working. 