### PR TITLE
Add `match` arg in `pytest.warns`  for `DeprecationWarning`

### DIFF
--- a/tests/unit/test_exceptions.py
+++ b/tests/unit/test_exceptions.py
@@ -60,5 +60,5 @@ class TestSourceSyntaxError:
 
 class TestNamespacePackageEncountered:
     def test_deprecated_access(self):
-        with pytest.warns(DeprecationWarning):
+        with pytest.warns(DeprecationWarning, match="NamespacePackageEncountered is deprecated"):
             exceptions.NamespacePackageEncountered


### PR DESCRIPTION
The changes in #284 introduced a new ruff rule which was violated by #276. Both have been merged but now the `main` branch is failing.

Since 284 was merged first, and the 276 branch was "out-of-date" relative to main, the CI for 276 didn't run the new ruff rule and didn't catch this.

I've also got this same fix commit in the two other open PRs (#289, #290).

