### PR TITLE
Remove dependency on typing_extensions

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ latest
 
 * Improve contribution experience for Windows developers using Just.
 * Tweak Just commands for running version-specific Python tests.
+* Remove `typing-extensions` as a dependency.
 
 3.14 (2025-12-10)
 -----------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,9 +15,7 @@ authors = [
     {name = "David Seddon", email = "david@seddonym.me"},
 ]
 requires-python = ">=3.10"
-dependencies = [
-    "typing-extensions>=3.10.0.0",
-]
+dependencies = []
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",


### PR DESCRIPTION
As suggested https://github.com/python-grimp/grimp/issues/278.