### PR TITLE
Upgrade the version of rustc

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -74,7 +74,7 @@ jobs:
             python-version: 3.14
 
         - name: Update to a Cargo version that supports 2024 edition
-          run: rustup install 1.90.0 && rustup default 1.90.0
+          run: rustup install 1.96.1 && rustup default 1.96.1
           
         - name: Run benchmarks
           uses: CodSpeedHQ/action@v4


### PR DESCRIPTION
Upgrades to a compatible version of rustc in the `benchmarks` CI job.

I missed this in [commit 5c5319](https://github.com/python-grimp/grimp/pull/306/changes/5c53194f3187322a5a97fc006d37589c9228d3d2) - I misinterpreted the benchmark failure as a regression that I'd acknowledged.
