### PR TITLE
Remove `pyupgrade` from the codebase

### DIFF
--- a/justfile
+++ b/justfile
@@ -132,13 +132,6 @@ show-benchmark-results:
 benchmark-ci:
     @uv run --group=benchmark-ci pytest --codspeed
 
-# Upgrade Python code to the supplied version. (E.g. just upgrade 310)
-[group('maintenance')]
-upgrade-python MIN_VERSION:
-    @find {docs,src,tests} -name "*.py" -not -path "tests/assets/*" -exec uv run pyupgrade --py{{MIN_VERSION}}-plus --exit-zero-even-if-changed {} +
-    @just autofix-python
-    @just format-python
-
 # Run all linters, build docs and tests. Worth running before pushing to Github.
 [group('prepush')]
 full-check:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,6 @@ dev = [
     "requests==2.32.3",
     "sqlalchemy==2.0.35",
     "google-cloud-audit-log==0.3.0",
-    "pyupgrade>=3.21.0",
 ]
 docs = [
     "sphinx>=7.4.7",


### PR DESCRIPTION
This is re-implemented with the `UP` Ruff rules. Sometimes there is a slight parity lag (i.e. rules exist in `pyupgrade` that don't exist in Ruff) but that's usually only during the pre-release phase of a new Python version while everyone sorts things out behind-the-scenes.

[ ] Add tests for the change. In general, aim for full test coverage at the Python level. Rust tests are optional.
[ ] Add any appropriate documentation.
[ ] Add a summary of changes to the `latest` section at the top of `CHANGELOG.rst`. (If it's not there, add it.)
[ ] Add your name to `AUTHORS.rst`.
[ ] Run `just full-check`.