### PR TITLE
Use quoted `@echo` calls consistently in `justfile`

### DIFF
--- a/justfile
+++ b/justfile
@@ -75,13 +75,13 @@ update-snapshots:
 [working-directory: 'rust']
 format-rust:
     @cargo fmt
-    @echo Formatted Rust code.
+    @echo 'Formatted Rust code.'
 
 # Format the Python code.
 [group('formatting')]
 format-python:
     @uv run ruff format
-    @echo Formatted Python code.
+    @echo 'Formatted Python code.'
 
 # Format all code.
 [group('formatting')]
@@ -92,13 +92,13 @@ format:
 # Lint Python code.
 [group('linting')]
 lint-python:
-    @echo Running ruff format...
+    @echo 'Running ruff format...'
     @uv run ruff format --check
-    @echo Running ruff check...
+    @echo 'Running ruff check...'
     @uv run ruff check
-    @echo Running mypy...
+    @echo 'Running mypy...'
     @uv run mypy src/grimp tests
-    @echo Running Import Linter...
+    @echo 'Running Import Linter...'
     @uv run lint-imports
 
 # Lint Rust code using cargo fmt and clippy
@@ -122,11 +122,11 @@ autofix-python:
 # Run linters.
 [group('linting')]
 lint:
-    @echo Linting Python...
+    @echo 'Linting Python...'
     @just lint-python
-    @echo Linting Rust...
+    @echo 'Linting Rust...'
     @just lint-rust
-    @echo
+    @echo ''
     @echo '👍 {{GREEN}} Linting all good.{{NORMAL}}'
 
 # Build docs.


### PR DESCRIPTION
[ ] Add tests for the change. In general, aim for full test coverage at the Python level. Rust tests are optional.
[ ] Add any appropriate documentation.
[ ] Add a summary of changes to `CHANGELOG.rst`.
[ ] Add your name to `AUTHORS.rst`.
[ ] Run `just full-check`.

This is a follow-up to enabling Powershell support in #277.

Due to inconsistencies in shell behaviours with `echo` commands, the using unquoted `echo` is not properly supported by Powershell. It will pause and wait for user input:
```
cmdlet Write-Output at command pipeline position 1
Supply values for the following parameters:
InputObject[0]:
```
