### PR TITLE
Raise ModuleNotPresent for absent modules in direct-import queries (#113)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,9 @@ latest
 * Tweak Just commands for running version-specific Python tests.
 * Remove `typing-extensions` as a dependency.
 * Make package FIPS compatible by marking blake2 hashing with `usedforsecurity=False`.
+* Raise `ModuleNotPresent` instead of an unclear error when `find_modules_that_directly_import` or
+  `find_modules_directly_imported_by` is called with a module that is not in the graph.
+  (https://github.com/python-grimp/grimp/issues/113)
 
 3.14 (2025-12-10)
 -----------------

--- a/src/grimp/application/graph.py
+++ b/src/grimp/application/graph.py
@@ -217,13 +217,26 @@ class ImportGraph:
         )
 
     def find_modules_directly_imported_by(self, module: str) -> set[str]:
+        """
+        Find all modules that are directly imported by the supplied module.
+
+        If the module is not present in the graph, grimp.exceptions.ModuleNotPresent will be raised.
+        """
+        if not self._rustgraph.contains_module(module):
+            msg = f'"{module}" not present in the graph.'
+            raise ModuleNotPresent(msg)
         return self._rustgraph.find_modules_directly_imported_by(module)
 
     def find_modules_that_directly_import(self, module: str) -> set[str]:
-        if self._rustgraph.contains_module(module):
-            # TODO panics if module isn't in modules.
-            return self._rustgraph.find_modules_that_directly_import(module)
-        return set()
+        """
+        Find all modules that directly import the supplied module.
+
+        If the module is not present in the graph, grimp.exceptions.ModuleNotPresent will be raised.
+        """
+        if not self._rustgraph.contains_module(module):
+            msg = f'"{module}" not present in the graph.'
+            raise ModuleNotPresent(msg)
+        return self._rustgraph.find_modules_that_directly_import(module)
 
     def get_import_details(self, *, importer: str, imported: str) -> list[DetailedImport]:
         """

--- a/tests/unit/application/graph/test_direct_imports.py
+++ b/tests/unit/application/graph/test_direct_imports.py
@@ -3,7 +3,7 @@ import re
 import pytest
 
 from grimp.application.graph import ImportGraph
-from grimp.exceptions import InvalidImportExpression
+from grimp.exceptions import InvalidImportExpression, ModuleNotPresent
 
 
 def test_find_modules_directly_imported_by():
@@ -32,6 +32,22 @@ def test_find_modules_that_directly_import():
     graph.add_import(importer=f, imported=b)
 
     assert {a, f} == graph.find_modules_that_directly_import("bar")
+
+
+def test_find_modules_directly_imported_by_raises_module_not_present():
+    graph = ImportGraph()
+    graph.add_module("foo")
+
+    with pytest.raises(ModuleNotPresent, match=re.escape('"bar" not present in the graph.')):
+        graph.find_modules_directly_imported_by("bar")
+
+
+def test_find_modules_that_directly_import_raises_module_not_present():
+    graph = ImportGraph()
+    graph.add_module("foo")
+
+    with pytest.raises(ModuleNotPresent, match=re.escape('"bar" not present in the graph.')):
+        graph.find_modules_that_directly_import("bar")
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Fixes #113.

## Problem

`ImportGraph.find_modules_that_directly_import` handled an absent module
inconsistently with the rest of the API: it silently returned an empty `set()`
(masking the missing module), while the underlying Rust call panics for an
absent module, as noted by the existing `# TODO`.

Its sibling `find_modules_directly_imported_by` had no guard at all and would
surface the raw Rust panic for an absent module.

Other query/manipulation methods (`squash_module`, `is_module_squashed`, ...)
already raise `grimp.exceptions.ModuleNotPresent` in this situation.

## Change

Apply the existing `ModuleNotPresent` guard pattern to both
`find_modules_that_directly_import` and `find_modules_directly_imported_by`, so
an absent module raises `ModuleNotPresent` with the same message format used
elsewhere, and add docstrings documenting the behaviour.

## Behaviour change

`find_modules_that_directly_import` previously returned `set()` for an absent
module; it now raises `ModuleNotPresent`, matching the issue title and the rest
of the API. No internal callers relied on the previous empty-set behaviour.

## Tests

- Added two regression tests in `tests/unit/application/graph/test_direct_imports.py`.
- `pytest tests/unit tests/functional` -> 828 passed, 1 skipped.
- `ruff check`, `ruff format --check`, and `mypy` on the changed files all pass.
- Added a `CHANGELOG.rst` entry under `latest`.
